### PR TITLE
fix(treeselect): add filter persistence and event emission for TreeSelect component | #19364

### DIFF
--- a/packages/primeng/src/treeselect/treeselect.spec.ts
+++ b/packages/primeng/src/treeselect/treeselect.spec.ts
@@ -1294,6 +1294,62 @@ describe('TreeSelect', () => {
             expect(treeSelectInstance.filterMode).toBe('lenient');
         });
 
+        it('should persist filter value when closing and reopening overlay', async () => {
+            testComponent.filter = true;
+            testComponent.resetFilterOnHide = false;
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const dropdown = testFixture.debugElement.query(By.css('.p-treeselect-dropdown'));
+            dropdown.nativeElement.click();
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            const treeSelectInstance = testFixture.debugElement.query(By.directive(TreeSelect)).componentInstance;
+
+            // Simulate filter input
+            treeSelectInstance.onFilterInput({ filter: 'Work', filteredValue: [] } as any);
+            testFixture.detectChanges();
+
+            expect(treeSelectInstance.filterValue).toBe('Work');
+
+            // Close overlay
+            dropdown.nativeElement.click();
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            // Reopen overlay
+            dropdown.nativeElement.click();
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            // Filter value should still be 'Work'
+            expect(treeSelectInstance.filterValue).toBe('Work');
+        });
+
+        it('should emit onFilter event when filter input changes', async () => {
+            testComponent.filter = true;
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const dropdown = testFixture.debugElement.query(By.css('.p-treeselect-dropdown'));
+            dropdown.nativeElement.click();
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            const treeSelectInstance = testFixture.debugElement.query(By.directive(TreeSelect)).componentInstance;
+
+            // Simulate filter event from Tree component
+            const filterEvent = { filter: 'Test', filteredValue: [] };
+            treeSelectInstance.onFilterInput(filterEvent as any);
+            testFixture.detectChanges();
+
+            expect(treeSelectInstance.filterValue).toBe('Test');
+            expect(testComponent.filterEvent).toEqual(filterEvent);
+        });
+
         it('should handle empty state properly', async () => {
             testComponent.options = [];
             testComponent.emptyMessage = 'No nodes available';

--- a/packages/primeng/src/treeselect/treeselect.ts
+++ b/packages/primeng/src/treeselect/treeselect.ts
@@ -172,6 +172,7 @@ const TREESELECT_INSTANCE = new InjectionToken<TreeSelect>('TREESELECT_INSTANCE'
                             [loading]="loading"
                             [filterInputAutoFocus]="filterInputAutoFocus"
                             [loadingMode]="loadingMode"
+                            (onFilter)="onFilterInput($event)"
                             [pt]="ptm('pcTree')"
                             [unstyled]="unstyled()"
                         >
@@ -739,7 +740,18 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
     onOverlayBeforeEnter() {
         if (this.filter) {
-            isNotEmpty(this.filterValue) && this.treeViewChild?._filter(<any>this.filterValue);
+            if (!isNotEmpty(this.filterValue)) {
+                return;
+            }
+
+            const treeFilterInput = this.treeViewChild?.filterViewChild?.nativeElement;
+
+            if (treeFilterInput) {
+                treeFilterInput.value = this.filterValue;
+            }
+
+            this.treeViewChild?._filter(<any>this.filterValue);
+
             this.filterInputAutoFocus && this.filterViewChild?.nativeElement.focus();
         } else {
             let focusableElements = <any>getFocusableElements(this.panelEl?.nativeElement!);
@@ -820,13 +832,9 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
         }
     }
 
-    onFilterInput(event: Event) {
-        this.filterValue = (event.target as HTMLInputElement).value;
-        this.treeViewChild?._filter(this.filterValue);
-        this.onFilter.emit({
-            filter: this.filterValue,
-            filteredValue: this.treeViewChild?.filteredNodes
-        });
+    onFilterInput(event: TreeFilterEvent) {
+        this.filterValue = event.filter;
+        this.onFilter.emit(event);
         setTimeout(() => {
             this.overlayViewChild?.alignOverlay();
         });
@@ -898,11 +906,9 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     }
 
     resetFilter() {
-        if (this.filter && !this.resetFilterOnHide) {
-            this.filteredNodes = this.treeViewChild?.filteredNodes;
-            this.treeViewChild?.resetFilter();
-        } else {
+        if (this.filter && this.resetFilterOnHide) {
             this.filterValue = null;
+            this.treeViewChild?.resetFilter();
         }
     }
 


### PR DESCRIPTION
# Bug Fix #138  : Filter Input Value Not Restored on TreeSelect Reopen

## 📋 Description

When using `[filter]="true"` with `[resetFilterOnHide]="false"` on `p-tree-select`, the **filter input value is not restored** when reopening the dropdown, even though the tree results remain filtered. This causes a confusing UX where users see filtered results but **no visible search term**.

## 🔄 Steps to Reproduce

1. Use `[filter]="true" [resetFilterOnHide]="false"` on `p-tree-select`
2. Open the dropdown
3. Type a search term (tree filters correctly)
4. Close the dropdown
5. Reopen the dropdown

### Expected Behavior ✅
Filter input shows the **previous search term**

### Actual Behavior ❌
Filter input is **empty**, but results are **still filtered**

## 🔍 Root Cause

The **TreeSelect component** doesn't preserve the filter input's visual value when `resetFilterOnHide` is `false`. While the filter logic persists, the input element value is cleared.

## ✨ Solution

The filter input value should be **restored** from the component's `filterValue` property when the dropdown reopens and `resetFilterOnHide` is `false`.

> Migrated from `primefaces/primeng#19384` — originally by `@mpozdal` on 2026-02-07

---
*Original base: `master` @ `f11b0ce`, head: `fix/issue-19364` @ `adfab7d`*