### PR TITLE
fix(treeselect): mark as touched on overlay hide

### DIFF
--- a/packages/primeng/src/treeselect/treeselect.spec.ts
+++ b/packages/primeng/src/treeselect/treeselect.spec.ts
@@ -669,6 +669,23 @@ describe('TreeSelect', () => {
             expect(treeSelectInstance.placeholder).toBe('Choose a tree node');
         });
 
+        it('should mark as touched on hide', async () => {
+            const treeSelectInstance = testFixture.debugElement.query(By.directive(TreeSelect)).componentInstance as any;
+
+            const touchedSpy = jasmine.createSpy('touched');
+            treeSelectInstance.registerOnTouched(touchedSpy);
+
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            treeSelectInstance.hide(new Event('hide'));
+
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            expect(touchedSpy).toHaveBeenCalled();
+        });
+
         it('should work with disabled state', async () => {
             testComponent.disabled = true;
             testFixture.changeDetectorRef.markForCheck();

--- a/packages/primeng/src/treeselect/treeselect.ts
+++ b/packages/primeng/src/treeselect/treeselect.ts
@@ -860,6 +860,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
         this.onHide.emit(event);
         this.cd.markForCheck();
+        this.onModelTouched?.();
     }
 
     clear(event: Event) {
@@ -1048,7 +1049,6 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     onInputBlur(event: Event) {
         this.focused = false;
         this.onBlur.emit(event);
-        this.onModelTouched();
     }
 
     /**


### PR DESCRIPTION
Fixes #575

- TreeSelect should not be marked as touched when overlay opens.
- Mark as touched when overlay hides (close).

Tests:
- pnpm --filter primeng test:unit -- --include="**/treeselect/*.spec.ts"

> Migrated from `primefaces/primeng#19264` — originally by `@moraisacr` on 2026-01-09

---
*Original base: `master` @ `5d830b1`, head: `fix/treeselect-touched-on-hide` @ `cefbc2f`*