### PR TITLE
Fix : Toast clear all

### DIFF
--- a/packages/primeng/src/toast/toast.ts
+++ b/packages/primeng/src/toast/toast.ts
@@ -492,6 +492,8 @@ export class Toast extends BaseComponent<ToastPassThrough> {
     }
 
     add(messages: ToastMessageOptions[]): void {
+        this.clearAllTrigger.set(null);
+
         this.messages = this.messages ? [...this.messages, ...messages] : [...messages];
 
         if (this.preventDuplicates) {

--- a/packages/primeng/src/toast/toast.ts
+++ b/packages/primeng/src/toast/toast.ts
@@ -182,6 +182,7 @@ export class ToastItem extends BaseComponent<ToastPassThrough> {
 
         effect(() => {
             if (this.clearAll()) {
+                this.isClosing = true;
                 this.visible.set(false);
             }
         });
@@ -199,6 +200,7 @@ export class ToastItem extends BaseComponent<ToastPassThrough> {
                 this.visible.set(true);
                 this.timeout = setTimeout(
                     () => {
+                        this.isClosing = true;
                         this.visible.set(false);
                     },
                     this.message?.life || this.life || 3000
@@ -215,7 +217,9 @@ export class ToastItem extends BaseComponent<ToastPassThrough> {
     }
 
     onMouseEnter() {
-        this.clearTimeout();
+        if (!this.isClosing) {
+            this.clearTimeout();
+        }
     }
 
     onMouseLeave() {


### PR DESCRIPTION
Fixes the disappearance of toast items when the `clearAll `trigger is called from the Toast component. 
Prevents the `OnMouseEnter` event from resetting the toast item disappearance timeout if the process is closing the toast triggered by `clearAll`.

Also fixes the reset of the Toast component's `clearAllTrigger` to `null` when a new message is added to prevent the signal state from persisting.

> Migrated from `primefaces/primeng#19478` — originally by `@Iksvihii` on 2026-03-17

---
*Original base: `master` @ `f06887c`, head: `hotfix/toast-clear-all` @ `1af6200`*