### PR TITLE
Fix Listbox checkbox toggle desync when clicking option label

### DIFF
--- a/packages/primeng/src/listbox/listbox.ts
+++ b/packages/primeng/src/listbox/listbox.ts
@@ -202,6 +202,7 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
                                         *ngIf="checkbox && multiple"
                                         styleClass="p-listbox-option-check-icon"
                                         [ngModel]="isSelected(option)"
+                                        [readonly]="true"
                                         [disabled]="disabled || isOptionDisabled(option)"
                                         [tabindex]="-1"
                                         [variant]="config.inputStyle() === 'filled' ? 'filled' : 'outlined' || config.inputVariant() === 'filled' ? 'filled' : 'outlined'"


### PR DESCRIPTION
### Bug Description
In `Listbox` with `multiple` selection enabled and `checkbox` mode active,
the checkbox visual state could become out of sync with the actual selected
option state.

When clicking on the option label or the `<li>` element, the selection was
updated correctly, but the checkbox component could toggle independently,
leading to an inconsistent UI state.

### Root Cause
`p-checkbox` was still handling its own internal toggle logic while the
Listbox component was also controlling selection state via option clicks.
This caused the checkbox to update separately from the Listbox selection
logic.

### Fix
The checkbox is now marked as `readonly` to prevent it from managing its
own state. The Listbox remains the single source of truth for selection,
and the checkbox becomes a purely visual indicator of the selected state.

```html
<p-checkbox
    ...
    [ngModel]="isSelected(option)"
    [readonly]="true"
    ...
>
```


### Reproduction Steps

Use p-listbox with multiple="true" and checkbox="true"

Click on the option label or list item

Observe checkbox toggling independently of selection state

### Affected Version

### PrimeNG 18.x

### Expected Behavior

Checkbox state should always stay in sync with the selected options.

> Migrated from `primefaces/primeng#19275` — originally by `@ValarMorghulis09` on 2026-01-12

---
*Original base: `v18-prod` @ `46109a1`, head: `fix/v18-listbox-checkbox-toggle-bug` @ `8cede0d`*