### PR TITLE
Fix(Table): Correct column reorder drag logic in RTL mode

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -2699,28 +2699,36 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     onColumnDragEnter(event: any, dropHeader: any) {
         if (this.reorderableColumns && this.draggedColumn && dropHeader) {
             event.preventDefault();
+
             let containerOffset = DomHandler.getOffset(this.el?.nativeElement);
             let dropHeaderOffset = DomHandler.getOffset(dropHeader);
 
             if (this.draggedColumn != dropHeader) {
-                let dragIndex = DomHandler.indexWithinGroup(this.draggedColumn, 'preorderablecolumn');
-                let dropIndex = DomHandler.indexWithinGroup(dropHeader, 'preorderablecolumn');
+                const isRtl = getComputedStyle(this.el.nativeElement).direction === 'rtl';
+
                 let targetLeft = dropHeaderOffset.left - containerOffset.left;
-                let targetTop = containerOffset.top - dropHeaderOffset.top;
                 let columnCenter = dropHeaderOffset.left + dropHeader.offsetWidth / 2;
+
+                const isMouseOnRightSide = event.pageX > columnCenter;
+                const isNextSlot = (isMouseOnRightSide && !isRtl) || (!isMouseOnRightSide && isRtl);
 
                 (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top - (<number>this.reorderIconHeight - 1) + 'px';
                 (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top + dropHeader.offsetHeight + 'px';
 
-                if (event.pageX > columnCenter) {
-                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
-                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                let arrowPos = 0;
+
+                if (isNextSlot) {
                     this.dropPosition = 1;
+                    arrowPos = isRtl ? targetLeft : targetLeft + dropHeader.offsetWidth;
                 } else {
-                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
-                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
                     this.dropPosition = -1;
+                    arrowPos = isRtl ? targetLeft + dropHeader.offsetWidth : targetLeft;
                 }
+
+                const finalPx = arrowPos - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.left = finalPx;
+                (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.left = finalPx;
+
                 (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.display = 'block';
                 (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.display = 'block';
             } else {


### PR DESCRIPTION
### Related Issue
Closes #150

### Description
This PR fixes the column reordering logic when the document direction is RTL.

**The Problem:**
The `onColumnDragEnter` method calculated `dropPosition` based solely on LTR assumptions:
* `pageX > columnCenter` (Right Half) always meant `dropPosition = 1` (After).
* In RTL, the "Next" logical slot is to the left, and the "Previous" slot is to the right.

**The Fix:**
1. Added detection for `getComputedStyle().direction === 'rtl'`.
2. Inverted the `dropPosition` logic in RTL:
   * **Right Half:** Now sets `dropPosition = -1` (Before).
   * **Left Half:** Now sets `dropPosition = 1` (After).
3. Adjusted the arrow indicator (`reorderIndicatorUp/Down`) positioning:
   * Correctly calculates `style.left` based on the physical edge (Left vs. Right) corresponding to the logical "Before/After" position in the current text direction.

### Scope
- **Modified Component:** `Table` (specifically `onColumnDragEnter`).
- **Breaking Changes:** No.
- **Behavioral Changes:**
    - **RTL:** Drag-and-drop reordering now intuitively matches the visual cursor position.
    - **LTR:** No change to existing behavior.

### Visual Proof / Reproduction
Tested in RTL mode:
* Dragging a column to the right side of a target now correctly shows the indicator on the right edge (Before).
* Dragging a column to the left side of a target now correctly shows the indicator on the left edge (After).

> Migrated from `primefaces/primeng#19311` — originally by `@O2sa` on 2026-01-23

---
*Original base: `master` @ `0c92d37`, head: `fix/reorder-table-cols-rtl` @ `a11b77a`*