### PR TITLE
fix(overlay, select, multiselect): respect overlayOptions.appendTo across components.

### DIFF
--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -1104,7 +1104,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     $variant = computed(() => this.variant() || this.config.inputStyle() || this.config.inputVariant());
 
-    $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
+    $appendTo = computed(() => this.appendTo() || this.overlayOptions?.appendTo || this.config.overlayAppendTo());
 
     $pcMultiSelect: MultiSelect | undefined = inject(MULTISELECT_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
 

--- a/packages/primeng/src/overlay/overlay.ts
+++ b/packages/primeng/src/overlay/overlay.ts
@@ -365,7 +365,7 @@ export class Overlay extends BaseComponent {
 
     hostAttrSelector = input<string>();
 
-    $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
+    $appendTo = computed(() => this.appendTo() || this.overlayOptions.appendTo || this.config.overlayAppendTo());
 
     _contentTemplate: TemplateRef<OverlayContentTemplateContext> | undefined;
 

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -791,7 +791,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
     itemsWrapper: Nullable<HTMLDivElement>;
 
-    $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
+    $appendTo = computed(() => this.appendTo() || this.overlayOptions?.appendTo || this.config.overlayAppendTo());
 
     /**
      * Custom item template.


### PR DESCRIPTION
### Fix overlayOptions.appendTo handling across overlay components

#### Problem
Several overlay-based components (Select, MultiSelect, Overlay/OverlayPanel)
ignore `overlayOptions.appendTo` and only fallback to:
- component `appendTo`
- global `config.overlayAppendTo`

This leads to incorrect overlay positioning inside dialogs, panels,
and scrollable containers, despite `overlayOptions.appendTo` being provided.

#### Solution
Include `overlayOptions.appendTo` in `$appendTo` computation with correct priority:
1. component `appendTo`
2. `overlayOptions.appendTo`
3. global config fallback

#### Components updated
- Select
- MultiSelect
- Overlay 

#### Backward compatibility
- No breaking changes
- Existing behavior preserved when `overlayOptions.appendTo` is not set

> Migrated from `primefaces/primeng#19388` — originally by `@O2sa` on 2026-02-08

---
*Original base: `master` @ `f11b0ce`, head: `fix-overlayoptions-appendto` @ `cf976de`*