### PR TITLE
fix(drawer): Allow pFocusTrap to be disabled

### DIFF
--- a/packages/primeng/src/drawer/drawer.ts
+++ b/packages/primeng/src/drawer/drawer.ts
@@ -64,6 +64,7 @@ const DRAWER_INSTANCE = new InjectionToken<Drawer>('DRAWER_INSTANCE');
                 role="complementary"
                 (keydown)="onKeyDown($event)"
                 pFocusTrap
+                [pFocusTrapDisabled]="focusTrap === false"
                 [attr.data-p]="dataP"
                 [attr.data-p-open]="visible"
             >
@@ -198,6 +199,11 @@ export class Drawer extends BaseComponent<DrawerPassThrough> {
      * @deprecated since v21.0.0. Use `motionOptions` instead.
      */
     @Input() transitionOptions: string = '150ms cubic-bezier(0, 0, 0.2, 1)';
+    /**
+     * When enabled, can only focus on elements inside the dialog.
+     * @group Props
+     */
+    @Input({ transform: booleanAttribute }) focusTrap: boolean = true;
     /**
      * The visible property is an input that determines the visibility of the component.
      * @defaultValue false


### PR DESCRIPTION
Closes #108 

Currently, `pFocusTrap` is always enabled for instances of `p-drawer`, which for most cases is desirable. However, for the case when `[dismissible]="false" [modal]="false"`,  moving focus from the non-dismissible, non-modal drawer become impossible. This edge case is overcome in similar components by adding an input variable that allows `pFocusTrapDisabled` to be set, i.e. the [dialog component](https://github.com/primefaces/primeng/blob/master/packages/primeng/src/dialog/dialog.ts#L78C26-L78C44).

> Migrated from `primefaces/primeng#19424` — originally by `@ddpdoj` on 2026-02-23

---
*Original base: `master` @ `f11b0ce`, head: `issue-19422` @ `ffbc91b`*