### PR TITLE
fix: #19590 - TreeSelect overlay position with virtual scroll

### DIFF
--- a/packages/primeng/src/treeselect/treeselect.spec.ts
+++ b/packages/primeng/src/treeselect/treeselect.spec.ts
@@ -1330,6 +1330,31 @@ describe('TreeSelect', () => {
             expect(treeSelectInstance.virtualScrollItemSize).toBe(32);
         });
 
+        it('should pass scrollHeight to tree when virtual scrolling is enabled', async () => {
+            testComponent.options = Array.from({ length: 50 }, (_, i) => ({
+                key: i.toString(),
+                label: `Node ${i}`,
+                data: `Data ${i}`
+            }));
+            testComponent.scrollHeight = '180px';
+            testComponent.virtualScroll = true;
+            testComponent.virtualScrollItemSize = 32;
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const treeSelectInstance = testFixture.debugElement.query(By.directive(TreeSelect)).componentInstance;
+            const dropdown = testFixture.debugElement.query(By.css('.p-treeselect-dropdown'));
+            dropdown.nativeElement.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+            await new Promise((resolve) => setTimeout(resolve));
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            expect(treeSelectInstance.treeViewChild?.scrollHeight).toBe('180px');
+        });
+
         it('should handle dynamic option updates', async () => {
             // Start with empty options
             testComponent.options = [];

--- a/packages/primeng/src/treeselect/treeselect.ts
+++ b/packages/primeng/src/treeselect/treeselect.ts
@@ -165,6 +165,7 @@ const TREESELECT_INSTANCE = new InjectionToken<TreeSelect>('TREESELECT_INSTANCE'
                             [filterPlaceholder]="filterPlaceholder"
                             [filterLocale]="filterLocale"
                             [filteredNodes]="filteredNodes"
+                            [scrollHeight]="virtualScroll ? scrollHeight : undefined"
                             [virtualScroll]="virtualScroll"
                             [virtualScrollItemSize]="virtualScrollItemSize"
                             [virtualScrollOptions]="virtualScrollOptions"


### PR DESCRIPTION
fixes #20

TreeSelect now passes its `scrollHeight` to the inner `p-tree` when virtual scrolling is enabled. Without that, the virtual scroller could miss the height used by the overlay wrapper and the panel could be positioned wrong when it opened above the input.

Added a regression for the virtual scroll case.

Tested:
- `pnpm --filter primeng test:unit -- --include src/treeselect/treeselect.spec.ts`
- `pnpm --filter primeng build`

> Migrated from `primefaces/primeng#19593` — originally by `@macayu17` on 2026-05-21

---
*Original base: `master` @ `22d9ca1`, head: `fix/19590-treeselect-overlay-virtual-scroll` @ `11eb344`*