### PR TITLE
fix(select): stabilize lazy virtual scroll at bottom

### DIFF
--- a/packages/primeng/src/scroller/scroller.spec.ts
+++ b/packages/primeng/src/scroller/scroller.spec.ts
@@ -1114,6 +1114,42 @@ describe('Scroller', () => {
             expect(scroller.onScrollChange).toHaveBeenCalled();
         });
 
+        it('should not show delayed loader when lazy page remains unchanged at the end', async () => {
+            component.items = Array.from({ length: 10000 }, (_, index) => index);
+            component.itemSize = 32;
+            component.scrollHeight = '200px';
+            component.lazy = true;
+            component.step = 200;
+            component.delay = 250;
+            component.showLoader = true;
+            component.appendOnly = false;
+
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            scroller._items = component.items;
+            scroller._itemSize = 32;
+            scroller._lazy = true;
+            scroller._step = 200;
+            scroller._delay = 250;
+            scroller._showLoader = true;
+            scroller._appendOnly = false;
+            scroller.numItemsInViewport = 7;
+            scroller.d_numToleratedItems = 4;
+            scroller.first = 9795;
+            scroller.last = 9820;
+            scroller.lastScrollPos = 9795 * 32;
+            scroller.lazyLoadState = { first: 9800, last: 10000 };
+
+            const mockEvent = { target: { scrollTop: 10000 * 32 - 200, scrollLeft: 0 } } as unknown as Event;
+
+            scroller.onContainerScroll(mockEvent);
+            expect(scroller.d_loading).toBeFalse();
+
+            clearTimeout(scroller.scrollTimeout);
+        });
+
         it('should handle events through options', async () => {
             const mockOnScroll = jasmine.createSpy('onScroll');
             component.options = { onScroll: mockOnScroll };

--- a/packages/primeng/src/scroller/scroller.spec.ts
+++ b/packages/primeng/src/scroller/scroller.spec.ts
@@ -662,7 +662,7 @@ describe('Scroller', () => {
             expect(scroller.loadedItems).toEqual(testItems.slice(0, 3));
         });
 
-        it('should return empty array when items are null or loading', async () => {
+        it('should return empty array when items are null or non-lazy loading', async () => {
             component.items = null as any;
 
             fixture.changeDetectorRef.markForCheck();
@@ -676,6 +676,26 @@ describe('Scroller', () => {
             await fixture.whenStable();
             fixture.detectChanges();
             expect(scroller.loadedItems).toEqual([]);
+        });
+
+        it('should keep loadedItems while lazy loading with built-in loader', async () => {
+            const testItems = [{ label: 'Item 1' }, { label: 'Item 2' }, { label: 'Item 3' }, { label: 'Item 4' }];
+            component.items = testItems;
+            component.lazy = true;
+            component.showLoader = true;
+
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            scroller.first = 1;
+            scroller.last = 3;
+            scroller.d_loading = true;
+            scroller._lazy = true;
+            scroller._showLoader = true;
+            scroller._loaderDisabled = false;
+
+            expect(scroller.loadedItems).toEqual(testItems.slice(1, 3));
         });
 
         it('should compute loadedRows correctly', async () => {
@@ -1141,6 +1161,43 @@ describe('Scroller', () => {
             scroller.last = 9820;
             scroller.lastScrollPos = 9795 * 32;
             scroller.lazyLoadState = { first: 9800, last: 10000 };
+
+            const mockEvent = { target: { scrollTop: 10000 * 32 - 200, scrollLeft: 0 } } as unknown as Event;
+
+            scroller.onContainerScroll(mockEvent);
+            expect(scroller.d_loading).toBeFalse();
+
+            clearTimeout(scroller.scrollTimeout);
+        });
+
+        it('should not set internal delayed loader when loading is controlled', async () => {
+            component.items = Array.from({ length: 10000 }, (_, index) => index);
+            component.itemSize = 32;
+            component.scrollHeight = '200px';
+            component.lazy = true;
+            component.step = 200;
+            component.delay = 250;
+            component.showLoader = true;
+            component.loading = false;
+
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            scroller._items = component.items;
+            scroller._itemSize = 32;
+            scroller._lazy = true;
+            scroller._step = 200;
+            scroller._delay = 250;
+            scroller._showLoader = true;
+            scroller._loading = false;
+            scroller.d_loading = false;
+            scroller.numItemsInViewport = 7;
+            scroller.d_numToleratedItems = 4;
+            scroller.first = 9600;
+            scroller.last = 9620;
+            scroller.lastScrollPos = 9600 * 32;
+            scroller.lazyLoadState = { first: 9600, last: 9800 };
 
             const mockEvent = { target: { scrollTop: 10000 * 32 - 200, scrollLeft: 0 } } as unknown as Event;
 

--- a/packages/primeng/src/scroller/scroller.spec.ts
+++ b/packages/primeng/src/scroller/scroller.spec.ts
@@ -1092,6 +1092,50 @@ describe('Scroller', () => {
             expect(component.onScroll).toHaveBeenCalledWith({ originalEvent: mockEvent });
         });
 
+        it('should prevent wheel scroll chaining at the vertical boundaries', () => {
+            const preventDefault = jasmine.createSpy('preventDefault');
+            const event = {
+                deltaY: 100,
+                deltaX: 0,
+                currentTarget: {
+                    scrollTop: 800,
+                    clientHeight: 200,
+                    scrollHeight: 1000,
+                    scrollLeft: 0,
+                    clientWidth: 200,
+                    scrollWidth: 200
+                },
+                preventDefault
+            } as unknown as WheelEvent;
+
+            scroller._orientation = 'vertical';
+            scroller.onContainerWheel(event);
+
+            expect(preventDefault).toHaveBeenCalled();
+        });
+
+        it('should allow wheel scrolling inside the current virtual scroller range', () => {
+            const preventDefault = jasmine.createSpy('preventDefault');
+            const event = {
+                deltaY: 100,
+                deltaX: 0,
+                currentTarget: {
+                    scrollTop: 400,
+                    clientHeight: 200,
+                    scrollHeight: 1000,
+                    scrollLeft: 0,
+                    clientWidth: 200,
+                    scrollWidth: 200
+                },
+                preventDefault
+            } as unknown as WheelEvent;
+
+            scroller._orientation = 'vertical';
+            scroller.onContainerWheel(event);
+
+            expect(preventDefault).not.toHaveBeenCalled();
+        });
+
         it('should emit onScrollIndexChange event', async () => {
             spyOn(component, 'onScrollIndexChange');
             spyOn(scroller, 'onScrollPositionChange').and.returnValue({
@@ -1891,6 +1935,13 @@ describe('Scroller', () => {
                 expect(element.style.padding).toBe('10px');
                 expect(element.style.backgroundColor).toBe('lightblue');
             }
+        });
+
+        it('should contain scroll chaining at the root boundary', async () => {
+            const scrollerElement = fixture.debugElement.query(By.css('[data-pc-section="root"]'));
+            const computedStyle = window.getComputedStyle(scrollerElement.nativeElement);
+
+            expect(computedStyle.getPropertyValue('overscroll-behavior-y')).toBe('contain');
         });
 
         it('should apply loading state classes', async () => {

--- a/packages/primeng/src/scroller/scroller.ts
+++ b/packages/primeng/src/scroller/scroller.ts
@@ -542,7 +542,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
     }
 
     get loadedItems() {
-        if (this._items && !this.d_loading) {
+        if (this._items && (!this.d_loading || (this._lazy && !this._loaderDisabled))) {
             if (this.both) {
                 return this._items.slice(this._appendOnly ? 0 : this.first.rows, this.last.rows).map((item) => {
                     if (this._columns) {
@@ -739,7 +739,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
         const itemsLength = (this._items || []).length;
 
         return {
-            first: this._step ? Math.min(page * this._step, itemsLength - this._step) : first,
+            first: this._step ? Math.min(page * this._step, Math.max(0, itemsLength - this._step)) : first,
             last: Math.min(this._step ? (page + 1) * this._step : last, itemsLength)
         };
     }
@@ -1122,11 +1122,13 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
         this.handleEvents('onScroll', { originalEvent: event });
 
         if (this._delay) {
+            const isLoadingControlled = this._loading !== undefined;
+
             if (this.scrollTimeout) {
                 clearTimeout(this.scrollTimeout);
             }
 
-            if (!this.d_loading && this._showLoader) {
+            if (!this.d_loading && this._showLoader && !isLoadingControlled) {
                 const { first, last, isRangeChanged } = this.onScrollPositionChange(event);
                 const changed = this._lazy ? this.isLazyLoadStateChanged(this.getLazyLoadState(first, last)) : isRangeChanged || (this._step ? this.isPageChanged(first) : false);
 
@@ -1140,7 +1142,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
             this.scrollTimeout = setTimeout(() => {
                 this.onScrollChange(event);
 
-                if (this.d_loading && this._showLoader && (!this._lazy || this._loading === undefined)) {
+                if (this.d_loading && this._showLoader && !isLoadingControlled) {
                     this.d_loading = false;
                     this.page = this.getPageByFirst();
                 }

--- a/packages/primeng/src/scroller/scroller.ts
+++ b/packages/primeng/src/scroller/scroller.ts
@@ -734,6 +734,20 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
         return this._step ? this.page !== this.getPageByFirst(first ?? this.first) : true;
     }
 
+    getLazyLoadState(first: any = this.first, last: any = this.last) {
+        const page = this.getPageByFirst(first);
+        const itemsLength = (this._items || []).length;
+
+        return {
+            first: this._step ? Math.min(page * this._step, itemsLength - this._step) : first,
+            last: Math.min(this._step ? (page + 1) * this._step : last, itemsLength)
+        };
+    }
+
+    isLazyLoadStateChanged(lazyLoadState: any) {
+        return this.lazyLoadState.first !== lazyLoadState.first || this.lazyLoadState.last !== lazyLoadState.last;
+    }
+
     scrollTo(options: ScrollToOptions) {
         // this.lastScrollPos = this.both ? { top: 0, left: 0 } : 0;
         this.elementViewChild?.nativeElement?.scrollTo(options);
@@ -1093,15 +1107,13 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
 
             this.handleEvents('onScrollIndexChange', newState);
 
-            if (this._lazy && this.isPageChanged(first)) {
-                const lazyLoadState = {
-                    first: this._step ? Math.min(this.getPageByFirst(first) * this._step, (<any[]>this._items).length - this._step) : first,
-                    last: Math.min(this._step ? (this.getPageByFirst(first) + 1) * this._step : last, (<any[]>this._items).length)
-                };
-                const isLazyStateChanged = this.lazyLoadState.first !== lazyLoadState.first || this.lazyLoadState.last !== lazyLoadState.last;
+            if (this._lazy) {
+                const lazyLoadState = this.getLazyLoadState(first, last);
 
-                isLazyStateChanged && this.handleEvents('onLazyLoad', lazyLoadState);
-                this.lazyLoadState = lazyLoadState;
+                if (this.isLazyLoadStateChanged(lazyLoadState)) {
+                    this.handleEvents('onLazyLoad', lazyLoadState);
+                    this.lazyLoadState = lazyLoadState;
+                }
             }
         }
     }
@@ -1115,8 +1127,8 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
             }
 
             if (!this.d_loading && this._showLoader) {
-                const { isRangeChanged } = this.onScrollPositionChange(event);
-                const changed = isRangeChanged || (this._step ? this.isPageChanged() : false);
+                const { first, last, isRangeChanged } = this.onScrollPositionChange(event);
+                const changed = this._lazy ? this.isLazyLoadStateChanged(this.getLazyLoadState(first, last)) : isRangeChanged || (this._step ? this.isPageChanged(first) : false);
 
                 if (changed) {
                     this.d_loading = true;

--- a/packages/primeng/src/scroller/scroller.ts
+++ b/packages/primeng/src/scroller/scroller.ts
@@ -50,7 +50,7 @@ const SCROLLER_INSTANCE = new InjectionToken<Scroller>('SCROLLER_INSTANCE');
     standalone: true,
     template: `
         <ng-container *ngIf="!_disabled; else disabledContainer">
-            <div #element [attr.id]="_id" [attr.tabindex]="tabindex" [ngStyle]="_style" [class]="cn(cx('root'), styleClass)" (scroll)="onContainerScroll($event)" [pBind]="ptm('root')">
+            <div #element [attr.id]="_id" [attr.tabindex]="tabindex" [ngStyle]="_style" [class]="cn(cx('root'), styleClass)" (scroll)="onContainerScroll($event)" (wheel)="onContainerWheel($event)" [pBind]="ptm('root')">
                 <ng-container *ngIf="contentTemplate || _contentTemplate; else buildInContent">
                     <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: loadedItems, options: getContentOptions() }"></ng-container>
                 </ng-container>
@@ -1151,6 +1151,29 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
         } else {
             !this.d_loading && this.onScrollChange(event);
         }
+    }
+
+    onContainerWheel(event: WheelEvent) {
+        const element = event.currentTarget as HTMLElement;
+
+        if (!element) {
+            return;
+        }
+
+        const isVerticalBoundary = (this.vertical || this.both) && this.isScrollBoundary(event.deltaY, element.scrollTop, element.clientHeight, element.scrollHeight);
+        const isHorizontalBoundary = (this.horizontal || this.both) && this.isScrollBoundary(event.deltaX, element.scrollLeft, element.clientWidth, element.scrollWidth);
+
+        if (isVerticalBoundary || isHorizontalBoundary) {
+            event.preventDefault();
+        }
+    }
+
+    isScrollBoundary(delta: number, scrollPos: number, clientSize: number, scrollSize: number) {
+        if (!delta || scrollSize <= clientSize) {
+            return false;
+        }
+
+        return delta < 0 ? scrollPos <= 0 : scrollSize - clientSize - scrollPos <= 1;
     }
 
     bindResizeListener() {

--- a/packages/primeng/src/scroller/style/scrollerstyle.ts
+++ b/packages/primeng/src/scroller/style/scrollerstyle.ts
@@ -5,6 +5,7 @@ const css = /*css*/ `
 .p-virtualscroller {
     position: relative;
     overflow: auto;
+    overscroll-behavior: contain;
     contain: strict;
     transform: translateZ(0);
     will-change: scroll-position;

--- a/packages/primeng/src/select/select.spec.ts
+++ b/packages/primeng/src/select/select.spec.ts
@@ -2711,7 +2711,20 @@ describe('Select ViewChild Properties', () => {
         await viewChildFixture.whenStable();
         viewChildFixture.detectChanges();
 
-        expect(virtualSelect.scroller?.scrollHeight).toBe(virtualSelect.scrollHeight);
+        expect(virtualSelect.scroller?.scrollHeight).toBe('200px');
+    });
+
+    it('should open virtual scroll overlay when clicked with numeric scrollHeight', async () => {
+        const virtualSelectElement = viewChildFixture.debugElement.query(By.css('p-select[placeholder="Virtual scroll select"]'));
+        const virtualSelect = virtualSelectElement.componentInstance;
+
+        virtualSelectElement.nativeElement.click();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await viewChildFixture.whenStable();
+        viewChildFixture.detectChanges();
+
+        expect(virtualSelect.overlayVisible).toBe(true);
+        expect(virtualSelect.scroller?.scrollHeight).toBe('200px');
     });
 
     it('should render hidden focusable elements ViewChild', async () => {

--- a/packages/primeng/src/select/select.spec.ts
+++ b/packages/primeng/src/select/select.spec.ts
@@ -2703,6 +2703,17 @@ describe('Select ViewChild Properties', () => {
         }
     });
 
+    it('should pass scrollHeight to the virtual scroller', async () => {
+        const virtualSelect = viewChildFixture.debugElement.query(By.css('p-select[placeholder="Virtual scroll select"]')).componentInstance;
+
+        virtualSelect.show();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await viewChildFixture.whenStable();
+        viewChildFixture.detectChanges();
+
+        expect(virtualSelect.scroller?.scrollHeight).toBe(virtualSelect.scrollHeight);
+    });
+
     it('should render hidden focusable elements ViewChild', async () => {
         const selectInstance = viewChildFixture.debugElement.query(By.css('p-select[placeholder="ViewChild test select"]')).componentInstance;
 

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -331,14 +331,14 @@ export class SelectItem extends BaseComponent {
                             </p-iconfield>
                         </ng-template>
                     </div>
-                    <div [class]="cx('listContainer')" [style.max-height]="virtualScroll ? 'auto' : scrollHeight || 'auto'" [pBind]="ptm('listContainer')">
+                    <div [class]="cx('listContainer')" [style.max-height]="virtualScroll ? 'auto' : normalizedScrollHeight || 'auto'" [pBind]="ptm('listContainer')">
                         <p-scroller
                             *ngIf="virtualScroll"
                             hostName="select"
                             #scroller
                             [items]="visibleOptions()"
-                            [style]="{ height: scrollHeight }"
-                            [scrollHeight]="scrollHeight"
+                            [style]="{ height: normalizedScrollHeight }"
+                            [scrollHeight]="normalizedScrollHeight"
                             [itemSize]="virtualScrollItemSize"
                             [autoSize]="true"
                             [lazy]="lazy"
@@ -445,6 +445,11 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
      * @group Props
      */
     @Input() scrollHeight: string = '200px';
+
+    get normalizedScrollHeight() {
+        return typeof this.scrollHeight === 'number' ? `${this.scrollHeight}px` : this.scrollHeight;
+    }
+
     /**
      * When specified, displays an input field to filter the items on keyup.
      * @group Props

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -338,6 +338,7 @@ export class SelectItem extends BaseComponent {
                             #scroller
                             [items]="visibleOptions()"
                             [style]="{ height: scrollHeight }"
+                            [scrollHeight]="scrollHeight"
                             [itemSize]="virtualScrollItemSize"
                             [autoSize]="true"
                             [lazy]="lazy"


### PR DESCRIPTION
Fixes #39

### Summary
- Stabilize Select lazy virtual scroll behavior when scrolling to the end of the overlay.
- Avoid repeated lazy-load handling for unchanged bottom ranges and keep loaded lazy items rendered while the built-in loader is active.
- Pass the normalized Select scroll height through to Scroller.
- Contain Scroller boundary wheel scrolling so the page does not scroll behind an open overlay.

### Validation
- `pnpm run test:unit`
  - Passed with `TOTAL: 7213 SUCCESS`.
  - The run still logs the existing Jasmine HTML reporter after-suite `appendChild` error, but exits with code 0.
- `git diff --check`
- Browser/CDP validation against the local Select Lazy Virtual Scroll showcase:
  - scrolled to the bottom of the dropdown
  - final items `Item #9990` through `Item #9999` remained visible
  - loader was hidden after data arrived
  - overlay stayed in viewport
  - page scroll did not move behind the overlay
  - no duplicate lazy-load ranges were emitted for the same range

### Notes
- No dependency changes.
- No public API symbols were renamed or removed.

> Migrated from `primefaces/primeng#19550` — originally by `@OlimjonovOtabek` on 2026-04-27

---
*Original base: `master` @ `451ca15`, head: `fix/select-lazy-scroll-bottom` @ `c5d58e3`*