### PR TITLE
Fix treetable events onNodeSelect/onNodeUnselect are not fired in checkbox-selection-mode with selectionKeys

### DIFF
--- a/packages/primeng/src/treetable/treetable.ts
+++ b/packages/primeng/src/treetable/treetable.ts
@@ -2011,6 +2011,11 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
             }
 
             this.selectionKeysChange.emit(this.selectionKeys);
+            if (check) {
+                this.onNodeSelect.emit({ originalEvent: event, node: node });
+            } else {
+                this.onNodeUnselect.emit({ originalEvent: event, node: node });
+            }
         } else {
             this.toggleNodeWithCheckbox({ originalEvent, rowNode });
         }


### PR DESCRIPTION
Fixes the following issue:

When using the treeTable with `selectionMode="checkbox"` with also using `[(selectionKeys)]="selectionKeys"`, then neither (onNodeSelect) nor (onNodeUnselect) events will be fired. Changing the selectionMode or removing selectionKeys make the events fire again.

Please see the attached [stackblitz](https://stackblitz.com/edit/g4tz45vh?file=src%2Fapp%2Ftreetable-selectioncheckbox-demo.ts). The `console.log` in the event-handlers are never called.

> Migrated from `primefaces/primeng#19465` — originally by `@ADegele` on 2026-03-06

---
*Original base: `master` @ `f06887c`, head: `master` @ `d514787`*