### PR TITLE
Fix tooltip with template lifecycle

### DIFF
--- a/packages/primeng/src/tooltip/tooltip.spec.ts
+++ b/packages/primeng/src/tooltip/tooltip.spec.ts
@@ -514,6 +514,18 @@ describe('Tooltip', () => {
         it('should handle template content', () => {
             expect(tooltipDirective.content).toEqual(component.tooltipTemplate);
         });
+
+        it('should not duplicate template content when rerendering', () => {
+            tooltipDirective.tooltipText = document.createElement('div');
+            tooltipDirective.setOption({ tooltipLabel: component.tooltipTemplate });
+
+            tooltipDirective.updateText();
+            expect(tooltipDirective.tooltipText.querySelectorAll('.custom-tooltip').length).toBe(1);
+
+            tooltipDirective.updateText();
+
+            expect(tooltipDirective.tooltipText.querySelectorAll('.custom-tooltip').length).toBe(1);
+        });
     });
 
     describe('Tooltip Options', () => {
@@ -581,6 +593,17 @@ describe('Tooltip', () => {
             expect(() => {
                 tooltipDirective.remove();
             }).not.toThrow();
+        });
+
+        it('should remove the container mouseleave listener on cleanup', () => {
+            const unlisten = jasmine.createSpy('unlisten');
+
+            tooltipDirective.containerMouseleaveListener = unlisten;
+
+            tooltipDirective.remove();
+
+            expect(unlisten).toHaveBeenCalled();
+            expect(tooltipDirective.containerMouseleaveListener).toBeNull();
         });
 
         it('should handle window resize events', () => {

--- a/packages/primeng/src/tooltip/tooltip.ts
+++ b/packages/primeng/src/tooltip/tooltip.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { booleanAttribute, computed, Directive, effect, ElementRef, inject, InjectionToken, input, Input, NgModule, NgZone, numberAttribute, SimpleChanges, TemplateRef, ViewContainerRef } from '@angular/core';
+import { booleanAttribute, computed, Directive, effect, ElementRef, EmbeddedViewRef, inject, InjectionToken, input, Input, NgModule, NgZone, numberAttribute, SimpleChanges, TemplateRef } from '@angular/core';
 import { appendChild, createElement, fadeIn, findSingle, getOuterHeight, getOuterWidth, getViewport, getWindowScrollLeft, getWindowScrollTop, hasClass, removeChild, uuid } from '@primeuix/utils';
 import { TooltipOptions } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
@@ -194,6 +194,8 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
 
     resizeListener: any;
 
+    embeddedViewRef: EmbeddedViewRef<unknown> | null = null;
+
     _componentStyle = inject(TooltipStyle);
 
     interactionInProgress = false;
@@ -218,10 +220,7 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
      */
     pTooltipUnstyled = input<boolean | undefined>();
 
-    constructor(
-        public zone: NgZone,
-        private viewContainer: ViewContainerRef
-    ) {
+    constructor(public zone: NgZone) {
         super();
         effect(() => {
             const pt = this.ptTooltip() || this.pTooltipPT();
@@ -540,7 +539,7 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
 
     unbindContainerMouseleaveListener() {
         if (this.containerMouseleaveListener) {
-            this.bindContainerMouseleaveListener();
+            this.containerMouseleaveListener();
             this.containerMouseleaveListener = null;
         }
     }
@@ -581,17 +580,28 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
         this.remove();
     }
 
+    clearTooltipContent() {
+        this.embeddedViewRef?.destroy();
+        this.embeddedViewRef = null;
+
+        if (this.tooltipText) {
+            this.tooltipText.innerHTML = '';
+        }
+    }
+
     updateText() {
         const content = this.getOption('tooltipLabel');
+
+        this.clearTooltipContent();
+
         if (content && typeof (content as TemplateRef<any>).createEmbeddedView === 'function') {
-            const embeddedViewRef = this.viewContainer.createEmbeddedView(content);
-            embeddedViewRef.detectChanges();
-            embeddedViewRef.rootNodes.forEach((node) => this.tooltipText.appendChild(node));
+            this.embeddedViewRef = (content as TemplateRef<any>).createEmbeddedView({});
+            this.embeddedViewRef.detectChanges();
+            this.embeddedViewRef.rootNodes.forEach((node) => this.tooltipText.appendChild(node));
         } else if (this.getOption('escape')) {
-            this.tooltipText.innerHTML = '';
-            this.tooltipText.appendChild(document.createTextNode(content));
+            this.tooltipText.appendChild(document.createTextNode(content ?? ''));
         } else {
-            this.tooltipText.innerHTML = content;
+            this.tooltipText.innerHTML = content ?? '';
         }
     }
 
@@ -794,6 +804,8 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
     }
 
     remove() {
+        this.clearTooltipContent();
+
         if (this.container && this.container.parentElement) {
             if (this.getOption('appendTo') === 'body') document.body.removeChild(this.container);
             else if (this.getOption('appendTo') === 'target') this.el.nativeElement.removeChild(this.container);
@@ -805,6 +817,7 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
         this.unbindContainerMouseleaveListener();
         this.unbindDocumentTouchListener();
         this.clearTimeouts();
+        this.tooltipText = null;
         this.container = null;
         this.scrollHandler = null;
     }


### PR DESCRIPTION
## Fix tooltip template lifecycle and container mouseleave cleanup

### Summary
This PR fixes two issues in the `Tooltip` directive:

1. Template-based tooltip content was rendered through the host `ViewContainerRef`, which could leave embedded views alive after the tooltip DOM was removed.
2. `unbindContainerMouseleaveListener()` was rebinding the listener instead of calling the stored unlistener.

### Problem
For `TemplateRef` tooltips, `updateText()` used `ViewContainerRef.createEmbeddedView()`, then moved the rendered DOM nodes into the tooltip overlay container. That created a lifecycle mismatch:
- the embedded view was attached to the host view container
- the tooltip overlay manually moved its DOM nodes elsewhere
- the created view was never stored or destroyed

This could lead to stale template content accumulating or ending up back in unrelated DOM during churn.

Separately, `unbindContainerMouseleaveListener()` contained a clear bug:
```ts
if (this.containerMouseleaveListener) {
    this.bindContainerMouseleaveListener();
    this.containerMouseleaveListener = null;
}
```

### Fix
This PR changes tooltip template rendering to let the tooltip own the embedded view lifecycle:

- use `TemplateRef.createEmbeddedView()` instead of `ViewContainerRef.createEmbeddedView()`
- store the created `EmbeddedViewRef`
- clear previous tooltip content before every re-render
- destroy the embedded view during tooltip cleanup
- null out `tooltipText` during removal
- fix `unbindContainerMouseleaveListener()` to call the stored unlistener

### Why this is better
- avoids inserting tooltip template views into the host container
- keeps overlay content lifecycle local to the tooltip
- prevents duplicate template DOM on repeated updates
- properly removes `mouseleave` listeners for `autoHide=false`

### Tests
Added regression coverage for:
- template tooltip content does not duplicate when `updateText()` runs multiple times
- container `mouseleave` listener is removed during cleanup

### Verification
I verified the new tests fail against the old implementation and pass with this fix.

Results:
- before fix: 2 failures in the new regression tests
- after fix: `46 SUCCESS`

> Migrated from `primefaces/primeng#19515` — originally by `@ericleib` on 2026-04-02

---
*Original base: `master` @ `85f00f7`, head: `fix/tooltip-template-lifecycle` @ `84c3775`*