### PR TITLE
[19637] fix: Add role="presentation" to container elements to fix aria-required-children violation

### DIFF
--- a/packages/primeng/src/stepper/stepper.ts
+++ b/packages/primeng/src/stepper/stepper.ts
@@ -80,7 +80,8 @@ export interface StepPanelContentTemplateContext {
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[class]': 'cx("root")'
+        '[class]': 'cx("root")',
+        '[attr.role]': '"presentation"'
     },
     providers: [StepListStyle, { provide: STEPLIST_INSTANCE, useExisting: StepList }, { provide: PARENT_INSTANCE, useExisting: StepList }],
     hostDirectives: [Bind]
@@ -144,6 +145,7 @@ export class StepperSeparator extends BaseComponent<StepperSeparatorPassThrough>
     encapsulation: ViewEncapsulation.None,
     host: {
         '[class]': 'cx("root")',
+        '[attr.role]': '"presentation"',
         '[attr.data-p-active]': 'isActive()'
     },
     providers: [StepItemStyle, { provide: STEPITEM_INSTANCE, useExisting: StepItem }, { provide: PARENT_INSTANCE, useExisting: StepItem }],
@@ -429,7 +431,8 @@ export class StepPanel extends BaseComponent<StepPanelPassThrough> {
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[class]': 'cx("root")'
+        '[class]': 'cx("root")',
+        '[attr.role]': '"presentation"'
     },
     providers: [StepPanelsStyle, { provide: STEPPANELS_INSTANCE, useExisting: StepPanels }, { provide: PARENT_INSTANCE, useExisting: StepPanels }],
     hostDirectives: [Bind]


### PR DESCRIPTION
fixes: #2

Fixes aria-required-children accessibility violation in the Stepper component.

**Problem**
The p-stepper component has role="tablist" which requires direct child elements with role="tab". The intermediate container components (p-step-list, p-step-item, p-step-panels) didn't have any ARIA role, breaking the required parent-child relationship.

**Solution**
Added role="presentation" to container components to make them semantically transparent:

- p-step-list
- p-step-item
- p-step-panels

This allows assistive technologies to correctly perceive the tab elements as direct children of the tablist.

**References**
Rule: aria-required-children
WCAG: 1.3.1 Info and Relationships

> Migrated from `primefaces/primeng#19638` — originally by `@fkwq34` on 2026-06-23

---
*Original base: `master` @ `8c0ce70`, head: `stepper-accessibility` @ `13650a8`*