### PR TITLE
fix(domhandler): respect theme prefix for anchor-gutter

### DIFF
--- a/packages/primeng/src/dom/domhandler.ts
+++ b/packages/primeng/src/dom/domhandler.ts
@@ -170,9 +170,9 @@ export class DomHandler {
         element.style.transformOrigin = origin;
 
         if (gutter) {
-            const gutterValue = getCSSVariableByRegex(/-anchor-gutter$/)?.value;
+            const gutterValue = getCSSVariableByRegex(/-anchor-gutter$/)?.value ?? '2px';
 
-            element.style.marginTop = origin === 'bottom' ? `calc(${gutterValue ?? '2px'} * -1)` : (gutterValue ?? '');
+            element.style.marginTop = origin === 'bottom' ? `calc(${gutterValue} * -1)` : `calc(${gutterValue})`;
         }
     }
 


### PR DESCRIPTION
### What’s changed
Ensures `relativePosition` uses the themed `--p-anchor-gutter` CSS variable when applying vertical gutter spacing.

### Why
The gutter value was previously ignored when a theme prefix was used, causing incorrect overlay positioning in themed setups.

### Tests
- Manual verification
- No existing unit tests cover this scenario

Fixes #440

> Migrated from `primefaces/primeng#19261` — originally by `@moraisacr` on 2026-01-08

---
*Original base: `master` @ `5d830b1`, head: `fix/domhandler-prefix-anchor-gutter` @ `1d628e2`*