### PR TITLE
fix: DynamicDialogRef.onDragStart never emits (#19611)

### DIFF
--- a/packages/primeng/src/dialog/dialog.spec.ts
+++ b/packages/primeng/src/dialog/dialog.spec.ts
@@ -49,6 +49,7 @@ import { Dialog } from './dialog';
             (onMaximize)="onMaximizeEvent($event)"
             (onResizeInit)="onResizeInitEvent($event)"
             (onResizeEnd)="onResizeEndEvent($event)"
+            (onDragStart)="onDragStartEvent($event)"
             (onDragEnd)="onDragEndEvent($event)"
             (visibleChange)="onVisibleChangeEvent($event)"
         >
@@ -99,6 +100,7 @@ class TestBasicDialogComponent {
     maximizeEvent: any = null as any;
     resizeInitEvent: any = null as any;
     resizeEndEvent: any = null as any;
+    dragStartEvent: any = null as any;
     dragEndEvent: any = null as any;
     visibleChangeEvent: any = null as any;
 
@@ -124,6 +126,10 @@ class TestBasicDialogComponent {
 
     onResizeEndEvent(event: any) {
         this.resizeEndEvent = event;
+    }
+
+    onDragStartEvent(event: any) {
+        this.dragStartEvent = event;
     }
 
     onDragEndEvent(event: any) {
@@ -517,6 +523,20 @@ describe('Dialog', () => {
             dialogInstance.onResizeInit.emit(mouseEvent);
 
             expect(component.onResizeInitEvent).toHaveBeenCalledWith(mouseEvent);
+        });
+
+        it('should emit onDragStart event when dragging starts', async () => {
+            spyOn(component, 'onDragStartEvent');
+
+            component.visible = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            const mouseEvent = new MouseEvent('mousedown');
+            dialogInstance.onDragStart.emit(mouseEvent);
+
+            expect(component.onDragStartEvent).toHaveBeenCalledWith(mouseEvent);
         });
 
         it('should emit onDragEnd event when dragging ends', async () => {
@@ -1298,6 +1318,30 @@ describe('Dialog', () => {
             dialogInstance.onResizeInit.emit(mouseEvent);
 
             expect(component.onResizeInitEvent).toHaveBeenCalledWith(mouseEvent);
+        });
+
+        it('should emit onDragStart event from initDrag', async () => {
+            component.draggable = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            component.visible = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            spyOn(dialogInstance.onDragStart, 'emit');
+
+            const targetElement = document.createElement('div');
+            const mouseEvent = new MouseEvent('mousedown', { clientX: 100, clientY: 100 });
+            Object.defineProperty(mouseEvent, 'target', { value: targetElement });
+            Object.defineProperty(mouseEvent, 'pageX', { value: 100 });
+            Object.defineProperty(mouseEvent, 'pageY', { value: 100 });
+
+            dialogInstance.initDrag(mouseEvent);
+
+            expect(dialogInstance.dragging).toBe(true);
+            expect(dialogInstance.onDragStart.emit).toHaveBeenCalledWith(mouseEvent);
         });
 
         it('should emit onDragEnd event', () => {

--- a/packages/primeng/src/dialog/dialog.ts
+++ b/packages/primeng/src/dialog/dialog.ts
@@ -448,6 +448,12 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
      */
     @Output() onResizeEnd: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
     /**
+     * Callback to invoke when dialog dragging is initiated.
+     * @param {MouseEvent} event - Mouse event.
+     * @group Emits
+     */
+    @Output() onDragStart: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+    /**
      * Callback to invoke when dialog dragging is completed.
      * @param {DragEvent} event - Drag event.
      * @group Emits
@@ -851,6 +857,7 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
             (this.container() as HTMLDivElement).style.margin = '0';
             this.document.body.setAttribute('data-p-unselectable-text', 'true');
             !this.$unstyled() && addStyle(this.document.body, { 'user-select': 'none' });
+            this.onDragStart.emit(event);
         }
     }
 

--- a/packages/primeng/src/dynamicdialog/dynamicdialog.spec.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.spec.ts
@@ -327,6 +327,17 @@ describe('DynamicDialog', () => {
             expect(mockDialogRef.dragStart).toHaveBeenCalledWith(mouseEvent);
         });
 
+        it('should forward drag start from dialog to dialog ref', () => {
+            const mouseEvent = new MouseEvent('mousedown');
+            Object.defineProperty(mouseEvent, 'pageX', { value: 100 });
+            Object.defineProperty(mouseEvent, 'pageY', { value: 100 });
+
+            component.onDialogDragStart(mouseEvent);
+
+            expect(component.dragging).toBe(true);
+            expect(mockDialogRef.dragStart).toHaveBeenCalledWith(mouseEvent);
+        });
+
         it('should not initialize drag when clicking on header icons', () => {
             const iconElement = document.createElement('i');
             iconElement.className = 'p-dialog-header-icon';

--- a/packages/primeng/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.ts
@@ -54,6 +54,7 @@ const DYNAMIC_DIALOG_INSTANCE = new InjectionToken<DynamicDialog>('DYNAMIC_DIALO
             (onResizeInit)="onDialogResizeInit($event)"
             (onResizeEnd)="onDialogResizeEnd($event)"
             (onDragEnd)="onDialogDragEnd($event)"
+            (onDragStart)="onDialogDragStart($event)"
             (visibleChange)="onVisibleChange($event)"
             [pt]="ddconfig.pt"
             appendTo="self"
@@ -304,6 +305,11 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
     onDialogDragEnd(event: DragEvent) {
         this.dragging = false;
         this.dialogRef.dragEnd(event);
+    }
+
+    onDialogDragStart(event: MouseEvent) {
+        this.dragging = true;
+        this.dialogRef.dragStart(event);
     }
 
     close() {


### PR DESCRIPTION
## Summary
- Add `onDragStart` output to `p-dialog` and emit it from `initDrag()`
- Bridge `(onDragStart)` in `DynamicDialog` to `DynamicDialogRef.dragStart()`
- Add unit tests for both components

Fixes #19611

## Problem
`DynamicDialogRef.onDragStart` never emitted in v21 because drag handling moved into `p-dialog`, but only `onDragEnd` was wired through to the ref.

## Test plan
- [x] `dialog.spec.ts` — `onDragStart` emission from `initDrag()`
- [x] `dynamicdialog.spec.ts` — `onDialogDragStart` forwards to ref
- [x] Manual repro: open `DialogService` dialog, drag header, confirm `onDragStart` and `onDragEnd` both fire

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

> Migrated from `primefaces/primeng#19612` — originally by `@gamble4846` on 2026-06-09

---
*Original base: `master` @ `5d23908`, head: `master` @ `3f67d61`*