### PR TITLE
fix: recursive sort-call for treetable in multisort-mode with custom sort function

### DIFF
--- a/packages/primeng/src/treetable/treetable.ts
+++ b/packages/primeng/src/treetable/treetable.ts
@@ -1301,7 +1301,7 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
 
         if (this.customSort) {
             this.sortFunction.emit({
-                data: this.value,
+                data: nodes,
                 mode: this.sortMode,
                 multiSortMeta: this.multiSortMeta
             });


### PR DESCRIPTION
I've noticed that the custom-sort-function in treetable is supposed to be called for each node and children, but because of a wrong variable reference the sort function is called multiple times for the same input. This PR fixes that.

> Migrated from `primefaces/primeng#19471` — originally by `@ADegele` on 2026-03-10

---
*Original base: `master` @ `f06887c`, head: `treetable-custom-multisort` @ `3d47ee8`*