### PR TITLE
fix(breadcrumb): add aria-current to current item

### DIFF
--- a/packages/primeng/src/breadcrumb/breadcrumb.spec.ts
+++ b/packages/primeng/src/breadcrumb/breadcrumb.spec.ts
@@ -872,6 +872,37 @@ describe('Breadcrumb', () => {
             expect(breadcrumbInstance.home?.tooltipOptions?.tooltipLabel).toBe('Home tooltip');
             expect(breadcrumbInstance.model?.[0]?.tooltipOptions?.tooltipLabel).toBe('Item tooltip');
         });
+
+        it('should set aria-current on the last non-router item', async () => {
+            component.model = [
+                { label: 'Products', url: '/products' },
+                { label: 'Category', url: '/products/category' }
+            ];
+            fixture.changeDetectorRef.markForCheck();
+
+            await fixture.whenStable();
+
+            fixture.detectChanges();
+
+            const itemLinks = fixture.debugElement.queryAll(By.css('[data-pc-section="item"] a'));
+
+            expect(itemLinks[0].nativeElement.getAttribute('aria-current')).toBeNull();
+            expect(itemLinks[1].nativeElement.getAttribute('aria-current')).toBe('page');
+        });
+
+        it('should set aria-current on the active last router item', async () => {
+            const routerFixture = TestBed.createComponent(TestRouterBreadcrumbComponent);
+
+            await router.navigateByUrl('/products/category');
+            routerFixture.detectChanges();
+            await routerFixture.whenStable();
+            routerFixture.detectChanges();
+
+            const itemLinks = routerFixture.debugElement.queryAll(By.css('[data-pc-section="item"] a'));
+
+            expect(itemLinks[0].nativeElement.getAttribute('aria-current')).toBeNull();
+            expect(itemLinks[1].nativeElement.getAttribute('aria-current')).toBe('page');
+        });
     });
 
     describe('Edge Cases', () => {

--- a/packages/primeng/src/breadcrumb/breadcrumb.ts
+++ b/packages/primeng/src/breadcrumb/breadcrumb.ts
@@ -108,6 +108,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                                 [attr.title]="menuitem?.title"
                                 [attr.tabindex]="menuitem?.disabled ? null : menuitem?.tabindex || '0'"
                                 [attr.data-automationid]="menuitem?.automationId"
+                                [attr.aria-current]="end ? 'page' : undefined"
                                 [pBind]="getPTOptions(menuitem, i, 'itemLink')"
                             >
                                 <ng-container *ngIf="!itemTemplate && !_itemTemplate">
@@ -129,6 +130,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                                 routerLinkActive="p-menuitem-link-active"
                                 [queryParams]="menuitem?.queryParams"
                                 [routerLinkActiveOptions]="menuitem?.routerLinkActiveOptions || { exact: false }"
+                                [ariaCurrentWhenActive]="end ? 'page' : undefined"
                                 [class]="cn(cx('itemLink'), menuitem?.linkClass)"
                                 [ngStyle]="menuitem?.linkStyle"
                                 (click)="onClick($event, menuitem)"


### PR DESCRIPTION
Breadcrumb items did not expose aria-current for the current page, despite the accessibility documentation stating that the current route is represented with aria-current="page".

Added aria-current handling for the last breadcrumb item, including router-linked items via ariaCurrentWhenActive.

Fixes primefaces/primeng#19523

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

> Migrated from `primefaces/primeng#19570` — originally by `@manichandra` on 2026-05-10

---
*Original base: `master` @ `3e0fa46`, head: `fix/19523-breadcrumb-aria-current` @ `40df7bf`*