### PR TITLE
[19577] fix: Remove aria-hidden from clear icon template

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -119,8 +119,8 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             [pInputTextUnstyled]="unstyled()"
         />
         <ng-container *ngIf="$filled() && !$disabled() && showClear && !loading">
-            <svg data-p-icon="times" *ngIf="!clearIconTemplate && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true" />
-            <span *ngIf="clearIconTemplate || _clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true">
+            <svg data-p-icon="times" *ngIf="!clearIconTemplate && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" />
+            <span *ngIf="clearIconTemplate || _clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()">
                 <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
             </span>
         </ng-container>

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -193,7 +193,6 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                         (keydown)="onContainerButtonKeydown($event)"
                                         [class]="cx('selectMonth')"
                                         [attr.disabled]="switchViewButtonDisabled() ? '' : undefined"
-                                        [attr.aria-label]="this.getTranslation('chooseMonth')"
                                         pRipple
                                         [pBind]="ptm('selectMonth')"
                                         [attr.data-pc-group-section]="'navigator'"
@@ -207,7 +206,6 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                         (keydown)="onContainerButtonKeydown($event)"
                                         [class]="cx('selectYear')"
                                         [attr.disabled]="switchViewButtonDisabled() ? '' : undefined"
-                                        [attr.aria-label]="getTranslation('chooseYear')"
                                         pRipple
                                         [pBind]="ptm('selectYear')"
                                         [attr.data-pc-group-section]="'navigator'"

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -193,6 +193,7 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                         (keydown)="onContainerButtonKeydown($event)"
                                         [class]="cx('selectMonth')"
                                         [attr.disabled]="switchViewButtonDisabled() ? '' : undefined"
+                                        [attr.aria-label]="this.getTranslation('chooseMonth')"
                                         pRipple
                                         [pBind]="ptm('selectMonth')"
                                         [attr.data-pc-group-section]="'navigator'"
@@ -206,6 +207,7 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                         (keydown)="onContainerButtonKeydown($event)"
                                         [class]="cx('selectYear')"
                                         [attr.disabled]="switchViewButtonDisabled() ? '' : undefined"
+                                        [attr.aria-label]="getTranslation('chooseYear')"
                                         pRipple
                                         [pBind]="ptm('selectYear')"
                                         [attr.data-pc-group-section]="'navigator'"


### PR DESCRIPTION
fixes: #26

This PR fixes an accessibility issue in Autocomplete clear icon rendering.
aria-hidden="true" was applied to clear icon elements that also handle click behavior and may wrap custom clearicon template content, which can include focusable descendants and trigger aria-hidden-focus violations.

> Migrated from `primefaces/primeng#19578` — originally by `@fkwq34` on 2026-05-13

---
*Original base: `master` @ `6da50ba`, head: `wcag-issue` @ `63c5c1f`*