### PR TITLE
fix(datepicker): prevent hour jumping to 11 when at minDate boundary

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -2807,15 +2807,16 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
             true // intentional fall through
         ) {
             case isMinDate && minHoursExceeds12 && this.minDate!.getHours() === 12 && this.minDate!.getHours() > convertedHour:
-                returnTimeTriple[0] = 11;
+                this.setCurrentHourPM(this.minDate!.getHours());
+                returnTimeTriple[0] = this.currentHour || 0;
             case isMinDate && this.minDate!.getHours() === convertedHour && this.minDate!.getMinutes() > minute:
                 returnTimeTriple[1] = this.minDate!.getMinutes();
             case isMinDate && this.minDate!.getHours() === convertedHour && this.minDate!.getMinutes() === minute && this.minDate!.getSeconds() > second:
                 returnTimeTriple[2] = this.minDate!.getSeconds();
                 break;
             case isMinDate && !minHoursExceeds12 && this.minDate!.getHours() - 1 === convertedHour && this.minDate!.getHours() > convertedHour:
-                returnTimeTriple[0] = 11;
-                this.pm = true;
+                this.setCurrentHourPM(this.minDate!.getHours());
+                returnTimeTriple[0] = this.currentHour || 0;
             case isMinDate && this.minDate!.getHours() === convertedHour && this.minDate!.getMinutes() > minute:
                 returnTimeTriple[1] = this.minDate!.getMinutes();
             case isMinDate && this.minDate!.getHours() === convertedHour && this.minDate!.getMinutes() === minute && this.minDate!.getSeconds() > second:


### PR DESCRIPTION
Fixes #143

## Problem
When using `p-datepicker` with `showTime`, `hourFormat="24"`, and a 
`minDate` with hours ≤ 12, decrementing the hour past the minimum 
causes it to jump to 11 instead of staying at the minimum value.

## Root Cause
The `constrainTime` method contained two hardcoded `returnTimeTriple[0] = 11` 
values instead of using the actual `minDate.getHours()` value.

## Solution
Replaced hardcoded values with `setCurrentHourPM(this.minDate.getHours())` 
which correctly handles both 12h and 24h formats. This is consistent with 
the approach already used in other branches of the same switch statement.

> Migrated from `primefaces/primeng#19385` — originally by `@vitopio-prete` on 2026-02-07

---
*Original base: `master` @ `f11b0ce`, head: `fix/datepicker-hour-mindate-19336` @ `ad51388`*