### PR TITLE
fix: Add show method to ToastStickyDemo class

### DIFF
--- a/apps/showcase/public/llms/components/toast.md
+++ b/apps/showcase/public/llms/components/toast.md
@@ -360,6 +360,15 @@ import { MessageService } from 'primeng/api';
 export class ToastStickyDemo {
     private messageService = inject(MessageService);
 
+    show() {
+        this.messageService.add({
+            severity: 'info',
+            summary: 'Sticky',
+            detail: 'Message Content',
+            sticky: true
+        });
+    }
+
     clear() {
         this.messageService.clear();
     }


### PR DESCRIPTION
Fixes #114

> Migrated from `primefaces/primeng#19412` — originally by `@navedqb` on 2026-02-19

---
*Original base: `master` @ `f11b0ce`, head: `fix--19407` @ `9656d24`*