### PR TITLE
fix(Table): wrong cursor when pReorderableColumn is disabled

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -4378,7 +4378,8 @@ export class ResizableColumn extends BaseComponent {
     selector: '[pReorderableColumn]',
     standalone: false,
     host: {
-        '[class]': "cx('reorderableColumn')"
+        '[class]': "cx('reorderableColumn')",
+        '[style.cursor]': 'isEnabled() ? "move" : "default"'
     },
     providers: [TableStyle]
 })


### PR DESCRIPTION
Closes #132

> Migrated from `primefaces/primeng#19377` — originally by `@Relictus2911` on 2026-02-05

---
*Original base: `master` @ `f11b0ce`, head: `master` @ `7bc766c`*