### PR TITLE
feat: Conditionally render p-togglebutton label (fixes: #19499)

### DIFF
--- a/packages/primeng/src/togglebutton/togglebutton.ts
+++ b/packages/primeng/src/togglebutton/togglebutton.ts
@@ -22,8 +22,7 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { PARENT_INSTANCE } from 'primeng/basecomponent';
 import { BaseEditableHolder } from 'primeng/baseeditableholder';
-import { Bind } from 'primeng/bind';
-import { BindModule } from 'primeng/bind';
+import { Bind, BindModule } from 'primeng/bind';
 import { Ripple } from 'primeng/ripple';
 import { Nullable } from 'primeng/ts-helpers';
 import { ToggleButtonChangeEvent, ToggleButtonContentTemplateContext, ToggleButtonIconTemplateContext, ToggleButtonPassThrough } from 'primeng/types/togglebutton';
@@ -67,7 +66,9 @@ export const TOGGLEBUTTON_VALUE_ACCESSOR: any = {
             } @else {
                 <ng-container *ngTemplateOutlet="iconTemplate || _iconTemplate; context: { $implicit: checked }"></ng-container>
             }
-            <span [class]="cx('label')" [pBind]="ptm('label')">{{ checked ? (hasOnLabel ? onLabel : ' ') : hasOffLabel ? offLabel : ' ' }}</span>
+            @if ((checked && hasOnLabel) || (!checked && hasOffLabel)) {
+                <span [class]="cx('label')" [pBind]="ptm('label')">{{ checked ? (hasOnLabel ? onLabel : ' ') : hasOffLabel ? offLabel : ' ' }}</span>
+            }
         }
     </span>`,
     providers: [TOGGLEBUTTON_VALUE_ACCESSOR, ToggleButtonStyle, { provide: TOGGLEBUTTON_INSTANCE, useExisting: ToggleButton }, { provide: PARENT_INSTANCE, useExisting: ToggleButton }],


### PR DESCRIPTION
Fixes #68 

Icons in conjunction with empty labels were injecting a span with a non-breaking space which was breaking proper icon alignment due to container's gap.

> Migrated from `primefaces/primeng#19500` — originally by `@wcroteau` on 2026-03-25

---
*Original base: `master` @ `f06887c`, head: `Fix19499` @ `8f04670`*