### PR TITLE
fix: #19495 - listbox content overflows container when filter or header is present

### DIFF
--- a/packages/primeng/src/listbox/style/listboxstyle.ts
+++ b/packages/primeng/src/listbox/style/listboxstyle.ts
@@ -6,6 +6,11 @@ const style = /*css*/ `
     ${listbox_style}
 
     /* For PrimeNG */
+    .p-listbox {
+        display: flex;
+        flex-direction: column;
+    }
+
     .p-listbox.ng-invalid.ng-dirty {
         border-color: dt('listbox.invalid.border.color');
     }
@@ -13,6 +18,7 @@ const style = /*css*/ `
     .p-listbox-header {
         display: flex;
         align-items: center;
+        flex-shrink: 0;
     }
 
     .p-listbox-header > .p-iconfield {
@@ -20,7 +26,9 @@ const style = /*css*/ `
     }
 
     .p-listbox-list-container {
-        height: 100%;
+        flex: 1 1 auto;
+        overflow: auto;
+        min-height: 0;
     }
 
     /* CDK Drag & Drop styles */


### PR DESCRIPTION
This PR fixes the listbox content overflow issue that occurs when a filter or header is present alongside scrollHeight. The root .p-listbox element now uses a flex column layout so the list container properly fills the remaining space after the header/filter instead of overflowing.

Fixes [#72](https://github.com/primefaces/primeng/issues/72)

> Migrated from `primefaces/primeng#19529` — originally by `@alex1972000` on 2026-04-16

---
*Original base: `master` @ `8fb53b4`, head: `fix/listbox-scroll-overflow` @ `a47fffa`*