### PR TITLE
fix(15240): properly close mobile menubar when clicking outside

### DIFF
--- a/packages/primeng/src/menubar/menubar.spec.ts
+++ b/packages/primeng/src/menubar/menubar.spec.ts
@@ -467,18 +467,18 @@ describe('Menubar', () => {
             expect(menuButton).toBeTruthy();
         });
 
-        it('should toggle mobile menu on button click', () => {
+        it('should toggle mobile menu on button click', async () => {
             menubarInstance.queryMatches.set(true);
-            fixture.detectChanges();
+            await fixture.whenStable();
 
             const menuButton = fixture.debugElement.query(By.css('a[data-pc-section="button"]'));
 
-            expect(menubarInstance.mobileActive).toBeFalsy();
+            expect(menubarInstance.mobileActive()).toBeFalsy();
 
             menuButton.nativeElement.click();
-            fixture.detectChanges();
+            await fixture.whenStable();
 
-            expect(menubarInstance.mobileActive).toBe(true);
+            expect(menubarInstance.mobileActive()).toBe(true);
         });
 
         it('should show and hide menu programmatically', () => {
@@ -490,6 +490,33 @@ describe('Menubar', () => {
 
             expect(menubarInstance.focusedItemInfo().index).toBe(-1);
             expect(menubarInstance.activeItemPath()).toEqual([]);
+        });
+
+        it('should hide mobile menu on outside click', async () => {
+            menubarInstance.queryMatches.set(true);
+            await fixture.whenStable();
+
+            const menuButton = fixture.debugElement.query(By.css('a[data-pc-section="button"]'));
+
+            expect(menubarInstance.mobileActive()).toBeFalsy();
+
+            menuButton.nativeElement.click();
+            await fixture.whenStable();
+
+            expect(menubarInstance.mobileActive()).toBe(true);
+            expect(menubarInstance.outsideClickListener).toBeTruthy();
+
+            // Check if root submenu is visible before outside click
+            const rootMenu = fixture.debugElement.query(By.css('ul[pMenubarSub]'));
+            expect(rootMenu).toBeTruthy();
+            expect(window.getComputedStyle(rootMenu.nativeElement).display).not.toBe('none');
+
+            const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+            document.dispatchEvent(clickEvent);
+            await fixture.whenStable();
+
+            expect(menubarInstance.mobileActive()).toBe(false);
+            expect(window.getComputedStyle(rootMenu.nativeElement).display).toBe('none');
         });
     });
 
@@ -1006,14 +1033,16 @@ describe('Menubar', () => {
             expect(menubarInstance.focusedItemInfo().index).toBe(-1);
         });
 
-        it('should call toggle method programmatically', () => {
+        it('should call toggle method programmatically', async () => {
             const mockEvent = new MouseEvent('click');
             spyOn(mockEvent, 'preventDefault');
 
-            expect(menubarInstance.mobileActive).toBeFalsy();
+            expect(menubarInstance.mobileActive()).toBeFalsy();
 
             menubarInstance.toggle(mockEvent);
-            expect(menubarInstance.mobileActive).toBe(true);
+            await fixture.whenStable();
+
+            expect(menubarInstance.mobileActive()).toBe(true);
             expect(mockEvent.preventDefault).toHaveBeenCalled();
         });
 
@@ -1320,17 +1349,17 @@ describe('Menubar', () => {
             }
         });
 
-        it('Case 4: should use instance variables in PT functions', () => {
+        it('Case 4: should use instance variables in PT functions', async () => {
             fixture.componentRef.setInput('pt', {
                 button: ({ instance }) => ({
                     class: {
-                        MOBILE_ACTIVE: instance.mobileActive
+                        MOBILE_ACTIVE: instance.mobileActive()
                     }
                 })
             });
 
-            menubar.mobileActive = true;
-            fixture.detectChanges();
+            menubar.mobileActive.set(true);
+            await fixture.whenStable();
 
             const buttonEl = fixture.nativeElement.querySelector('[class*="p-menubar-button"]');
             expect(buttonEl).toBeTruthy();

--- a/packages/primeng/src/menubar/menubar.ts
+++ b/packages/primeng/src/menubar/menubar.ts
@@ -390,7 +390,7 @@ export class MenubarSub extends BaseComponent<MenubarPassThrough> {
             tabindex="0"
             role="button"
             [attr.aria-haspopup]="model.length && model.length > 0 ? true : false"
-            [attr.aria-expanded]="mobileActive"
+            [attr.aria-expanded]="mobileActive()"
             [attr.aria-controls]="id"
             [attr.aria-label]="config.translation.aria.navigation"
             *ngIf="model && model.length > 0"
@@ -412,7 +412,7 @@ export class MenubarSub extends BaseComponent<MenubarPassThrough> {
             [root]="true"
             [baseZIndex]="baseZIndex"
             [autoZIndex]="autoZIndex"
-            [mobileActive]="mobileActive"
+            [mobileActive]="mobileActive()"
             [autoDisplay]="autoDisplay"
             [attr.aria-label]="ariaLabel"
             [attr.aria-labelledby]="ariaLabelledBy"
@@ -538,7 +538,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
 
     @ViewChild('rootmenu') rootmenu: MenubarSub | undefined;
 
-    mobileActive: boolean | undefined;
+    mobileActive = signal<boolean | undefined>(undefined);
 
     private matchMediaListener: () => void;
 
@@ -726,7 +726,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
 
                 this.matchMediaListener = () => {
                     this.queryMatches.set(query.matches);
-                    this.mobileActive = false;
+                    this.mobileActive.set(false);
                     this.cd.markForCheck();
                 };
 
@@ -777,7 +777,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
                 this.hide(originalEvent);
                 this.changeFocusedItemIndex(originalEvent, rootProcessedItem ? rootProcessedItem.index : -1);
 
-                this.mobileActive = false;
+                this.mobileActive.set(false);
                 focus(this.rootmenu?.el.nativeElement);
             }
         }
@@ -845,12 +845,12 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
     }
 
     toggle(event: MouseEvent) {
-        if (this.mobileActive) {
-            this.mobileActive = false;
+        if (this.mobileActive()) {
+            this.mobileActive.set(false);
             ZIndexUtils.clear(this.rootmenu?.el.nativeElement);
             this.hide();
         } else {
-            this.mobileActive = true;
+            this.mobileActive.set(true);
             ZIndexUtils.set('menu', this.rootmenu?.el.nativeElement, this.config.zIndex.menu);
             setTimeout(() => {
                 this.show();
@@ -859,10 +859,11 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
 
         this.bindOutsideClickListener();
         event.preventDefault();
+        event.stopPropagation();
     }
 
     hide(event?, isFocus?: boolean) {
-        if (this.mobileActive) {
+        if (this.mobileActive()) {
             setTimeout(() => {
                 focus(this.menubutton?.nativeElement);
             }, 0);
@@ -1235,7 +1236,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
                         this.hide(event, true);
                     }
 
-                    this.mobileActive = false;
+                    this.mobileActive.set(false);
                 });
             }
         }
@@ -1246,10 +1247,10 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = this.renderer.listen(this.document, 'click', (event) => {
                     const isOutsideContainer = this.rootmenu?.el.nativeElement !== event.target && !this.rootmenu?.el.nativeElement?.contains(event.target);
-                    const isOutsideMenuButton = this.mobileActive && this.menubutton?.nativeElement !== event.target && !this.menubutton?.nativeElement?.contains(event.target);
+                    const isOutsideMenuButton = this.mobileActive() && this.menubutton?.nativeElement !== event.target && !this.menubutton?.nativeElement?.contains(event.target);
 
                     if (isOutsideContainer) {
-                        isOutsideMenuButton ? (this.mobileActive = false) : this.hide();
+                        isOutsideMenuButton ? this.mobileActive.set(false) : this.hide();
                     }
                 });
             }

--- a/packages/primeng/src/menubar/style/menubarstyle.ts
+++ b/packages/primeng/src/menubar/style/menubarstyle.ts
@@ -11,7 +11,7 @@ const classes = {
         'p-menubar p-component',
         {
             'p-menubar-mobile': instance.queryMatches(),
-            'p-menubar-mobile-active': instance.mobileActive
+            'p-menubar-mobile-active': instance.mobileActive()
         }
     ],
     start: 'p-menubar-start',


### PR DESCRIPTION
Fixes [#15240](https://github.com/primefaces/primeng/issues/15240)

Up until then, menubar had quite some weird behaviour when on mobile mode, from v17 to v21. The root menu overlay didn't really disappear when a click outside its scope occured, sometimes going off on further hover, sometimes not.

The core of the problem was that the initial clicked was also triggering the freshly created clickOutside listener, instantaneously killing the listener +  letting the CSS class responsible for hiding the menu. The fix was to prevent that initial click (from the toggle) to bubble up to the document listener. Also, mobileActive has been modernized with signal to ease change detection.

I also added a test to effectively check if the said root overlay properly goes "unvisible" after clicking outside the menubar.

> Migrated from `primefaces/primeng#19416` — originally by `@Cr3aHal0` on 2026-02-20

---
*Original base: `master` @ `f11b0ce`, head: `fix-15240-mobile-menubar-wont-close-on-click-outside` @ `9eec636`*