### PR TITLE
fix: correct typo in toast message options description

### DIFF
--- a/apps/showcase/doc/apidoc/index.json
+++ b/apps/showcase/doc/apidoc/index.json
@@ -2363,7 +2363,7 @@
             "values": [
                 {
                     "name": "ToastMessageOptions",
-                    "description": "Deines valid options for the toast message.",
+                    "description": "Defines valid options for the toast message.",
                     "props": [
                         {
                             "name": "text",

--- a/packages/primeng/src/api/toastmessage.ts
+++ b/packages/primeng/src/api/toastmessage.ts
@@ -1,5 +1,5 @@
 /**
- * Deines valid options for the toast message.
+ * Defines valid options for the toast message.
  * @group Interface
  */
 export interface ToastMessageOptions {


### PR DESCRIPTION
Just fixing a small typo in docs.

Thanks for all your Open Source work!

Closes #63

> Migrated from `primefaces/primeng#19508` — originally by `@shaman-apprentice` on 2026-03-30

---
*Original base: `master` @ `7c4a446`, head: `docs/fix-typo-in-defines` @ `508eed9`*