### PR TITLE
fix: add draggable property to Confirmation interface

### DIFF
--- a/packages/primeng/src/api/confirmation.ts
+++ b/packages/primeng/src/api/confirmation.ts
@@ -114,4 +114,8 @@ export interface Confirmation {
      * @defaultValue true
      */
     modal?: boolean;
+    /**
+     * Specifies whether the confirmation dialog can be dragged.
+     */
+    draggable?: boolean;
 }


### PR DESCRIPTION
This PR adds the missing `draggable` property to the `Confirmation` interface, allowing users to configure whether the confirmation dialog can be dragged.

Fixes #60

> Migrated from `primefaces/primeng#19517` — originally by `@Deepak8858` on 2026-04-03

---
*Original base: `master` @ `85f00f7`, head: `fix/issue-19516-draggable-confirmation` @ `4c605a6`*