### PR TITLE
fix(toast): correct typo in toast documentation

### DIFF
--- a/apps/showcase/doc/apidoc/index.json
+++ b/apps/showcase/doc/apidoc/index.json
@@ -2363,7 +2363,7 @@
             "values": [
                 {
                     "name": "ToastMessageOptions",
-                    "description": "Deines valid options for the toast message.",
+                    "description": "Defines valid options for the toast message.",
                     "props": [
                         {
                             "name": "text",

--- a/packages/primeng/src/api/toastmessage.ts
+++ b/packages/primeng/src/api/toastmessage.ts
@@ -1,5 +1,5 @@
 /**
- * Deines valid options for the toast message.
+ * Defines valid options for the toast message.
  * @group Interface
  */
 export interface ToastMessageOptions {


### PR DESCRIPTION
closes #63

### Defect Fix
Fixed a typo in the Toast component documentation.

> Migrated from `primefaces/primeng#19512` — originally by `@sridharbommena` on 2026-03-31

---
*Original base: `master` @ `7c4a446`, head: `fix-typo-in-docs` @ `20a5961`*