### PR TITLE
fix: onYearChange not emitting when navigating with arrows

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -1610,6 +1610,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
             setTimeout(() => {
                 this.updateFocus();
             }, 1);
+            this.onYearChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
         } else if (this.currentView === 'year') {
             this.incrementDecade();
             setTimeout(() => {

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -1578,6 +1578,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
             setTimeout(() => {
                 this.updateFocus();
             }, 1);
+            this.onYearChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
         } else if (this.currentView === 'year') {
             this.decrementDecade();
             setTimeout(() => {


### PR DESCRIPTION
## Summary
- Added emit event to navBackward and navForward

Fixes #19620

## Problem
Using chevron buttons to change years doesn't emit onYearChange event

> Migrated from `primefaces/primeng#19619` — originally by `@bedirhan-arslan` on 2026-06-11

---
*Original base: `master` @ `5d23908`, head: `fix/datepicker-year-change-not-emitting` @ `2ff96cf`*