### PR TITLE
fix: #19485 - Table virtualScroll rows not visible with percentage scrollHeight

### DIFF
--- a/packages/primeng/src/table/style/tablestyle.ts
+++ b/packages/primeng/src/table/style/tablestyle.ts
@@ -231,7 +231,8 @@ const classes = {
 
 const inlineStyles = {
     tableContainer: ({ instance }) => ({
-        'max-height': instance.virtualScroll ? '' : instance.scrollHeight,
+        'max-height': instance.virtualScroll ? null : (instance.scrollHeight ?? null),
+        height: instance.virtualScrollViewportHeight,
         overflow: 'auto'
     }),
     thead: { position: 'sticky' },

--- a/packages/primeng/src/table/table.spec.ts
+++ b/packages/primeng/src/table/table.spec.ts
@@ -193,6 +193,91 @@ describe('Table', () => {
 
     @Component({
         standalone: false,
+        selector: 'test-virtual-scroll-percent-height-table',
+        template: `
+            <div style="height: 480px;">
+                <p-table [value]="products" [scrollable]="true" [virtualScroll]="true" [virtualScrollItemSize]="40" [scrollHeight]="'100%'">
+                    <ng-template #header>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                        </tr>
+                    </ng-template>
+                    <ng-template #body let-product>
+                        <tr style="height: 40px">
+                            <td>{{ product.id }}</td>
+                            <td>{{ product.name }}</td>
+                        </tr>
+                    </ng-template>
+                </p-table>
+            </div>
+        `
+    })
+    class TestVirtualScrollPercentHeightTableComponent {
+        products = Array.from({ length: 1000 }, (_, i) => ({
+            id: i + 1,
+            name: `Product ${i + 1}`
+        }));
+    }
+
+    @Component({
+        standalone: false,
+        selector: 'test-scrollable-non-virtual-table',
+        template: `
+            <p-table [value]="products" [scrollable]="true" [scrollHeight]="'400px'">
+                <ng-template #header>
+                    <tr>
+                        <th>ID</th>
+                        <th>Name</th>
+                    </tr>
+                </ng-template>
+                <ng-template #body let-product>
+                    <tr>
+                        <td>{{ product.id }}</td>
+                        <td>{{ product.name }}</td>
+                    </tr>
+                </ng-template>
+            </p-table>
+        `
+    })
+    class TestScrollableNonVirtualTableComponent {
+        products = Array.from({ length: 20 }, (_, i) => ({
+            id: i + 1,
+            name: `Product ${i + 1}`
+        }));
+    }
+
+    @Component({
+        standalone: false,
+        selector: 'test-virtual-scroll-flex-height-table',
+        template: `
+            <div style="height: 480px;">
+                <p-table [value]="products" [scrollable]="true" [virtualScroll]="true" [virtualScrollItemSize]="40" [scrollHeight]="'flex'">
+                    <ng-template #header>
+                        <tr>
+                            <th>ID</th>
+                            <th>Name</th>
+                        </tr>
+                    </ng-template>
+                    <ng-template #body let-product>
+                        <tr style="height: 40px">
+                            <td>{{ product.id }}</td>
+                            <td>{{ product.name }}</td>
+                        </tr>
+                    </ng-template>
+                </p-table>
+            </div>
+        `
+    })
+    class TestVirtualScrollFlexHeightTableComponent {
+        products = Array.from({ length: 1000 }, (_, i) => ({
+            id: i + 1,
+            name: `Product ${i + 1}`
+        }));
+    }
+
+    @Component({
+        standalone: false,
         template: `
             <p-table [value]="products" [lazy]="true" [totalRecords]="totalRecords" [paginator]="true" [rows]="10" (onLazyLoad)="loadProducts($event)">
                 <ng-template #header>
@@ -264,7 +349,19 @@ describe('Table', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [Table, TestBasicTableComponent, TestSelectionTableComponent, TestSortingTableComponent, TestFilteringTableComponent, TestVirtualScrollTableComponent, TestLazyLoadTableComponent, TestTemplatesTableComponent],
+            declarations: [
+                Table,
+                TestBasicTableComponent,
+                TestSelectionTableComponent,
+                TestSortingTableComponent,
+                TestFilteringTableComponent,
+                TestVirtualScrollTableComponent,
+                TestVirtualScrollPercentHeightTableComponent,
+                TestScrollableNonVirtualTableComponent,
+                TestVirtualScrollFlexHeightTableComponent,
+                TestLazyLoadTableComponent,
+                TestTemplatesTableComponent
+            ],
             imports: [CommonModule, FormsModule, TableModule, SharedModule, Select],
             providers: [TableService, provideZonelessChangeDetection()]
         }).compileComponents();
@@ -410,6 +507,55 @@ describe('Table', () => {
 
         it('should handle large datasets efficiently', () => {
             expect(testComponent.products.length).toBe(10000);
+        });
+
+        it('should apply host and container height for virtual scroll with 100% scrollHeight', async () => {
+            const percentHeightFixture = TestBed.createComponent(TestVirtualScrollPercentHeightTableComponent);
+            await percentHeightFixture.whenStable();
+            percentHeightFixture.detectChanges();
+
+            const tableElement = percentHeightFixture.debugElement.query(By.css('p-table')).nativeElement as HTMLElement;
+            const containerElement = percentHeightFixture.nativeElement.querySelector('.p-datatable-table-container') as HTMLElement;
+            const scrollerElement = percentHeightFixture.nativeElement.querySelector('.p-virtualscroller');
+
+            expect(tableElement.style.height).toBe('100%');
+            expect(containerElement.style.height).toBe('100%');
+            expect(scrollerElement).toBeTruthy();
+            expect(scrollerElement.offsetHeight).toBeGreaterThan(0);
+        });
+
+        it('should apply explicit height for virtual scroll with pixel scrollHeight', () => {
+            const tableElement = testFixture.debugElement.query(By.css('p-table')).nativeElement as HTMLElement;
+            const containerElement = testFixture.nativeElement.querySelector('.p-datatable-table-container') as HTMLElement;
+
+            expect(tableElement.style.height).toBe('400px');
+            expect(containerElement.style.height).toBe('400px');
+        });
+
+        it('should not apply host height when virtualScroll is false', async () => {
+            const nonVirtualFixture = TestBed.createComponent(TestScrollableNonVirtualTableComponent);
+            await nonVirtualFixture.whenStable();
+            nonVirtualFixture.detectChanges();
+
+            const tableElement = nonVirtualFixture.debugElement.query(By.css('p-table')).nativeElement as HTMLElement;
+            const containerElement = nonVirtualFixture.nativeElement.querySelector('.p-datatable-table-container') as HTMLElement;
+
+            expect(tableElement.style.height).toBe('');
+            expect(containerElement.style.maxHeight).toBe('400px');
+        });
+
+        it('should keep flex mode on class-based path without inline height', async () => {
+            const flexFixture = TestBed.createComponent(TestVirtualScrollFlexHeightTableComponent);
+            await flexFixture.whenStable();
+            flexFixture.detectChanges();
+
+            const tableElement = flexFixture.debugElement.query(By.css('p-table')).nativeElement as HTMLElement;
+            const containerElement = flexFixture.nativeElement.querySelector('.p-datatable-table-container') as HTMLElement;
+            const rootElement = flexFixture.nativeElement.querySelector('.p-datatable') as HTMLElement;
+
+            expect(tableElement.style.height).toBe('');
+            expect(containerElement.style.height).toBe('');
+            expect(rootElement.classList.contains('p-datatable-flex-scrollable')).toBeTrue();
         });
     });
 

--- a/packages/primeng/src/table/table.spec.ts
+++ b/packages/primeng/src/table/table.spec.ts
@@ -349,19 +349,7 @@ describe('Table', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [
-                Table,
-                TestBasicTableComponent,
-                TestSelectionTableComponent,
-                TestSortingTableComponent,
-                TestFilteringTableComponent,
-                TestVirtualScrollTableComponent,
-                TestVirtualScrollPercentHeightTableComponent,
-                TestScrollableNonVirtualTableComponent,
-                TestVirtualScrollFlexHeightTableComponent,
-                TestLazyLoadTableComponent,
-                TestTemplatesTableComponent
-            ],
+            declarations: [Table, TestBasicTableComponent, TestSelectionTableComponent, TestSortingTableComponent, TestFilteringTableComponent, TestVirtualScrollTableComponent, TestLazyLoadTableComponent, TestTemplatesTableComponent],
             imports: [CommonModule, FormsModule, TableModule, SharedModule, Select],
             providers: [TableService, provideZonelessChangeDetection()]
         }).compileComponents();

--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -358,6 +358,7 @@ export class TableService {
     encapsulation: ViewEncapsulation.None,
     host: {
         '[class]': "cn(cx('root'), styleClass)",
+        '[style.height]': 'virtualScrollViewportHeight',
         '[attr.data-p]': 'dataP'
     },
     hostDirectives: [Bind]
@@ -596,6 +597,11 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
      * @group Props
      */
     @Input() scrollHeight: string | undefined;
+
+    get virtualScrollViewportHeight(): string | null {
+        const height = this.scrollHeight;
+        return this.virtualScroll && height != null && height !== 'flex' ? height : null;
+    }
     /**
      * Whether the data should be loaded on demand during scroll.
      * @group Props


### PR DESCRIPTION
### Description  
This PR fixes a regression in PrimeNG v21 where p-table rows are not visible when virtualScroll is enabled with percentage-based scrollHeight (for example 100%).  
Root cause: the virtual scroller viewport could resolve against an auto-height chain, causing the effective viewport to collapse.

### Fix Summary  
The fix applies height for virtual scroll in two places to ensure a valid sizing chain:
1. Table container inline style in tablestyle.ts now sets height when virtualScroll is enabled and scrollHeight is not flex.
2. Table host binding in table.ts now applies the same conditional height to the host element.
3. Regression test added in table.spec.ts for virtual scroll with scrollHeight set to 100%.

### Reproduction
Change `[virtualScroll]="true"` to `false` and it does render:
https://stackblitz.com/edit/github-qb3dzpr6-92f9fuq6?file=src%2Fapp%2Fapp.component.html

### Testing  
Validated by adding a table unit test for virtualScroll with 100% scrollHeight and verifying the virtual scroller viewport remains visible.  
Manually verified against the provided StackBlitz reproduction behavior.

### Affected Version  
PrimeNG v21

### Checklist  
- [x] Defect fix only (no feature scope)  
- [x] Linked to existing issue #79  
- [x] Added regression test for the reported scenario  
- [x] Verified behavior against provided reproduction

> Migrated from `primefaces/primeng#19536` — originally by `@karoc123` on 2026-04-20

---
*Original base: `master` @ `451ca15`, head: `issue-19485` @ `d647da4`*