### PR TITLE
[19635] fix: Add scope="col" to th elements for td-has-header a11y compliance

### DIFF
--- a/packages/primeng/src/stepper/stepper.ts
+++ b/packages/primeng/src/stepper/stepper.ts
@@ -80,8 +80,7 @@ export interface StepPanelContentTemplateContext {
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[class]': 'cx("root")',
-        '[attr.role]': '"presentation"'
+        '[class]': 'cx("root")'
     },
     providers: [StepListStyle, { provide: STEPLIST_INSTANCE, useExisting: StepList }, { provide: PARENT_INSTANCE, useExisting: StepList }],
     hostDirectives: [Bind]
@@ -145,7 +144,6 @@ export class StepperSeparator extends BaseComponent<StepperSeparatorPassThrough>
     encapsulation: ViewEncapsulation.None,
     host: {
         '[class]': 'cx("root")',
-        '[attr.role]': '"presentation"',
         '[attr.data-p-active]': 'isActive()'
     },
     providers: [StepItemStyle, { provide: STEPITEM_INSTANCE, useExisting: StepItem }, { provide: PARENT_INSTANCE, useExisting: StepItem }],
@@ -431,8 +429,7 @@ export class StepPanel extends BaseComponent<StepPanelPassThrough> {
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[class]': 'cx("root")',
-        '[attr.role]': '"presentation"'
+        '[class]': 'cx("root")'
     },
     providers: [StepPanelsStyle, { provide: STEPPANELS_INSTANCE, useExisting: StepPanels }, { provide: PARENT_INSTANCE, useExisting: StepPanels }],
     hostDirectives: [Bind]

--- a/packages/primeng/src/stepper/stepper.ts
+++ b/packages/primeng/src/stepper/stepper.ts
@@ -80,7 +80,8 @@ export interface StepPanelContentTemplateContext {
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[class]': 'cx("root")'
+        '[class]': 'cx("root")',
+        '[attr.role]': '"presentation"'
     },
     providers: [StepListStyle, { provide: STEPLIST_INSTANCE, useExisting: StepList }, { provide: PARENT_INSTANCE, useExisting: StepList }],
     hostDirectives: [Bind]
@@ -144,6 +145,7 @@ export class StepperSeparator extends BaseComponent<StepperSeparatorPassThrough>
     encapsulation: ViewEncapsulation.None,
     host: {
         '[class]': 'cx("root")',
+        '[attr.role]': '"presentation"',
         '[attr.data-p-active]': 'isActive()'
     },
     providers: [StepItemStyle, { provide: STEPITEM_INSTANCE, useExisting: StepItem }, { provide: PARENT_INSTANCE, useExisting: StepItem }],
@@ -429,7 +431,8 @@ export class StepPanel extends BaseComponent<StepPanelPassThrough> {
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[class]': 'cx("root")'
+        '[class]': 'cx("root")',
+        '[attr.role]': '"presentation"'
     },
     providers: [StepPanelsStyle, { provide: STEPPANELS_INSTANCE, useExisting: StepPanels }, { provide: PARENT_INSTANCE, useExisting: StepPanels }],
     hostDirectives: [Bind]

--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -1353,7 +1353,16 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
             if (this.isStateful() && this.resizableColumns) {
                 this.restoreColumnWidths();
             }
+            this.updateThScope();
         }
+    }
+
+    /**
+     * Adds scope="col" to th elements for accessibility (td-has-header rule).
+     * @group Method
+     */
+    updateThScope() {
+        setTimeout(() => this.el.nativeElement.querySelectorAll('th:not([scope])').forEach((th: HTMLElement) => th.setAttribute('scope', 'col')));
     }
 
     onChanges(simpleChange: SimpleChanges) {
@@ -1379,6 +1388,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
             }
 
             this.tableService.onValueChange(simpleChange.value.currentValue);
+            this.updateThScope();
         }
 
         if (simpleChange.columns) {
@@ -1392,6 +1402,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
 
                 this.tableService.onColumnsChange(this._columns);
             }
+            this.updateThScope();
         }
 
         if (simpleChange.sortField) {

--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -1176,6 +1176,8 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
 
     id: string = UniqueComponentId();
 
+    private thScopeObserver: MutationObserver | null = null;
+
     styleElement: any;
 
     responsiveStyleElement: any;
@@ -1353,16 +1355,8 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
             if (this.isStateful() && this.resizableColumns) {
                 this.restoreColumnWidths();
             }
-            this.updateThScope();
+            this.initThScopeObserver();
         }
-    }
-
-    /**
-     * Adds scope="col" to th elements for accessibility (td-has-header rule).
-     * @group Method
-     */
-    updateThScope() {
-        setTimeout(() => this.el.nativeElement.querySelectorAll('th:not([scope])').forEach((th: HTMLElement) => th.setAttribute('scope', 'col')));
     }
 
     onChanges(simpleChange: SimpleChanges) {
@@ -1388,7 +1382,6 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
             }
 
             this.tableService.onValueChange(simpleChange.value.currentValue);
-            this.updateThScope();
         }
 
         if (simpleChange.columns) {
@@ -1402,7 +1395,6 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
 
                 this.tableService.onColumnsChange(this._columns);
             }
-            this.updateThScope();
         }
 
         if (simpleChange.sortField) {
@@ -3209,6 +3201,36 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
 
         this.destroyStyleElement();
         this.destroyResponsiveStyle();
+
+        if (this.thScopeObserver) {
+            this.thScopeObserver.disconnect();
+            this.thScopeObserver = null;
+        }
+    }
+
+    private initThScopeObserver() {
+        const thead = this.tableHeaderViewChild?.nativeElement;
+        if (!thead) {
+            return;
+        }
+
+        thead.querySelectorAll(':scope > tr > th:not([scope])').forEach((th: HTMLElement) => th.setAttribute('scope', 'col'));
+
+        this.thScopeObserver = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (node.nodeType === Node.ELEMENT_NODE) {
+                        const element = node as HTMLElement;
+                        if (element.tagName === 'TH' && !element.hasAttribute('scope')) {
+                            element.setAttribute('scope', 'col');
+                        }
+                        element.querySelectorAll?.('th:not([scope])').forEach((th: HTMLElement) => th.setAttribute('scope', 'col'));
+                    }
+                });
+            });
+        });
+
+        this.thScopeObserver.observe(thead, { childList: true, subtree: true });
     }
 
     get dataP() {

--- a/packages/primeng/src/treetable/treetable.ts
+++ b/packages/primeng/src/treetable/treetable.ts
@@ -1033,6 +1033,20 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
         });
     }
 
+    onAfterViewInit() {
+        if (isPlatformBrowser(this.platformId)) {
+            this.updateThScope();
+        }
+    }
+
+    /**
+     * Adds scope="col" to th elements for accessibility (td-has-header rule).
+     * @group Method
+     */
+    updateThScope() {
+        setTimeout(() => this.el.nativeElement.querySelectorAll('th:not([scope])').forEach((th: HTMLElement) => th.setAttribute('scope', 'col')));
+    }
+
     filterService = inject(FilterService);
 
     tableService = inject(TreeTableService);
@@ -1055,6 +1069,7 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
 
             this.updateSerializedValue();
             this.tableService.onUIUpdate(this.value);
+            this.updateThScope();
         }
 
         if (simpleChange.sortField) {
@@ -1094,6 +1109,10 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
                 this.tableService.onSelectionChange();
             }
             this.preventSelectionSetterPropagation = false;
+        }
+
+        if (simpleChange.columns) {
+            this.updateThScope();
         }
     }
 

--- a/packages/primeng/src/treetable/treetable.ts
+++ b/packages/primeng/src/treetable/treetable.ts
@@ -914,6 +914,8 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
 
     toggleRowIndex: Nullable<number>;
 
+    private thScopeObserver: MutationObserver | null = null;
+
     onInit() {
         if (this.lazy && this.lazyLoadOnInit && !this.virtualScroll) {
             this.onLazyLoad.emit(this.createLazyLoadMetadata());
@@ -1035,16 +1037,8 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
 
     onAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
-            this.updateThScope();
+            this.initThScopeObserver();
         }
-    }
-
-    /**
-     * Adds scope="col" to th elements for accessibility (td-has-header rule).
-     * @group Method
-     */
-    updateThScope() {
-        setTimeout(() => this.el.nativeElement.querySelectorAll('th:not([scope])').forEach((th: HTMLElement) => th.setAttribute('scope', 'col')));
     }
 
     filterService = inject(FilterService);
@@ -1069,7 +1063,6 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
 
             this.updateSerializedValue();
             this.tableService.onUIUpdate(this.value);
-            this.updateThScope();
         }
 
         if (simpleChange.sortField) {
@@ -1109,10 +1102,6 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
                 this.tableService.onSelectionChange();
             }
             this.preventSelectionSetterPropagation = false;
-        }
-
-        if (simpleChange.columns) {
-            this.updateThScope();
         }
     }
 
@@ -2365,6 +2354,40 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
         this.editingCellField = null;
         this.editingCellData = null;
         this.initialized = null;
+
+        if (this.thScopeObserver) {
+            this.thScopeObserver.disconnect();
+            this.thScopeObserver = null;
+        }
+    }
+
+    private initThScopeObserver() {
+        const theads = this.el.nativeElement.querySelectorAll(':scope thead');
+        if (!theads.length) {
+            return;
+        }
+
+        theads.forEach((thead: HTMLElement) => {
+            thead.querySelectorAll(':scope > tr > th:not([scope])').forEach((th: HTMLElement) => th.setAttribute('scope', 'col'));
+        });
+
+        this.thScopeObserver = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (node.nodeType === Node.ELEMENT_NODE) {
+                        const element = node as HTMLElement;
+                        if (element.tagName === 'TH' && !element.hasAttribute('scope')) {
+                            element.setAttribute('scope', 'col');
+                        }
+                        element.querySelectorAll?.('th:not([scope])').forEach((th: HTMLElement) => th.setAttribute('scope', 'col'));
+                    }
+                });
+            });
+        });
+
+        theads.forEach((thead: HTMLElement) => {
+            this.thScopeObserver!.observe(thead, { childList: true, subtree: true });
+        });
     }
 
     get dataP() {


### PR DESCRIPTION
fixes: #3 

Description
Adds scope="col" attribute to <th> elements in Table and TreeTable components to fix the td-has-header accessibility violation.

Changes

- Added updateThScope() method that sets scope="col" on all <th> elements
- Method is called on view init, when data loads, and when columns change
- Ensures dynamically loaded content and toggled columns maintain accessibility compliance

Why
Without the scope attribute, screen reader users cannot understand data context when navigating table cells. The scope="col" attribute creates a programmatic relationship between data cells and their column headers.

Testing

1. Run axe DevTools or Lighthouse accessibility audit on Table/TreeTable demos
2. Verify td-has-header rule passes
3. Inspect <th> elements and confirm scope="col" is present

References

- axe rule: td-has-header
- WCAG: 1.3.1 Info and Relationships (Level A)

> Migrated from `primefaces/primeng#19636` — originally by `@fkwq34` on 2026-06-23

---
*Original base: `master` @ `8c0ce70`, head: `tables-accessibility-scopes` @ `35ad53b`*