### PR TITLE
fix(datepicker): prevent redundant date boundary rebuilds

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.spec.ts
+++ b/packages/primeng/src/datepicker/datepicker.spec.ts
@@ -135,6 +135,21 @@ class TestDatePickerComponent {
 
 @Component({
     standalone: false,
+    template: ` <p-datepicker [(ngModel)]="rangeDates" [minDate]="today" [inline]="true" selectionMode="range" [readonlyInput]="true"></p-datepicker> `
+})
+class TestGetterMinDateDatePickerComponent {
+    rangeDates: Date[] | null = null as any;
+
+    get today(): Date {
+        const date = new Date(2026, 4, 4);
+        date.setHours(0, 0, 0, 0);
+
+        return date;
+    }
+}
+
+@Component({
+    standalone: false,
     template: `
         <form [formGroup]="form">
             <p-datepicker formControlName="date" [dateFormat]="'dd/mm/yy'" [placeholder]="'Select date'"></p-datepicker>
@@ -361,7 +376,7 @@ describe('DatePicker', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [DatePicker, FormsModule, ReactiveFormsModule, CommonModule],
-            declarations: [TestDatePickerComponent, TestReactiveFormDatePickerComponent, TestTemplatesDatePickerComponent, TestPTemplatesDatePickerComponent, TestRefTemplatesDatePickerComponent],
+            declarations: [TestDatePickerComponent, TestGetterMinDateDatePickerComponent, TestReactiveFormDatePickerComponent, TestTemplatesDatePickerComponent, TestPTemplatesDatePickerComponent, TestRefTemplatesDatePickerComponent],
             providers: [provideZonelessChangeDetection()]
         }).compileComponents();
 
@@ -627,6 +642,24 @@ describe('DatePicker', () => {
 
             const datePickerComponent = testFixture.debugElement.query(By.css('p-datepicker')).componentInstance;
             expect(datePickerComponent.minDate).toEqual(minDate);
+        });
+
+        it('should not recreate months when minDate getter returns equivalent dates', async () => {
+            const getterFixture = TestBed.createComponent(TestGetterMinDateDatePickerComponent);
+            getterFixture.changeDetectorRef.markForCheck();
+            await getterFixture.whenStable();
+
+            const datePickerComponent = getterFixture.debugElement.query(By.css('p-datepicker')).componentInstance;
+            const nextButton = getterFixture.nativeElement.querySelector('.p-datepicker-next-button');
+            const createMonthsSpy = spyOn(datePickerComponent, 'createMonths').and.callThrough();
+
+            expect(nextButton).toBeTruthy();
+
+            getterFixture.changeDetectorRef.markForCheck();
+            await getterFixture.whenStable();
+
+            expect(createMonthsSpy).not.toHaveBeenCalled();
+            expect(getterFixture.nativeElement.querySelector('.p-datepicker-next-button')).toBe(nextButton);
         });
 
         it('should handle maxDate restriction', async () => {

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -810,9 +810,10 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         return this._minDate;
     }
     set minDate(date: Date | undefined | null) {
+        const dateChanged = !this.isSameDate(this._minDate, date);
         this._minDate = date;
 
-        if (this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
+        if (dateChanged && this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
             this.createMonths(this.currentMonth, this.currentYear);
         }
     }
@@ -824,9 +825,10 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         return this._maxDate;
     }
     set maxDate(date: Date | undefined | null) {
+        const dateChanged = !this.isSameDate(this._maxDate, date);
         this._maxDate = date;
 
-        if (this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
+        if (dateChanged && this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
             this.createMonths(this.currentMonth, this.currentYear);
         }
     }
@@ -3119,6 +3121,10 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
 
     isValidDate(date: any) {
         return isDate(date) && isNotEmpty(date);
+    }
+
+    isSameDate(date: Date | undefined | null, comparedDate: Date | undefined | null): boolean {
+        return date === comparedDate || (!!date && !!comparedDate && Object.is(date.getTime(), comparedDate.getTime()));
     }
 
     updateUI() {


### PR DESCRIPTION
DatePicker rebuilt its month model whenever minDate or maxDate received a new Date object, even when the timestamp was unchanged.

Getter-backed bindings such as [minDate]="today" can create a fresh Date during every change detection pass. In inline desktop mode that DOM churn can replace the month navigation button between pointer events and prevent the arrow click from navigating.

Compare previous and incoming date bounds by timestamp before recreating months, while preserving rebuilds for real minDate and maxDate changes.

Add regression coverage for inline range DatePicker with a getter-backed minDate to verify equivalent date inputs do not recreate months or replace the next navigation button.

Fixes primefaces/primeng#19562

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

> Migrated from `primefaces/primeng#19564` — originally by `@OlimjonovOtabek` on 2026-05-04

---
*Original base: `master` @ `3e0fa46`, head: `fix-datepicker-min-date-navigation` @ `85e2d7b`*