### PR TITLE
fix(breadcrumb): add nav landmark label inputs

### DIFF
--- a/packages/primeng/src/breadcrumb/breadcrumb.spec.ts
+++ b/packages/primeng/src/breadcrumb/breadcrumb.spec.ts
@@ -10,7 +10,7 @@ import { Breadcrumb } from './breadcrumb';
 
 @Component({
     standalone: false,
-    template: ` <p-breadcrumb [model]="model" [home]="home" [style]="style" [styleClass]="styleClass" [homeAriaLabel]="homeAriaLabel" (onItemClick)="onItemClick($event)"> </p-breadcrumb> `
+    template: ` <p-breadcrumb [model]="model" [home]="home" [style]="style" [styleClass]="styleClass" [homeAriaLabel]="homeAriaLabel" [ariaLabel]="ariaLabel" [ariaLabelledBy]="ariaLabelledBy" (onItemClick)="onItemClick($event)"> </p-breadcrumb> `
 })
 class TestBasicBreadcrumbComponent {
     model: MenuItem[] | undefined = [
@@ -22,6 +22,8 @@ class TestBasicBreadcrumbComponent {
     style: { [key: string]: any } | undefined;
     styleClass: string | undefined;
     homeAriaLabel: string | undefined = 'Home';
+    ariaLabel: string | undefined;
+    ariaLabelledBy: string | undefined;
     clickedItem: BreadcrumbItemClickEvent | undefined;
 
     onItemClick(event: BreadcrumbItemClickEvent) {
@@ -231,6 +233,8 @@ describe('Breadcrumb', () => {
             expect(freshBreadcrumb.style).toBeUndefined();
             expect(freshBreadcrumb.styleClass).toBeUndefined();
             expect(freshBreadcrumb.homeAriaLabel).toBeUndefined();
+            expect(freshBreadcrumb.ariaLabel).toBeUndefined();
+            expect(freshBreadcrumb.ariaLabelledBy).toBeUndefined();
         });
 
         it('should accept custom values', async () => {
@@ -241,6 +245,8 @@ describe('Breadcrumb', () => {
             component.home = testHome;
             component.styleClass = 'custom-class';
             component.homeAriaLabel = 'Custom Home';
+            component.ariaLabel = 'Main breadcrumb';
+            component.ariaLabelledBy = 'breadcrumb-heading';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
@@ -249,6 +255,8 @@ describe('Breadcrumb', () => {
             expect(breadcrumbInstance.home).toBe(testHome);
             expect(breadcrumbInstance.styleClass).toBe('custom-class');
             expect(breadcrumbInstance.homeAriaLabel).toBe('Custom Home');
+            expect(breadcrumbInstance.ariaLabel).toBe('Main breadcrumb');
+            expect(breadcrumbInstance.ariaLabelledBy).toBe('breadcrumb-heading');
         });
 
         it('should initialize templates properties', () => {
@@ -309,12 +317,34 @@ describe('Breadcrumb', () => {
             expect(breadcrumbInstance.homeAriaLabel).toBe('Go to home page');
         });
 
+        it('should bind aria label to the navigation landmark', async () => {
+            component.ariaLabel = 'Primary breadcrumb';
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const nav = fixture.debugElement.query(By.css('nav'));
+            expect(nav.nativeElement.getAttribute('aria-label')).toBe('Primary breadcrumb');
+        });
+
+        it('should bind aria labelledby to the navigation landmark', async () => {
+            component.ariaLabelledBy = 'breadcrumb-title';
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const nav = fixture.debugElement.query(By.css('nav'));
+            expect(nav.nativeElement.getAttribute('aria-labelledby')).toBe('breadcrumb-title');
+        });
+
         it('should handle undefined inputs', async () => {
             component.model = undefined as any;
             component.home = undefined as any;
             component.style = undefined as any;
             component.styleClass = undefined as any;
             component.homeAriaLabel = undefined as any;
+            component.ariaLabel = undefined as any;
+            component.ariaLabelledBy = undefined as any;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
@@ -324,6 +354,8 @@ describe('Breadcrumb', () => {
             expect(breadcrumbInstance.style).toBeUndefined();
             expect(breadcrumbInstance.styleClass).toBeUndefined();
             expect(breadcrumbInstance.homeAriaLabel).toBeUndefined();
+            expect(breadcrumbInstance.ariaLabel).toBeUndefined();
+            expect(breadcrumbInstance.ariaLabelledBy).toBeUndefined();
         });
     });
 

--- a/packages/primeng/src/breadcrumb/breadcrumb.ts
+++ b/packages/primeng/src/breadcrumb/breadcrumb.ts
@@ -21,7 +21,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
     standalone: true,
     imports: [CommonModule, RouterModule, RouterLink, RouterLinkActive, TooltipModule, ChevronRightIcon, HomeIcon, SharedModule, Bind, Badge],
     template: `
-        <nav [pBind]="ptm('root')" [class]="cn(cx('root'), styleClass)" [style]="style">
+        <nav [pBind]="ptm('root')" [class]="cn(cx('root'), styleClass)" [style]="style" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy">
             <ol [class]="cx('list')" [pBind]="ptm('list')">
                 <li [attr.id]="home.id" [class]="cn(cx('homeItem'), home.styleClass)" [ngStyle]="home.style" *ngIf="home && home.visible !== false" pTooltip [tooltipOptions]="home.tooltipOptions" [pBind]="ptm('homeItem')" [unstyled]="unstyled()">
                     @if (itemTemplate || _itemTemplate) {
@@ -199,6 +199,16 @@ export class Breadcrumb extends BaseComponent<BreadcrumbPassThrough> {
      * @group Props
      */
     @Input() homeAriaLabel: string | undefined;
+    /**
+     * Defines a string value that labels the navigation landmark for accessibility.
+     * @group Props
+     */
+    @Input() ariaLabel: string | undefined;
+    /**
+     * Identifier of the element that labels the navigation landmark for accessibility.
+     * @group Props
+     */
+    @Input() ariaLabelledBy: string | undefined;
     /**
      * Fired when an item is selected.
      * @param {BreadcrumbItemClickEvent} event - custom click event.


### PR DESCRIPTION
Breadcrumb root nav elements could not be labelled, causing axe-core landmark-unique violations when multiple Breadcrumb components are used on the same page. Added ariaLabel and ariaLabelledBy inputs to bind accessible labels to the root nav landmark, matching existing PrimeNG accessibility patterns used by other navigation components.

Fixes primefaces/primeng#19527

Verification:
ng test primeng --watch=false --browsers=ChromeHeadless --include='**/breadcrumb.spec.ts'

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

> Migrated from `primefaces/primeng#19569` — originally by `@manichandra` on 2026-05-10

---
*Original base: `master` @ `3e0fa46`, head: `fix/19527-breadcrumb-nav-aria-label` @ `6dcce29`*