### PR TITLE
fix: #19212 - Tab onKeyDown only stops propagation for handled keys

### DIFF
--- a/packages/primeng/src/tabs/tab.ts
+++ b/packages/primeng/src/tabs/tab.ts
@@ -97,39 +97,44 @@ export class Tab extends BaseComponent<TabPassThrough> {
         switch (event.code) {
             case 'ArrowRight':
                 this.onArrowRightKey(event);
+                event.stopPropagation();
                 break;
 
             case 'ArrowLeft':
                 this.onArrowLeftKey(event);
+                event.stopPropagation();
                 break;
 
             case 'Home':
                 this.onHomeKey(event);
+                event.stopPropagation();
                 break;
 
             case 'End':
                 this.onEndKey(event);
+                event.stopPropagation();
                 break;
 
             case 'PageDown':
                 this.onPageDownKey(event);
+                event.stopPropagation();
                 break;
 
             case 'PageUp':
                 this.onPageUpKey(event);
+                event.stopPropagation();
                 break;
 
             case 'Enter':
             case 'NumpadEnter':
             case 'Space':
                 this.onEnterKey(event);
+                event.stopPropagation();
                 break;
 
             default:
                 break;
         }
-
-        event.stopPropagation();
     }
 
     onAfterViewInit(): void {

--- a/packages/primeng/src/tabs/tabs.spec.ts
+++ b/packages/primeng/src/tabs/tabs.spec.ts
@@ -500,6 +500,28 @@ describe('Tabs', () => {
             expect(component.value).toBe(2);
         });
 
+        it('should stop propagation for handled keys', () => {
+            const rightArrowEvent = new KeyboardEvent('keydown', { code: 'ArrowRight' });
+            spyOn(rightArrowEvent, 'stopPropagation');
+
+            tabs[0].nativeElement.dispatchEvent(rightArrowEvent);
+            fixture.detectChanges();
+
+            expect(rightArrowEvent.stopPropagation).toHaveBeenCalled();
+        });
+
+        it('should not stop propagation for unhandled keys like Escape', () => {
+            const escapeEvent = new KeyboardEvent('keydown', { code: 'Escape' });
+            spyOn(escapeEvent, 'stopPropagation');
+            spyOn(escapeEvent, 'preventDefault');
+
+            tabs[0].nativeElement.dispatchEvent(escapeEvent);
+            fixture.detectChanges();
+
+            expect(escapeEvent.stopPropagation).not.toHaveBeenCalled();
+            expect(escapeEvent.preventDefault).not.toHaveBeenCalled();
+        });
+
         it('should skip disabled tabs in navigation', async () => {
             component.tab3Disabled = true;
             fixture.changeDetectorRef.markForCheck();


### PR DESCRIPTION
Fixes #181

## Problem

The Tab component's `onKeyDown` handler called `event.stopPropagation()` unconditionally for **all** keydown events, not just the keys it actually handles (Arrow keys, Home, End, PageUp/PageDown, Enter, Space).

This prevented parent components from receiving keyboard events like `Escape`, breaking common patterns such as closing a Dialog with `Escape` while a tab header is focused.

## Fix

Moved `event.stopPropagation()` into each handled `case` block. Unhandled keys (e.g. `Escape`) now fall through the `default` case and propagate to parent components as expected.

> Migrated from `primefaces/primeng#19628` — originally by `@luber` on 2026-06-15

---
*Original base: `master` @ `5d23908`, head: `fix-19212` @ `30c46ec`*