### PR TITLE
isOutsideClicked method to check for pcoverlay

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -6233,6 +6233,7 @@ export class ColumnFilter extends BaseComponent {
         return !(
             findSingle((this.overlay as HTMLElement).nextElementSibling!, '[data-pc-section="filteroverlay"]') ||
             findSingle((this.overlay as HTMLElement).nextElementSibling!, '[data-pc-name="popover"]') ||
+            findSingle((this.overlay as HTMLElement).nextElementSibling!, '[data-pc-name="pcoverlay"]') ||
             this.overlay?.isSameNode(event.target) ||
             this.overlay?.contains(event.target) ||
             this.icon?.nativeElement.isSameNode(event.target) ||


### PR DESCRIPTION
Fixes #1047 

The overlays of the constraint and operator dropdown have this pc-name not popover. Without this fix the overlay closes when overlayAppendTo is set to body globally. 

Here is the reproducer: 
https://stackblitz.com/edit/github-xbd4newb

> Migrated from `primefaces/primeng#19370` — originally by `@denny99` on 2026-02-03

---
*Original base: `master` @ `f11b0ce`, head: `patch-1` @ `da5d7f0`*