### PR TITLE
Fix FrozenColumn.updateStickyPosition misplacing cells

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -3644,12 +3644,15 @@ export class FrozenColumn extends BaseComponent {
                 this.el.nativeElement.style.left = left + 'px';
             }
 
-            const filterRow = this.el.nativeElement?.parentElement?.nextElementSibling;
-            if (filterRow) {
+            const nextRow = this.el.nativeElement?.parentElement?.nextElementSibling;
+            const isHeaderCell = this.el.nativeElement?.tagName === 'TH';
+            const nextRowIsFilterRow = !!nextRow && !!DomHandler.findSingle(nextRow, '[data-pc-section="columnfilter"]');
+
+            if (isHeaderCell && nextRow && nextRowIsFilterRow) {
                 let index = DomHandler.index(this.el.nativeElement);
-                if (filterRow.children && filterRow.children[index]) {
-                    filterRow.children[index].style.left = this.el.nativeElement.style.left;
-                    filterRow.children[index].style.right = this.el.nativeElement.style.right;
+                if (nextRow.children && nextRow.children[index]) {
+                    nextRow.children[index].style.left = this.el.nativeElement.style.left;
+                    nextRow.children[index].style.right = this.el.nativeElement.style.right;
                 }
             }
         }


### PR DESCRIPTION
Fixes #19631

Edit: the issue was closed by mistake, my changes do apply to v22 as well. I can prepare a PR for the v22 branch too.

> Migrated from `primefaces/primeng#19632` — originally by `@kabalage` on 2026-06-18

---
*Original base: `master` @ `8c0ce70`, head: `bugfix/table-frozen-column-sticky-position` @ `b345a97`*