### PR TITLE
fix #19392: respect chooseButtonProps.iconPos in fileupload basic mode

### DIFF
--- a/packages/primeng/src/fileupload/fileupload.ts
+++ b/packages/primeng/src/fileupload/fileupload.ts
@@ -298,17 +298,17 @@ export class FileContent extends BaseComponent {
                     [pt]="ptm('pcChooseButton')"
                     [unstyled]="unstyled()"
                 >
-                    <ng-template #icon>
+                    <ng-template #icon let-iconClass="class">
                         @if (hasFiles() && !auto) {
-                            <span *ngIf="uploadIcon" class="p-button-icon p-button-icon-left" [ngClass]="uploadIcon" [pBind]="ptm('pcChooseButton')?.icon"></span>
+                            <span *ngIf="uploadIcon" [class]="iconClass" [ngClass]="uploadIcon" [pBind]="ptm('pcChooseButton')?.icon"></span>
                             <ng-container *ngIf="!uploadIcon">
-                                <svg data-p-icon="upload" *ngIf="!uploadIconTemplate && !_uploadIconTemplate" [class]="'p-button-icon p-button-icon-left'" [pBind]="ptm('pcChooseButton')?.icon" />
-                                <span *ngIf="_uploadIconTemplate || uploadIconTemplate" class="p-button-icon p-button-icon-left" [pBind]="ptm('pcChooseButton')?.icon">
+                                <svg data-p-icon="upload" *ngIf="!uploadIconTemplate && !_uploadIconTemplate" [class]="iconClass" [pBind]="ptm('pcChooseButton')?.icon" />
+                                <span *ngIf="_uploadIconTemplate || uploadIconTemplate" [class]="iconClass" [pBind]="ptm('pcChooseButton')?.icon">
                                     <ng-template *ngTemplateOutlet="_uploadIconTemplate || uploadIconTemplate"></ng-template>
                                 </span>
                             </ng-container>
                         } @else {
-                            <span *ngIf="chooseIcon" class="p-button-icon p-button-icon-left pi" [ngClass]="chooseIcon" [pBind]="ptm('pcChooseButton')?.icon"></span>
+                            <span *ngIf="chooseIcon" [class]="iconClass" [ngClass]="chooseIcon" [pBind]="ptm('pcChooseButton')?.icon"></span>
                             <ng-container *ngIf="!chooseIcon">
                                 <svg data-p-icon="plus" *ngIf="!chooseIconTemplate && !_chooseIconTemplate" [pBind]="ptm('pcChooseButton')?.icon" />
                                 <ng-template *ngTemplateOutlet="chooseIconTemplate || _chooseIconTemplate"></ng-template>


### PR DESCRIPTION
Fixes [#123](https://github.com/primefaces/primeng/issues/123)

### Problem

In basic mode, `p-fileupload` ignores `chooseButtonProps.iconPos`. Setting `[chooseButtonProps]="{ iconPos: 'right' }"` has no effect — the icon always stays on the left.

### Root Cause

The `#icon` ng-template in the basic mode template hardcodes `p-button-icon-left` on all icon elements, instead of using the computed icon classes from `p-button`.

### Solution

Added `let-iconClass="class"` to the `#icon` ng-template and replaced the hardcoded classes with `[class]="iconClass"`. This way the icon position classes are computed by `p-button`'s `cx('icon')` based on `buttonProps.iconPos`. This is the same pattern already used in the advanced mode template at line 69 of the same file.

> Migrated from `primefaces/primeng#19394` — originally by `@vitopio-prete` on 2026-02-12

---
*Original base: `master` @ `f11b0ce`, head: `fix/fileupload-basic-iconpos` @ `54452cb`*