### PR TITLE
fix(progressbar): use dynamic transition for fast value updates

### DIFF
--- a/packages/primeng/src/progressbar/progressbar.spec.ts
+++ b/packages/primeng/src/progressbar/progressbar.spec.ts
@@ -181,6 +181,50 @@ describe('ProgressBar', () => {
             await fixture.whenStable();
             expect(progressBarInstance.valueStyleClass).toBe('value-test-class');
         });
+
+        describe('value transition behavior', () => {
+            // beforeEach binds value=50, which starts the 1s debounce timer.
+            // Any value change within the same test therefore counts as a rapid update.
+
+            afterEach(() => jasmine.clock().uninstall());
+
+            it('should not apply inline transition style on initial value set', () => {
+                const valueElement = fixture.debugElement.query(By.css('[data-pc-section="value"]')).nativeElement;
+                expect(progressBarInstance._isRapidUpdate).toBe(false);
+                expect(valueElement.style.transition).toBe('');
+            });
+
+            it('should apply short transition when value changes within 1s of a prior change', () => {
+                component.value = 75;
+                fixture.changeDetectorRef.markForCheck();
+                fixture.detectChanges();
+
+                const valueElement = fixture.debugElement.query(By.css('[data-pc-section="value"]')).nativeElement;
+                expect(progressBarInstance._isRapidUpdate).toBe(true);
+                expect(valueElement.style.transition).toBe('width 100ms ease-in-out');
+            });
+
+            it('should reset rapid-update mode after 1s and apply no inline transition on the next slow update', () => {
+                jasmine.clock().install();
+
+                component.value = 75; // rapid — timer already pending from beforeEach
+                fixture.changeDetectorRef.markForCheck();
+                fixture.detectChanges();
+                expect(progressBarInstance._isRapidUpdate).toBe(true);
+
+                jasmine.clock().tick(1000); // debounce timer fires → _isRapidUpdate resets to false
+                expect(progressBarInstance._isRapidUpdate).toBe(false);
+
+                component.value = 90; // slow — no pending timer
+                fixture.changeDetectorRef.markForCheck();
+                fixture.detectChanges();
+
+                const valueElement = fixture.debugElement.query(By.css('[data-pc-section="value"]')).nativeElement;
+                expect(progressBarInstance._isRapidUpdate).toBe(false);
+                expect(valueElement.style.transition).toBe('');
+                jasmine.clock().tick(1000); // flush new pending timer before uninstall
+            });
+        });
     });
 
     describe('Determinate Mode Rendering', () => {

--- a/packages/primeng/src/progressbar/progressbar.ts
+++ b/packages/primeng/src/progressbar/progressbar.ts
@@ -17,7 +17,16 @@ const PROGRESSBAR_INSTANCE = new InjectionToken<ProgressBar>('PROGRESSBAR_INSTAN
     standalone: true,
     imports: [CommonModule, SharedModule, Bind],
     template: `
-        <div *ngIf="mode === 'determinate'" [class]="cn(cx('value'), valueStyleClass)" [pBind]="ptm('value')" [style.width]="value + '%'" [style.display]="'flex'" [style.background]="color" [attr.data-p]="dataP">
+        <div
+            *ngIf="mode === 'determinate'"
+            [class]="cn(cx('value'), valueStyleClass)"
+            [pBind]="ptm('value')"
+            [style.width]="value + '%'"
+            [style.display]="'flex'"
+            [style.background]="color"
+            [style.transition]="_isRapidUpdate ? 'width 100ms ease-in-out' : null"
+            [attr.data-p]="dataP"
+        >
             <div [class]="cx('label')" [pBind]="ptm('label')" [attr.data-p]="dataP">
                 <div *ngIf="showValue && !contentTemplate && !_contentTemplate" [style.display]="value != null && value !== 0 ? 'flex' : 'none'">{{ value }}{{ unit }}</div>
                 <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: value }"></ng-container>
@@ -46,11 +55,37 @@ export class ProgressBar extends BaseComponent<ProgressBarPassThrough> {
 
     bindDirectiveInstance = inject(Bind, { self: true });
 
+    private _value: number | undefined;
+    // A pending timer means a previous update arrived within the CSS transition duration (1s).
+    private _rapidUpdateTimer: ReturnType<typeof setTimeout> | null = null;
+    _isRapidUpdate = false;
+
     /**
      * Current value of the progress.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) value: number | undefined;
+    @Input({ transform: numberAttribute })
+    set value(val: number | undefined) {
+        this._value = val;
+
+        if (this._rapidUpdateTimer !== null) {
+            // A timer is already running, meaning the last update was less than 1s ago.
+            // Switch to a short ease-in-out transition so the bar tracks the real value smoothly
+            // without the 1s ease-in-out causing visual lag.
+            this._isRapidUpdate = true;
+            clearTimeout(this._rapidUpdateTimer);
+        }
+
+        // Re-enable the transition once updates have stopped for a full transition duration (1s).
+        this._rapidUpdateTimer = setTimeout(() => {
+            this._isRapidUpdate = false;
+            this._rapidUpdateTimer = null;
+        }, 1000);
+    }
+
+    get value(): number | undefined {
+        return this._value;
+    }
     /**
      * Whether to display the progress bar value.
      * @group Props


### PR DESCRIPTION
The root cause is in the CSS:

```css
.p-progressbar-determinate .p-progressbar-value {                                                                     
      transition: width 1s ease-in-out;                                                                                 
}
```

When the value increments faster than 1 second, each Angular binding update starts a new CSS transition from the current visual position (not the previous data value). So the bar perpetually lags — at 50%, it may visually only be at e.g. 20% because each 1s animation was interrupted mid-way. 

To fix the issue of fast updates, I implemented a simple 1-second timeout strategy. If the previous value update occurred less than a second ago, the transition property is temporarily overridden to a 100 ms ease-in-out animation. Otherwise, it uses the standard CSS transition defined above. I have written some tests that should also help to understand the written code.

closes primefaces#19224

> Migrated from `primefaces/primeng#19419` — originally by `@Will-Smith-007` on 2026-02-21

---
*Original base: `master` @ `f11b0ce`, head: `bugfix/fast-progressbar-value-updates` @ `e5411a0`*