### PR TITLE
fix(autocomplete): Patching Form Value displays OptionValue

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -895,7 +895,16 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
 
     inputValue = computed(() => {
         const modelValue = this.modelValue();
-        const selectedOption = this.optionValueSelected ? (this.suggestions || []).find((option: any) => equals(option, modelValue, this.equalityKey())) : modelValue;
+        const selectedOption = this.optionValueSelected
+            ? (this.suggestions || []).find((option: any) => {
+                  if (typeof option === 'object') {
+                      const optVal = resolveFieldData(option, this.optionValue);
+                      return optVal == modelValue;
+                  }
+
+                  return equals(option, modelValue, this.equalityKey());
+              })
+            : modelValue;
 
         if (isNotEmpty(modelValue)) {
             if (typeof modelValue === 'object' || this.optionValueSelected) {


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/102 https://github.com/primefaces/primeng/issues/707


## Scope
- inputValue logic only
- No breaking changes
- No visual or API changes
- No behavior change for the multiple mode or if the optionValue input dose not set
- No CSS or DOM structure changes

> Migrated from `primefaces/primeng#19483` — originally by `@O2sa` on 2026-03-19

---
*Original base: `master` @ `f06887c`, head: `bugfix/autocomplete-display-value` @ `f0e97d0`*