### PR TITLE
fix: BlockUI content was displayed by default

### DIFF
--- a/packages/primeng/src/blockui/blockui.ts
+++ b/packages/primeng/src/blockui/blockui.ts
@@ -27,7 +27,8 @@ const BLOCKUI_INSTANCE = new InjectionToken<BlockUI>('BLOCKUI_INSTANCE');
     providers: [BlockUiStyle, { provide: BLOCKUI_INSTANCE, useExisting: BlockUI }, { provide: PARENT_INSTANCE, useExisting: BlockUI }],
     host: {
         '[attr.aria-busy]': 'blocked',
-        '[class]': "cn(cx('root'), styleClass)"
+        '[class]': "cn(cx('root'), styleClass)",
+        style: 'display: none'
     },
     hostDirectives: [Bind]
 })


### PR DESCRIPTION
Fix #37

> Migrated from `primefaces/primeng#19552` — originally by `@akasaka-oc` on 2026-04-28

---
*Original base: `master` @ `451ca15`, head: `feature/fix-blockui-content-visibility` @ `a42096e`*