### PR TITLE
perf(table): memoize dataToRender and $params to cut per-cycle render cost (#19537)

### DIFF
--- a/packages/primeng/src/basecomponent/basecomponent.ts
+++ b/packages/primeng/src/basecomponent/basecomponent.ts
@@ -36,6 +36,10 @@ export class BaseComponent<PT = any> implements Lifecycle {
 
     public scopedStyleEl: any;
 
+    // Declared before `parent` (which reads `$params` during construction) so this define-semantics
+    // field initializer does not reset a cache already populated at construction time.
+    private _$paramsCache: { instance: any; parent: { instance: BaseComponent | undefined } } | undefined;
+
     public parent = this.$params.parent;
 
     protected readonly cn = cn;
@@ -116,14 +120,17 @@ export class BaseComponent<PT = any> implements Lifecycle {
     }
 
     get $params() {
-        const parentInstance = this._getHostInstance(this) || this.$parentInstance;
-
-        return {
+        // Memoized: `instance` is `this` and the resolved parent (host-instance chain walk or the
+        // injected `$parentInstance`) are both fixed for the component's lifetime, so this is
+        // computed once. `instance` stays the live `this`, so style/PT functions still read live
+        // state. Eliminates the per-call `_getHostInstance` chain walk and object allocation that
+        // ran inside every `cx()`/`sx()`/`ptm()` on every change detection cycle.
+        return (this._$paramsCache ??= {
             instance: this as any,
             parent: {
-                instance: parentInstance
+                instance: this._getHostInstance(this) || this.$parentInstance
             }
-        };
+        });
     }
 
     /******************** Lifecycle Hooks ********************/

--- a/packages/primeng/src/table/table.spec.ts
+++ b/packages/primeng/src/table/table.spec.ts
@@ -311,6 +311,137 @@ describe('Table', () => {
         });
     });
 
+    describe('dataToRender memoization (performance)', () => {
+        let perfFixture: ComponentFixture<TestBasicTableComponent>;
+        let table: Table;
+
+        beforeEach(async () => {
+            perfFixture = TestBed.createComponent(TestBasicTableComponent);
+            await perfFixture.whenStable();
+            perfFixture.detectChanges();
+            table = perfFixture.debugElement.query(By.css('p-table')).componentInstance as Table;
+        });
+
+        // Regression guard for #19537: the body's [value]="dataToRender(...)" binding is
+        // re-evaluated on every change detection cycle. Without memoization it produced a fresh
+        // array each cycle, churning *ngFor and re-firing the TableBody value setter (which forces
+        // a layout reflow for frozen rows). These tests pin the referential-stability invariant.
+
+        it('returns a stable reference across change detection cycles when inputs are unchanged (no paginator)', () => {
+            const firstResult = table.dataToRender(undefined);
+
+            perfFixture.detectChanges();
+            perfFixture.detectChanges();
+
+            const secondResult = table.dataToRender(undefined);
+
+            expect(secondResult).toBe(firstResult);
+            // With no paginator the rendered data is exactly processedData (same reference).
+            expect(secondResult).toBe(table.processedData);
+        });
+
+        it('does not allocate a new sliced array on cache hits (paginator on)', () => {
+            table.paginator = true;
+            table.rows = 2;
+            table.first = 0;
+
+            const page = table.dataToRender(undefined); // cache miss -> one slice computed
+            const pageAgain = table.dataToRender(undefined); // cache hit -> reuses the same array
+            const pageThird = table.dataToRender(undefined); // cache hit -> reuses the same array
+
+            expect(page.length).toBe(2);
+            // Referential equality is the allocation invariant: a stable reference is only
+            // possible if no fresh slice was produced on the repeat calls.
+            expect(pageAgain).toBe(page);
+            expect(pageThird).toBe(page);
+        });
+
+        it('recomputes the page slice when first/rows change (paginator on)', () => {
+            table.paginator = true;
+            table.rows = 2;
+            table.first = 0;
+
+            const pageOne = table.dataToRender(undefined);
+            expect(table.dataToRender(undefined)).toBe(pageOne); // stable within the same key
+            expect(pageOne[0]).toBe(table.processedData[0]);
+
+            table.first = 2; // key changes -> must recompute
+
+            const pageTwo = table.dataToRender(undefined);
+            expect(pageTwo).not.toBe(pageOne);
+            expect(pageTwo[0]).toBe(table.processedData[2]);
+
+            table.rows = 1; // key changes again
+            expect(table.dataToRender(undefined).length).toBe(1);
+        });
+
+        it('invalidates the cache when the data reference changes (immutable update contract)', () => {
+            const before = table.dataToRender(undefined);
+
+            // Sort/filter/value updates all replace the array reference; emulate that contract.
+            table.value = [...table.value];
+
+            const after = table.dataToRender(undefined);
+            expect(after).not.toBe(before);
+            expect(after).toBe(table.processedData);
+        });
+
+        it('reflects sorting through a fresh, correctly ordered reference (no stale cache)', async () => {
+            const before = table.dataToRender(undefined);
+
+            table.sort({ field: 'price', order: 1 });
+            await perfFixture.whenStable();
+
+            const after = table.dataToRender(undefined);
+            expect(after).not.toBe(before); // sort reassigns _value -> cache busted
+            for (let i = 1; i < after.length; i++) {
+                expect(after[i].price >= after[i - 1].price).toBeTrue(); // ascending order preserved
+            }
+        });
+
+        it('preserves exact behavior for non-array arguments (bypasses cache)', () => {
+            // Imperative callers may pass non-array values (e.g. a row count). With paginator off
+            // the original implementation returns the resolved value as-is; the bypass must keep
+            // this identical and never cache it.
+            expect(table.paginator).toBeFalsy();
+            expect(table.dataToRender(42 as any)).toBe(42 as any);
+            // null/undefined fall through to processedData exactly as before.
+            expect(table.dataToRender(null)).toBe(table.processedData);
+        });
+    });
+
+    describe('$params memoization (performance)', () => {
+        let paramsFixture: ComponentFixture<TestBasicTableComponent>;
+        let table: Table;
+
+        beforeEach(async () => {
+            paramsFixture = TestBed.createComponent(TestBasicTableComponent);
+            await paramsFixture.whenStable();
+            paramsFixture.detectChanges();
+            table = paramsFixture.debugElement.query(By.css('p-table')).componentInstance as Table;
+        });
+
+        // BaseComponent.$params is read by cx()/sx()/ptm() on every change detection cycle for every
+        // element and row. It is now memoized; these guard that the cached object is stable and correct.
+        it('returns a stable object reference across repeated reads', () => {
+            const a: any = table.$params;
+            const b: any = table.$params;
+
+            expect(b).toBe(a); // memoized, not re-allocated
+            expect(a.instance).toBe(table); // instance stays the live component
+            expect(a.parent).toBeDefined();
+        });
+
+        it('stays referentially stable across change detection cycles', () => {
+            const a: any = table.$params;
+
+            paramsFixture.detectChanges();
+            paramsFixture.detectChanges();
+
+            expect(table.$params).toBe(a);
+        });
+    });
+
     describe('Selection Functionality', () => {
         let testComponent: TestSelectionTableComponent;
         let testFixture: ComponentFixture<TestSelectionTableComponent>;

--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -1472,15 +1472,52 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
 
     private _initialColWidths: number[];
 
+    private _dataToRenderCacheKey: any = null;
+
+    private _dataToRenderCacheResult: any[] | undefined;
+
     dataToRender(data: any) {
         const _data = data || this.processedData;
 
-        if (_data && this.paginator) {
-            const first = this.lazy ? 0 : this.first;
-            return _data.slice(first, <number>first + <number>this.rows);
+        // Imperative callers may pass non-array values (e.g. a row count); preserve the
+        // original, un-cached behavior for those so the semantics stay byte-for-byte identical.
+        if (!Array.isArray(_data)) {
+            if (_data && this.paginator) {
+                const first = this.lazy ? 0 : this.first;
+                return _data.slice(first, <number>first + <number>this.rows);
+            }
+
+            return _data;
         }
 
-        return _data;
+        const first = this.lazy ? 0 : this.first;
+        const key = this._dataToRenderCacheKey;
+
+        // Return the previously computed array while every input that affects the result is
+        // unchanged. This keeps the body's [value] binding referentially stable across change
+        // detection cycles, avoiding a fresh slice (and the TableBody value-setter side effects,
+        // including a forced layout reflow for frozen rows) on every cycle. Sort/filter/value
+        // changes all replace the array reference (sort: `_value = [...]`, filter: reassigns
+        // `filteredValue`), so the `source`/`length` checks invalidate the cache correctly.
+        if (
+            key !== null &&
+            key.data === data &&
+            key.source === _data &&
+            key.length === _data.length &&
+            key.first === first &&
+            key.rows === this.rows &&
+            key.lazy === this.lazy &&
+            key.paginator === this.paginator
+        ) {
+            return this._dataToRenderCacheResult;
+        }
+
+        const result = this.paginator ? _data.slice(<number>first, <number>first + <number>this.rows) : _data;
+
+        this._dataToRenderCacheKey = { data, source: _data, length: _data.length, first, rows: this.rows, lazy: this.lazy, paginator: this.paginator };
+        this._dataToRenderCacheResult = result;
+
+        return result;
     }
 
     updateSelectionKeys() {


### PR DESCRIPTION
Closes #45

## Defining the issue

Table rendering latency regressed for large datasets (#45). Profiling the change-detection hot
path surfaced two pieces of redundant work that run on **every CD cycle**, because both `Table` and
the per-row `TableBody` use `ChangeDetectionStrategy.Default`:

1. **`dataToRender()` re-allocates the row array every cycle.** The body binds
   `[value]="dataToRender(scrollerOptions.rows)"` — a method binding. With a paginator it returned a
   fresh `.slice()` on every cycle, which re-fired the `TableBody.value` setter (a forced layout
   reflow `getOuterHeight()` for frozen rows) and handed `*ngFor` a new collection reference to
   re-diff.
2. **`BaseComponent.$params` is recomputed per element per cycle.** `cx()`/`sx()`/`ptm()` (and the
   `$pt`/`$style`/`$globalPT`/`$defaultPT` getters) read `$params`, which walked the
   `$parentInstance` chain via `_getHostInstance` and allocated two objects on every call. For a
   row directive such as `pSelectableRow` (`[class]="cx('selectableRow')"`) this ran once per row,
   per cycle.

## Fix

- **`dataToRender()` (`table.ts`)** now memoizes its result, returning a referentially stable array
  until its inputs change. Cache key: resolved data reference, length, effective `first`, `rows`,
  `lazy`, `paginator`. Sort reassigns `_value = [...]` and filter reassigns `filteredValue`, so any
  data change flips the reference and invalidates the cache automatically. Non-array arguments
  bypass the cache, preserving the original behavior byte-for-byte.
- **`BaseComponent.$params` (`basecomponent.ts`)** is computed once per instance and cached. Its
  inputs (`$parentInstance`, `$name`, `$hostName`) are immutable after construction, and `instance`
  remains the live `this`, so style/PT functions still read live state. The cache field is declared
  before `parent = this.$params.parent` so ES2022 define-semantics field init does not reset a cache
  populated during construction.

No public API changes and no change-detection-strategy changes.

## Tests

Added deterministic, referential-stability tests (no wall-clock benchmarks) to `table.spec.ts`:
`dataToRender memoization` (stable reference, no per-cycle allocation, correct re-slice on
`first`/`rows` change, sort/filter cache busting, non-array bypass) and `$params memoization`
(stable reference, `instance === component`).

Validated against the suites that most exercise PassThrough + the `_getHostInstance` parent-chain
walk:

| Suite | Result |
| --- | --- |
| `table.spec.ts` (incl. 23 PassThrough) | 73 passing |
| `treetable.spec.ts` | 174 passing |
| `stepper.spec.ts` | 58 passing |
| `tabs.spec.ts` | 73 passing |

All green; no functional regressions in sorting, filtering, pagination, selection, virtual scroll,
templates, or PassThrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Migrated from `primefaces/primeng#19603` — originally by `@asrita-pyda` on 2026-05-29

---
*Original base: `master` @ `22d9ca1`, head: `fix/table-render-perf-19537` @ `1e84358`*