### PR TITLE
fix(breadcrumb): hide separator list items from accessibility tree

### DIFF
--- a/packages/primeng/src/breadcrumb/breadcrumb.ts
+++ b/packages/primeng/src/breadcrumb/breadcrumb.ts
@@ -80,7 +80,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                         </a>
                     }
                 </li>
-                <li *ngIf="model && home" [class]="cx('separator')" [pBind]="ptm('separator')">
+                <li *ngIf="model && home" [class]="cx('separator')" [pBind]="ptm('separator')" aria-hidden="true">
                     <svg data-p-icon="chevron-right" *ngIf="!separatorTemplate && !_separatorTemplate" [pBind]="ptm('separatorIcon')" />
                     <ng-template *ngTemplateOutlet="separatorTemplate || _separatorTemplate"></ng-template>
                 </li>
@@ -157,7 +157,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                             </a>
                         }
                     </li>
-                    <li *ngIf="!end && menuitem.visible !== false" [class]="cx('separator')" [pBind]="ptm('separator')">
+                    <li *ngIf="!end && menuitem.visible !== false" [class]="cx('separator')" [pBind]="ptm('separator')" aria-hidden="true">
                         <svg data-p-icon="chevron-right" *ngIf="!separatorTemplate && !_separatorTemplate" [pBind]="ptm('separatorIcon')" />
                         <ng-template *ngTemplateOutlet="separatorTemplate || _separatorTemplate"></ng-template>
                     </li>


### PR DESCRIPTION
Separator <li> elements (chevron icons) were exposed in the accessibility tree, causing screen readers to announce decorative separators between breadcrumb items. Added aria-hidden="true" to both separator elements — the one following the home item and the one between each menu item.

Fixes #57
Relates to #13437

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

> Migrated from `primefaces/primeng#19568` — originally by `@manichandra` on 2026-05-10

---
*Original base: `master` @ `3e0fa46`, head: `fix/breadcrumb-separator-aria-hidden` @ `4c28b96`*