### PR TITLE
fix(menu): avoid rerendering stable menu items

### DIFF
--- a/packages/primeng/src/menu/menu.spec.ts
+++ b/packages/primeng/src/menu/menu.spec.ts
@@ -1065,6 +1065,68 @@ describe('Menu', () => {
 
             expect(dynamicMenu.model.length).toBe(0);
         });
+
+        it('should reuse flat menu item elements when model items are recomputed', async () => {
+            const dynamicFixture = TestBed.createComponent(TestDynamicMenuComponent);
+            const dynamicComponent = dynamicFixture.componentInstance;
+            dynamicComponent.dynamicModel = [{ label: 'Item 1', icon: 'pi pi-test' }];
+            dynamicFixture.detectChanges();
+            await dynamicFixture.whenStable();
+
+            const itemElement = dynamicFixture.nativeElement.querySelector('li[data-pc-section="item"]') as HTMLElement;
+
+            expect(itemElement).toBeTruthy();
+            expect(itemElement.textContent).toContain('Item 1');
+
+            dynamicComponent.dynamicModel = [{ label: 'Item 1 updated', icon: 'pi pi-test' }];
+            dynamicFixture.changeDetectorRef.markForCheck();
+            dynamicFixture.detectChanges();
+            await dynamicFixture.whenStable();
+
+            const updatedItemElement = dynamicFixture.nativeElement.querySelector('li[data-pc-section="item"]') as HTMLElement;
+
+            expect(updatedItemElement).toBe(itemElement);
+            expect(updatedItemElement.textContent).toContain('Item 1 updated');
+        });
+
+        it('should reuse grouped menu item elements when submenu items are recomputed', async () => {
+            const submenuFixture = TestBed.createComponent(TestSubmenuMenuComponent);
+            const submenuComponent = submenuFixture.componentInstance;
+            submenuComponent.submenuModel = [
+                {
+                    label: 'Group',
+                    items: [
+                        { label: 'Item 1', icon: 'pi pi-test' },
+                        { label: 'Item 2', icon: 'pi pi-test2' }
+                    ]
+                }
+            ];
+            submenuFixture.detectChanges();
+            await submenuFixture.whenStable();
+
+            const itemElement = submenuFixture.nativeElement.querySelector('li[data-pc-section="item"]') as HTMLElement;
+
+            expect(itemElement).toBeTruthy();
+            expect(itemElement.textContent).toContain('Item 1');
+
+            submenuComponent.submenuModel = [
+                {
+                    label: 'Group',
+                    items: [
+                        { label: 'Item 1 updated', icon: 'pi pi-test' },
+                        { label: 'Item 2', icon: 'pi pi-test2' }
+                    ]
+                }
+            ];
+            submenuFixture.changeDetectorRef.markForCheck();
+            submenuFixture.detectChanges();
+            await submenuFixture.whenStable();
+
+            const updatedItemElement = submenuFixture.nativeElement.querySelector('li[data-pc-section="item"]') as HTMLElement;
+
+            expect(updatedItemElement).toBe(itemElement);
+            expect(updatedItemElement.textContent).toContain('Item 1 updated');
+        });
     });
 
     describe('Popup Menu Tests', () => {

--- a/packages/primeng/src/menu/menu.ts
+++ b/packages/primeng/src/menu/menu.ts
@@ -199,7 +199,7 @@ export class MenuItemContent extends BaseComponent {
                     (blur)="onListBlur($event)"
                     (keydown)="onListKeyDown($event)"
                 >
-                    <ng-template ngFor let-submenu let-i="index" [ngForOf]="model" *ngIf="hasSubMenu()">
+                    <ng-template ngFor let-submenu let-i="index" [ngForOf]="model" [ngForTrackBy]="trackByMenuItem" *ngIf="hasSubMenu()">
                         <li [class]="cx('separator')" [pBind]="ptm('separator')" *ngIf="submenu.separator && submenu.visible !== false" role="separator" [attr.data-pc-section]="'separator'"></li>
                         <li
                             [class]="cx('submenuLabel')"
@@ -219,7 +219,7 @@ export class MenuItemContent extends BaseComponent {
                             </ng-container>
                             <ng-container *ngTemplateOutlet="submenuHeaderTemplate ?? _submenuHeaderTemplate; context: { $implicit: submenu }"></ng-container>
                         </li>
-                        <ng-template ngFor let-item let-j="index" [ngForOf]="submenu.items">
+                        <ng-template ngFor let-item let-j="index" [ngForOf]="submenu.items" [ngForTrackBy]="trackByMenuItem">
                             <li [class]="cx('separator')" [pBind]="ptm('separator')" *ngIf="item.separator && (item.visible !== false || submenu.visible !== false)" role="separator" [attr.data-pc-section]="'separator'"></li>
                             <li
                                 [class]="cn(cx('item', { item, id: menuitemId(item, id, i, j) }), item?.styleClass)"
@@ -244,7 +244,7 @@ export class MenuItemContent extends BaseComponent {
                             ></li>
                         </ng-template>
                     </ng-template>
-                    <ng-template ngFor let-item let-i="index" [ngForOf]="model" *ngIf="!hasSubMenu()">
+                    <ng-template ngFor let-item let-i="index" [ngForOf]="model" [ngForTrackBy]="trackByMenuItem" *ngIf="!hasSubMenu()">
                         <li [class]="cx('separator')" [pBind]="ptm('separator')" *ngIf="item.separator && item.visible !== false" role="separator" [attr.data-pc-section]="'separator'"></li>
                         <li
                             [class]="cn(cx('item', { item, id: menuitemId(item, id, i) }), item?.styleClass)"
@@ -615,6 +615,10 @@ export class Menu extends BaseComponent<MenuPassThrough> {
 
     menuitemId(item: MenuItem, id: string | any, index?: string | number, childIndex?: string | number) {
         return item?.id ?? `${id}_${index}${childIndex !== undefined ? '_' + childIndex : ''}`;
+    }
+
+    trackByMenuItem(index: number, item: MenuItem) {
+        return item?.id ?? index;
     }
 
     isItemFocused(id) {


### PR DESCRIPTION
Fixes #41.

### What changed
- Adds `trackBy` behavior to flat and grouped `p-menu` item rendering.
- Preserves existing generated IDs by using `item.id` when present and falling back to the item index.
- Adds regression coverage that asserts menu item DOM nodes are reused when models are recomputed.

### Testing
- `pnpm exec prettier --check packages/primeng/src/menu/menu.ts packages/primeng/src/menu/menu.spec.ts`
- `pnpm --filter primeng exec ng test primeng --watch=false --browsers=ChromeHeadless --include='**/menu.spec.ts'`

> Migrated from `primefaces/primeng#19549` — originally by `@OlimjonovOtabek` on 2026-04-27

---
*Original base: `master` @ `451ca15`, head: `fix/menu-trackby` @ `bbbd5b7`*