### PR TITLE
fix: #19527 - add ariaLabel input to breadcrumb component for accessi…

### DIFF
--- a/packages/primeng/src/breadcrumb/breadcrumb.spec.ts
+++ b/packages/primeng/src/breadcrumb/breadcrumb.spec.ts
@@ -10,7 +10,7 @@ import { Breadcrumb } from './breadcrumb';
 
 @Component({
     standalone: false,
-    template: ` <p-breadcrumb [model]="model" [home]="home" [style]="style" [styleClass]="styleClass" [homeAriaLabel]="homeAriaLabel" (onItemClick)="onItemClick($event)"> </p-breadcrumb> `
+    template: ` <p-breadcrumb [model]="model" [home]="home" [style]="style" [styleClass]="styleClass" [ariaLabel]="ariaLabel" [homeAriaLabel]="homeAriaLabel" (onItemClick)="onItemClick($event)"> </p-breadcrumb> `
 })
 class TestBasicBreadcrumbComponent {
     model: MenuItem[] | undefined = [
@@ -21,6 +21,7 @@ class TestBasicBreadcrumbComponent {
     home: MenuItem | undefined = { icon: 'pi pi-home', routerLink: '/' };
     style: { [key: string]: any } | undefined;
     styleClass: string | undefined;
+    ariaLabel: string | undefined;
     homeAriaLabel: string | undefined = 'Home';
     clickedItem: BreadcrumbItemClickEvent | undefined;
 
@@ -230,6 +231,7 @@ describe('Breadcrumb', () => {
             expect(freshBreadcrumb.home).toBeUndefined();
             expect(freshBreadcrumb.style).toBeUndefined();
             expect(freshBreadcrumb.styleClass).toBeUndefined();
+            expect(freshBreadcrumb.ariaLabel).toBeUndefined();
             expect(freshBreadcrumb.homeAriaLabel).toBeUndefined();
         });
 
@@ -301,6 +303,14 @@ describe('Breadcrumb', () => {
             expect(breadcrumbInstance.styleClass).toBe('test-class');
         });
 
+        it('should update ariaLabel input', async () => {
+            component.ariaLabel = 'Page navigation';
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+            expect(breadcrumbInstance.ariaLabel).toBe('Page navigation');
+        });
+
         it('should update homeAriaLabel input', async () => {
             component.homeAriaLabel = 'Go to home page';
             fixture.changeDetectorRef.markForCheck();
@@ -314,6 +324,7 @@ describe('Breadcrumb', () => {
             component.home = undefined as any;
             component.style = undefined as any;
             component.styleClass = undefined as any;
+            component.ariaLabel = undefined as any;
             component.homeAriaLabel = undefined as any;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
@@ -323,6 +334,7 @@ describe('Breadcrumb', () => {
             expect(breadcrumbInstance.home).toBeUndefined();
             expect(breadcrumbInstance.style).toBeUndefined();
             expect(breadcrumbInstance.styleClass).toBeUndefined();
+            expect(breadcrumbInstance.ariaLabel).toBeUndefined();
             expect(breadcrumbInstance.homeAriaLabel).toBeUndefined();
         });
     });
@@ -808,6 +820,26 @@ describe('Breadcrumb', () => {
     });
 
     describe('Accessibility Tests', () => {
+        it('should apply ariaLabel to the nav element', async () => {
+            component.ariaLabel = 'Breadcrumb';
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const navElement = fixture.debugElement.query(By.css('nav'));
+            expect(navElement.nativeElement.getAttribute('aria-label')).toBe('Breadcrumb');
+        });
+
+        it('should not render aria-label on nav when ariaLabel is undefined', async () => {
+            component.ariaLabel = undefined;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const navElement = fixture.debugElement.query(By.css('nav'));
+            expect(navElement.nativeElement.getAttribute('aria-label')).toBeNull();
+        });
+
         it('should have proper ARIA attributes on home link', async () => {
             component.home = { label: 'Home' };
             component.homeAriaLabel = 'Go to homepage';

--- a/packages/primeng/src/breadcrumb/breadcrumb.ts
+++ b/packages/primeng/src/breadcrumb/breadcrumb.ts
@@ -21,7 +21,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
     standalone: true,
     imports: [CommonModule, RouterModule, RouterLink, RouterLinkActive, TooltipModule, ChevronRightIcon, HomeIcon, SharedModule, Bind, Badge],
     template: `
-        <nav [pBind]="ptm('root')" [class]="cn(cx('root'), styleClass)" [style]="style">
+        <nav [pBind]="ptm('root')" [attr.aria-label]="ariaLabel" [class]="cn(cx('root'), styleClass)" [style]="style">
             <ol [class]="cx('list')" [pBind]="ptm('list')">
                 <li [attr.id]="home.id" [class]="cn(cx('homeItem'), home.styleClass)" [ngStyle]="home.style" *ngIf="home && home.visible !== false" pTooltip [tooltipOptions]="home.tooltipOptions" [pBind]="ptm('homeItem')" [unstyled]="unstyled()">
                     @if (itemTemplate || _itemTemplate) {
@@ -194,6 +194,11 @@ export class Breadcrumb extends BaseComponent<BreadcrumbPassThrough> {
      * @group Props
      */
     @Input() home: MenuItem | undefined;
+    /**
+     * Defines a string that labels the breadcrumb navigation element for accessibility.
+     * @group Props
+     */
+    @Input() ariaLabel: string | undefined;
     /**
      * Defines a string that labels the home icon for accessibility.
      * @group Props


### PR DESCRIPTION
Fixes #51

## Description

The `p-breadcrumb` component's root `<nav>` element had no accessible label, causing axe-core `landmark-unique` violations when multiple breadcrumb instances appear on the same page.

Although the documentation states that `aria-label` can be passed implicitly to the root, this is not currently the case, the attribute is not forwarded to the inner `<nav>`, so consumers have no way to set it without DOM manipulation.

## Changes

- Added an `ariaLabel` input (`string | undefined`) on `p-breadcrumb`, following the same pattern already used in other navigation components such as `p-menu`
- Bound `[attr.aria-label]="ariaLabel"` on the root `<nav>` element
- Updated the component's API documentation
- Added unit tests covering both the DOM attribute binding and the `undefined` default behavior

## Usage

```html
<!-- Single breadcrumb -->
<p-breadcrumb [model]="items" ariaLabel="Breadcrumb" />

<!-- Multiple breadcrumbs on the same page -->
<p-breadcrumb [model]="items1" ariaLabel="Primary navigation" />
<p-breadcrumb [model]="items2" ariaLabel="Secondary navigation" />
```

## Notes

- Default value is `undefined` to preserve current behavior and avoid unexpected changes for existing consumers. Consumers are expected to provide a meaningful label when needed (following the [W3C APG breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/)).
- No breaking changes.

> Migrated from `primefaces/primeng#19538` — originally by `@vitopio-prete` on 2026-04-21

---
*Original base: `master` @ `451ca15`, head: `fix/breadcrumb-aria-label` @ `36bb42a`*