### PR TITLE
fix: inputs should have same height

### DIFF
--- a/apps/showcase/doc/autocomplete/sizes-doc.ts
+++ b/apps/showcase/doc/autocomplete/sizes-doc.ts
@@ -1,8 +1,8 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AutoCompleteModule } from 'primeng/autocomplete';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
-import { AppCode } from '@/components/doc/app.code';
 
 @Component({
     selector: 'sizes-doc',
@@ -12,9 +12,9 @@ import { AppCode } from '@/components/doc/app.code';
             <p>AutoComplete provides <i>small</i> and <i>large</i> sizes as alternatives to the base.</p>
         </app-docsectiontext>
         <div class="card flex flex-col items-center gap-4">
-            <p-autocomplete [(ngModel)]="value1" [suggestions]="items" (completeMethod)="search()" size="small" placeholder="Small" dropdown />
-            <p-autocomplete [(ngModel)]="value2" [suggestions]="items" (completeMethod)="search()" placeholder="Normal" dropdown />
-            <p-autocomplete [(ngModel)]="value3" [suggestions]="items" (completeMethod)="search()" size="large" placeholder="Large" dropdown />
+            <p-autocomplete [(ngModel)]="value1" [suggestions]="items" (completeMethod)="search()" size="small" placeholder="Small" class="h-8" dropdown />
+            <p-autocomplete [(ngModel)]="value2" [suggestions]="items" (completeMethod)="search()" placeholder="Normal" class="h-10" dropdown />
+            <p-autocomplete [(ngModel)]="value3" [suggestions]="items" (completeMethod)="search()" size="large" placeholder="Large" class="h-11" dropdown />
         </div>
         <app-code></app-code>`
 })

--- a/apps/showcase/doc/inputmask/sizes-doc.ts
+++ b/apps/showcase/doc/inputmask/sizes-doc.ts
@@ -1,9 +1,9 @@
+import { AppCodeModule } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { InputMaskModule } from 'primeng/inputmask';
 import { InputText } from 'primeng/inputtext';
-import { AppCodeModule } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'sizes-doc',
@@ -14,9 +14,9 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <p>InputMask provides <i>small</i> and <i>large</i> sizes as alternatives to the base.</p>
         </app-docsectiontext>
         <div class="card flex flex-col items-center gap-4">
-            <input pInputText [(ngModel)]="value1" placeholder="Small" pSize="small" pInputMask="99-999999" />
-            <input pInputText [(ngModel)]="value2" placeholder="Normal" pInputMask="99-999999" />
-            <input pInputText [(ngModel)]="value3" placeholder="Large" pSize="large" pInputMask="99-999999" />
+            <input pInputText [(ngModel)]="value1" placeholder="Small" pSize="small" pInputMask="99-999999" class="h-8" />
+            <input pInputText [(ngModel)]="value2" placeholder="Normal" pInputMask="99-999999" class="h-10" />
+            <input pInputText [(ngModel)]="value3" placeholder="Large" pSize="large" pInputMask="99-999999" class="h-11" />
         </div>
         <app-code></app-code>
     `

--- a/apps/showcase/doc/inputnumber/sizes-doc.ts
+++ b/apps/showcase/doc/inputnumber/sizes-doc.ts
@@ -1,8 +1,8 @@
+import { AppCodeModule } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { InputNumberModule } from 'primeng/inputnumber';
-import { AppCodeModule } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'sizes-doc',
@@ -13,9 +13,9 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <p>InputNumber provides <i>small</i> and <i>large</i> sizes as alternatives to the base.</p>
         </app-docsectiontext>
         <div class="card flex flex-col items-center gap-4">
-            <p-inputnumber [(ngModel)]="value1" size="small" placeholder="Small" mode="currency" currency="USD" locale="en-US" />
-            <p-inputnumber [(ngModel)]="value2" placeholder="Normal" mode="currency" currency="USD" locale="en-US" />
-            <p-inputnumber [(ngModel)]="value3" size="large" placeholder="Large" mode="currency" currency="USD" locale="en-US" />
+            <p-inputnumber [(ngModel)]="value1" size="small" placeholder="Small" mode="currency" currency="USD" locale="en-US" class="h-8" />
+            <p-inputnumber [(ngModel)]="value2" placeholder="Normal" mode="currency" currency="USD" locale="en-US" class="h-10" />
+            <p-inputnumber [(ngModel)]="value3" size="large" placeholder="Large" mode="currency" currency="USD" locale="en-US" class="h-11" />
         </div>
         <app-code></app-code>
     `

--- a/apps/showcase/doc/inputotp/sizes-doc.ts
+++ b/apps/showcase/doc/inputotp/sizes-doc.ts
@@ -1,8 +1,8 @@
+import { AppCodeModule } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { InputOtpModule } from 'primeng/inputotp';
-import { AppCodeModule } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'sizes-doc',
@@ -13,9 +13,9 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <p>InputOtp provides <i>small</i> and <i>large</i> sizes as alternatives to the base.</p>
         </app-docsectiontext>
         <div class="card flex flex-col items-center gap-4">
-            <p-inputotp [(ngModel)]="value1" size="small" />
-            <p-inputotp [(ngModel)]="value2" />
-            <p-inputotp [(ngModel)]="value3" size="large" />
+            <p-inputotp [(ngModel)]="value1" size="small" class="h-8" />
+            <p-inputotp [(ngModel)]="value2" class="h-10" />
+            <p-inputotp [(ngModel)]="value3" size="large" class="h-11" />
         </div>
         <app-code></app-code>
     `

--- a/apps/showcase/doc/inputtext/sizes-doc.ts
+++ b/apps/showcase/doc/inputtext/sizes-doc.ts
@@ -1,8 +1,8 @@
+import { AppCodeModule } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { InputTextModule } from 'primeng/inputtext';
-import { AppCodeModule } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'sizes-doc',
@@ -13,9 +13,9 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <p>InputText provides <i>small</i> and <i>large</i> sizes as alternatives to the standard.</p>
         </app-docsectiontext>
         <div class="card flex flex-col items-center gap-4 ">
-            <input pInputText [(ngModel)]="value1" type="text" pSize="small" placeholder="Small" />
-            <input pInputText [(ngModel)]="value2" type="text" placeholder="Normal" />
-            <input pInputText [(ngModel)]="value3" type="text" pSize="large" placeholder="Large" />
+            <input pInputText [(ngModel)]="value1" type="text" pSize="small" placeholder="Small" class="h-8" />
+            <input pInputText [(ngModel)]="value2" type="text" placeholder="Normal" class="h-10" />
+            <input pInputText [(ngModel)]="value3" type="text" pSize="large" placeholder="Large" class="h-11" />
         </div>
         <app-code></app-code>
     `

--- a/apps/showcase/doc/select/sizes-doc.ts
+++ b/apps/showcase/doc/select/sizes-doc.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SelectModule } from 'primeng/select';
 
@@ -18,9 +18,9 @@ interface City {
             <p>Select provides <i>small</i> and <i>large</i> sizes as alternatives to the base.</p>
         </app-docsectiontext>
         <div class="card flex flex-col items-center gap-4">
-            <p-select [(ngModel)]="value1" [options]="cities" optionLabel="name" size="small" placeholder="Small" class="w-full md:w-56" />
-            <p-select [(ngModel)]="value2" [options]="cities" optionLabel="name" placeholder="Normal" class="w-full md:w-56" />
-            <p-select [(ngModel)]="value3" [options]="cities" optionLabel="name" size="large" placeholder="Large" class="w-full md:w-56" />
+            <p-select [(ngModel)]="value1" [options]="cities" optionLabel="name" size="small" placeholder="Small" class="w-full md:w-56 h-8" />
+            <p-select [(ngModel)]="value2" [options]="cities" optionLabel="name" placeholder="Normal" class="w-full md:w-56 h-10" />
+            <p-select [(ngModel)]="value3" [options]="cities" optionLabel="name" size="large" placeholder="Large" class="w-full md:w-56 h-11" />
         </div>
         <app-code></app-code>
     `

--- a/apps/showcase/doc/selectbutton/sizes-doc.ts
+++ b/apps/showcase/doc/selectbutton/sizes-doc.ts
@@ -1,8 +1,8 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SelectButton } from 'primeng/selectbutton';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
-import { AppCode } from '@/components/doc/app.code';
 
 @Component({
     selector: 'sizes-doc',
@@ -13,9 +13,9 @@ import { AppCode } from '@/components/doc/app.code';
             <p>SelectButton provides <i>small</i> and <i>large</i> sizes as alternatives to the base.</p>
         </app-docsectiontext>
         <div class="card flex flex-col items-center gap-4">
-            <p-selectbutton [(ngModel)]="value1" [options]="options" size="small" />
-            <p-selectbutton [(ngModel)]="value2" [options]="options" />
-            <p-selectbutton [(ngModel)]="value3" [options]="options" size="large" />
+            <p-selectbutton [(ngModel)]="value1" [options]="options" size="small" class="h-8" />
+            <p-selectbutton [(ngModel)]="value2" [options]="options" class="h-10" />
+            <p-selectbutton [(ngModel)]="value3" [options]="options" size="large" class="h-11" />
         </div>
         <app-code></app-code>
     `


### PR DESCRIPTION
fixes #23 

**The issue:**
The Select component has a different height compared to AutoComplete, InputText, InputNumber etc. This is happening for all size variants.

**The fix:**
Inputs fields have same height

> Migrated from `primefaces/primeng#19587` — originally by `@StankaKopalova` on 2026-05-19

---
*Original base: `master` @ `22d9ca1`, head: `fix-19585-different-height` @ `c95653c`*