### PR TITLE
Allow registering custom modules in quill editor.

### DIFF
--- a/packages/primeng/src/editor/editor.spec.ts
+++ b/packages/primeng/src/editor/editor.spec.ts
@@ -220,7 +220,7 @@ describe('Editor', () => {
             expect(editorInstance.placeholder).toBe('Enter text here...');
             expect(editorInstance.formats).toBeUndefined();
             expect(editorInstance.modules).toBeUndefined();
-            expect(editorInstance.customModules).toBe({});
+            expect(editorInstance.customModules).toBeUndefined();
         });
 
         it('should accept input values', async () => {

--- a/packages/primeng/src/editor/editor.spec.ts
+++ b/packages/primeng/src/editor/editor.spec.ts
@@ -123,12 +123,17 @@ class TestReadonlyComponent {
 
 @Component({
     standalone: false,
-    template: ` <p-editor [(ngModel)]="text" [modules]="customModules" [formats]="customFormats"> </p-editor> `
+    template: ` <p-editor [(ngModel)]="text" [modules]="customModules" [customModules]="customQuillModules" [formats]="customFormats"> </p-editor> `
 })
 class TestCustomConfigurationComponent {
     text: string = '<div>Custom config</div>';
     customModules = {
         toolbar: [['bold', 'italic'], ['clean']]
+    };
+    customQuillModules = {
+        'modules/counter': class CounterModule {
+            constructor(public quill: any) {}
+        }
     };
     customFormats = ['bold', 'italic', 'underline'];
 }
@@ -215,6 +220,7 @@ describe('Editor', () => {
             expect(editorInstance.placeholder).toBe('Enter text here...');
             expect(editorInstance.formats).toBeUndefined();
             expect(editorInstance.modules).toBeUndefined();
+            expect(editorInstance.customModules).toBe({});
         });
 
         it('should accept input values', async () => {
@@ -546,6 +552,27 @@ describe('Editor', () => {
             const editorInstance = editorEl.componentInstance as Editor;
 
             expect(editorInstance.formats).toEqual(['bold', 'italic', 'underline']);
+        });
+
+        it('should accept custom quill modules configuration', () => {
+            const editorEl = fixture.debugElement.query(By.css('p-editor'));
+            const editorInstance = editorEl.componentInstance as Editor;
+
+            expect(editorInstance.customModules).toEqual(component.customQuillModules);
+        });
+
+        it('should register custom quill modules', () => {
+            const editorEl = fixture.debugElement.query(By.css('p-editor'));
+            const editorInstance = editorEl.componentInstance as Editor;
+            const registerSpy = jasmine.createSpy('register');
+
+            (editorInstance as any).dynamicQuill = {
+                register: registerSpy
+            };
+
+            (editorInstance as any).registerQuillModules();
+
+            expect(registerSpy).toHaveBeenCalledWith('modules/counter', component.customQuillModules['modules/counter']);
         });
     });
 

--- a/packages/primeng/src/editor/editor.ts
+++ b/packages/primeng/src/editor/editor.ts
@@ -7,7 +7,7 @@ import { PARENT_INSTANCE } from 'primeng/basecomponent';
 import { BaseEditableHolder } from 'primeng/baseeditableholder';
 import { Bind, BindModule } from 'primeng/bind';
 import { Nullable } from 'primeng/ts-helpers';
-import { EditorBlurEvent, EditorChangeEvent, EditorFocusEvent, EditorInitEvent, EditorPassThrough, EditorSelectionChangeEvent, EditorTextChangeEvent } from 'primeng/types/editor';
+import { EditorBlurEvent, EditorChangeEvent, EditorFocusEvent, EditorInitEvent, EditorPassThrough, EditorSelectionChangeEvent, EditorTextChangeEvent, QuillModule } from 'primeng/types/editor';
 import { EditorStyle } from './style/editorstyle';
 
 const EDITOR_INSTANCE = new InjectionToken<Editor>('EDITOR_INSTANCE');
@@ -118,6 +118,11 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
      * @group Props
      */
     @Input() modules: object | undefined;
+    /**
+     * List of custom Quill modules that need to be registered before initialization, see [here](https://quilljs.com/docs/modules#extending).
+     * @group Props
+     */
+    @Input() customModules: Record<string, QuillModule> = {};
     /**
      * DOM Element or a CSS selector for a DOM Element, within which the editor’s p elements (i.e. tooltips, etc.) should be confined. Currently, it only considers left and right boundaries.
      * @group Props
@@ -291,11 +296,19 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
             import('quill')
                 .then((quillModule: any) => {
                     this.dynamicQuill = quillModule.default;
+                    this.registerQuillModules();
                     this.createQuillEditor();
                 })
                 .catch((e) => console.error(e.message));
         } else {
+            this.registerQuillModules();
             this.createQuillEditor();
+        }
+    }
+
+    private registerQuillModules(): void {
+        for (const [moduleName, moduleInstance] of Object.entries(this.customModules)) {
+            this.dynamicQuill.registered(moduleName, moduleInstance);
         }
     }
 

--- a/packages/primeng/src/editor/editor.ts
+++ b/packages/primeng/src/editor/editor.ts
@@ -123,7 +123,7 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
      * Keys must be full Quill registration paths (for example, `'modules/myModule'`), as they are passed directly to `Quill.register` and are not auto-prefixed by the component.
      * @group Props
      */
-    @Input() customModules: Record<string, QuillModule> = {};
+    @Input() customModules: Record<string, QuillModule> | undefined;
     /**
      * DOM Element or a CSS selector for a DOM Element, within which the editor’s p elements (i.e. tooltips, etc.) should be confined. Currently, it only considers left and right boundaries.
      * @group Props
@@ -308,8 +308,10 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
     }
 
     private registerQuillModules(): void {
-        for (const [moduleName, moduleInstance] of Object.entries(this.customModules)) {
-            this.dynamicQuill.register(moduleName, moduleInstance);
+        if (this.customModules) {
+            for (const [moduleName, moduleInstance] of Object.entries(this.customModules)) {
+                this.dynamicQuill.register(moduleName, moduleInstance);
+            }
         }
     }
 

--- a/packages/primeng/src/editor/editor.ts
+++ b/packages/primeng/src/editor/editor.ts
@@ -119,7 +119,8 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
      */
     @Input() modules: object | undefined;
     /**
-     * List of custom Quill modules that need to be registered before initialization, see [here](https://quilljs.com/docs/modules#extending).
+     * Map of custom Quill modules that need to be registered before initialization, see [here](https://quilljs.com/docs/modules#extending).
+     * Keys must be full Quill registration paths (for example, `'modules/myModule'`), as they are passed directly to `Quill.register` and are not auto-prefixed by the component.
      * @group Props
      */
     @Input() customModules: Record<string, QuillModule> = {};
@@ -308,7 +309,7 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
 
     private registerQuillModules(): void {
         for (const [moduleName, moduleInstance] of Object.entries(this.customModules)) {
-            this.dynamicQuill.registered(moduleName, moduleInstance);
+            this.dynamicQuill.register(moduleName, moduleInstance);
         }
     }
 

--- a/packages/primeng/src/types/editor/editor.types.ts
+++ b/packages/primeng/src/types/editor/editor.types.ts
@@ -209,6 +209,6 @@ export interface EditorTemplates {
     header(): TemplateRef<any>;
 }
 /**
- * Defined valid custom module.
+ * Defines a valid custom module.
  */
 export type QuillModule = ((quill: any, options: any) => void) | (new (quill: any, options: any) => unknown);

--- a/packages/primeng/src/types/editor/editor.types.ts
+++ b/packages/primeng/src/types/editor/editor.types.ts
@@ -208,3 +208,7 @@ export interface EditorTemplates {
      */
     header(): TemplateRef<any>;
 }
+/**
+ * Defined valid custom module.
+ */
+export type QuillModule = ((quill: any, options: any) => void) | (new (quill: any, options: any) => unknown);


### PR DESCRIPTION
### Feature Requests
This pull request adds support for registering custom Quill modules in the `Editor` component, allowing users to extend the editor's functionality by providing custom modules. The implementation introduces a new `customModules` input property and ensures modules are registered before the editor is initialized.

Enhancements for custom Quill module registration:
* Added a new `customModules` input property to the `Editor` component, allowing users to specify custom Quill modules to be registered before initialization. (`editor.ts`)
* Implemented the `registerQuillModules()` method in the `Editor` class, which iterates through the provided custom modules and registers them with Quill during the initialization process. (`editor.ts`)
* Introduced the `QuillModule` type definition to clarify the expected shape of custom modules, supporting both function and class module formats. (`editor.types.ts`)
* Updated imports to include the new `QuillModule` type for use in the `Editor` component. (`editor.ts`)

> Migrated from `primefaces/primeng#19421` — originally by `@Bartek20` on 2026-02-22

---
*Original base: `master` @ `f11b0ce`, head: `editor-quill-register` @ `9b7aef7`*