### PR TITLE
fix(#19591): togglebutton size allow undefined

### DIFF
--- a/packages/primeng/src/togglebutton/style/togglebuttonstyle.ts
+++ b/packages/primeng/src/togglebutton/style/togglebuttonstyle.ts
@@ -22,8 +22,8 @@ const classes = {
             'p-togglebutton-checked': instance.checked,
             'p-invalid': instance.invalid(),
             'p-disabled': instance.$disabled(),
-            'p-togglebutton-sm p-inputfield-sm': instance.size === 'small',
-            'p-togglebutton-lg p-inputfield-lg': instance.size === 'large',
+            'p-togglebutton-sm p-inputfield-sm': instance.size() === 'small',
+            'p-togglebutton-lg p-inputfield-lg': instance.size() === 'large',
             'p-togglebutton-fluid': instance.fluid()
         }
     ],

--- a/packages/primeng/src/togglebutton/togglebutton.spec.ts
+++ b/packages/primeng/src/togglebutton/togglebutton.spec.ts
@@ -383,7 +383,7 @@ describe('ToggleButton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(toggleButtonInstance.size).toBe('large');
+            expect(toggleButtonInstance.size()).toBe('large');
         });
     });
 

--- a/packages/primeng/src/togglebutton/togglebutton.ts
+++ b/packages/primeng/src/togglebutton/togglebutton.ts
@@ -171,9 +171,10 @@ export class ToggleButton extends BaseEditableHolder<ToggleButtonPassThrough> {
     @Input({ transform: booleanAttribute }) autofocus: boolean | undefined;
     /**
      * Defines the size of the component.
+     * @defaultValue undefined
      * @group Props
      */
-    @Input() size: 'large' | 'small';
+    size = input<'small' | 'large' | undefined>();
     /**
      * Whether selection can not be cleared.
      * @group Props
@@ -270,7 +271,7 @@ export class ToggleButton extends BaseEditableHolder<ToggleButtonPassThrough> {
         return this.cn({
             checked: this.active,
             invalid: this.invalid(),
-            [this.size as string]: this.size
+            [this.size() as string]: this.size()
         });
     }
 }


### PR DESCRIPTION
Fixes #19 and refactores the code to use input signal for the size input

> Migrated from `primefaces/primeng#19592` — originally by `@gianluca-moro` on 2026-05-21

---
*Original base: `master` @ `22d9ca1`, head: `fix/19591/toggle-button-size` @ `9acf1ee`*