### PR TITLE
fix(19395): only have empty-message generated once and only within main body part

### DIFF
--- a/packages/primeng/src/table/table.spec.ts
+++ b/packages/primeng/src/table/table.spec.ts
@@ -1457,4 +1457,144 @@ describe('Table', () => {
             expect(editingCell.querySelector('[data-p-cell-editing="true"]') || editingCell.getAttribute('data-p-cell-editing')).toBeTruthy();
         });
     });
+
+    describe('EmptyMessage with FrozenBody', () => {
+
+        beforeEach(() => TestBed.resetTestingModule());
+
+        @Component({
+            standalone: false,
+            template: `
+                <p-table [value]="products">
+                    <ng-template #frozenBody let-rowData>
+                        <tr class="frozen-row">
+                            <td>Frozen: {{ rowData?.id }}</td>
+                        </tr>
+                    </ng-template>
+                    <ng-template #body let-product>
+                        <tr>
+                            <td>{{ product.id }}</td>
+                        </tr>
+                    </ng-template>
+                    <ng-template #emptymessage>
+                        <tr class="empty-row"><td>No products available</td></tr>
+                    </ng-template>
+                </p-table>
+            `
+        })
+        class TestEmptyMessageFrozenAndBodyComponent {
+            products: any[] = [];
+        }
+
+        @Component({
+            standalone: false,
+            template: `
+                <p-table [value]="products">
+                    <ng-template #frozenBody let-rowData>
+                        <tr class="frozen-row">
+                            <td>Frozen: {{ rowData?.id }}</td>
+                        </tr>
+                    </ng-template>
+                    <ng-template #emptymessage>
+                        <tr class="empty-row"><td>No products available</td></tr>
+                    </ng-template>
+                </p-table>
+            `
+        })
+        class TestEmptyMessageFrozenComponent {
+            products: any[] = [];
+        }
+
+        @Component({
+            standalone: false,
+            template: `
+                <p-table [value]="products">
+                    <ng-template #body let-product>
+                        <tr>
+                            <td>{{ product.id }}</td>
+                        </tr>
+                    </ng-template>
+                    <ng-template #emptymessage>
+                        <tr class="empty-row"><td>No products available</td></tr>
+                    </ng-template>
+                </p-table>
+            `
+        })
+        class TestEmptyMessageBodyComponent {
+            products: any[] = [];
+        }
+
+        @Component({
+            standalone: false,
+            template: `
+                <p-table [value]="products">
+                    <ng-template #body let-product>
+                        <tr>
+                            <td>{{ product.id }}</td>
+                        </tr>
+                    </ng-template>
+                    <ng-template #emptymessage>
+                        <tr class="empty-row"><td>No products available</td></tr>
+                    </ng-template>
+                </p-table>
+            `
+        })
+        class TestEmptyMessageNoneComponent {
+            products: any[] = []; // empty to trigger empty message
+        }
+
+        it('should render empty message only once if frozenBody and body are defined', async () => {
+
+            await TestBed.configureTestingModule({
+                imports: [TableModule, CommonModule, FormsModule],
+                declarations: [TestEmptyMessageFrozenAndBodyComponent],
+                providers: [provideZonelessChangeDetection()]
+            }).compileComponents();
+
+            const testFixture = TestBed.createComponent(TestEmptyMessageFrozenAndBodyComponent);
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const emptyRow = testFixture.debugElement.queryAll(By.css('.empty-row'));
+            expect(emptyRow).toBeTruthy();
+            expect(emptyRow.length).toEqual(1);
+            expect(emptyRow[0].nativeElement.textContent).toContain('No products available');
+        });
+
+        it('should render empty message only once if only frozenBody is defined', async () => {
+
+            await TestBed.configureTestingModule({
+                imports: [TableModule, CommonModule, FormsModule],
+                declarations: [TestEmptyMessageFrozenComponent],
+                providers: [provideZonelessChangeDetection()]
+            }).compileComponents();
+
+            const testFixture = TestBed.createComponent(TestEmptyMessageFrozenComponent);
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const emptyRow = testFixture.debugElement.queryAll(By.css('.empty-row'));
+            expect(emptyRow).toBeTruthy();
+            expect(emptyRow.length).toEqual(1);
+            expect(emptyRow[0].nativeElement.textContent).toContain('No products available');
+        });
+
+        it('should render empty message only once if only body is defined', async () => {
+
+            await TestBed.configureTestingModule({
+                imports: [TableModule, CommonModule, FormsModule],
+                declarations: [TestEmptyMessageBodyComponent],
+                providers: [provideZonelessChangeDetection()]
+            }).compileComponents();
+
+            const testFixture = TestBed.createComponent(TestEmptyMessageBodyComponent);
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const emptyRow = testFixture.debugElement.queryAll(By.css('.empty-row'));
+            expect(emptyRow).toBeTruthy();
+            expect(emptyRow.length).toEqual(1);
+            expect(emptyRow[0].nativeElement.textContent).toContain('No products available');
+        });
+    });
 });

--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -3378,7 +3378,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
         <ng-container *ngIf="dataTable.loading">
             <ng-container *ngTemplateOutlet="dataTable.loadingBodyTemplate || dataTable._loadingBodyTemplate; context: { $implicit: columns, frozen: frozen }"></ng-container>
         </ng-container>
-        <ng-container *ngIf="dataTable.isEmpty() && !dataTable.loading">
+        <ng-container *ngIf="dataTable.isEmpty() && !dataTable.loading && !frozen">
             <ng-container *ngTemplateOutlet="dataTable.emptyMessageTemplate || dataTable._emptyMessageTemplate; context: { $implicit: columns, frozen: frozen }"></ng-container>
         </ng-container>
     `,


### PR DESCRIPTION
Fixes [19395](https://github.com/primefaces/primeng/issues/121)

> Migrated from `primefaces/primeng#19403` — originally by `@Cr3aHal0` on 2026-02-16

---
*Original base: `master` @ `f11b0ce`, head: `duplicated-table-empty-message` @ `2a5dcfe`*