### PR TITLE
fix: mark for change detection when closing the dialog

### DIFF
--- a/packages/primeng/src/dialog/dialog.ts
+++ b/packages/primeng/src/dialog/dialog.ts
@@ -745,6 +745,7 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
     close(event: Event) {
         this.visible = false;
         this.visibleChange.emit(this.visible);
+        this.cd.markForCheck();
         event.preventDefault();
     }
 


### PR DESCRIPTION
When running Angular with Zone change detection, the modal will not close when pressing the escape key because the `onAfterLeave` callback is not triggered. Marking the dialog for change detection will trigger the callback and close the modal

Fixes #43

> Migrated from `primefaces/primeng#19540` — originally by `@mmawhinney` on 2026-04-22

---
*Original base: `master` @ `451ca15`, head: `bug/mark-dialog-for-change-detection-on-close` @ `66b0436`*