### PR TITLE
Fix #16300 - Add isItemVisible to isValidItem check on Menu Item (Keyboard activates hidden items)

### DIFF
--- a/packages/primeng/src/contextmenu/contextmenu.ts
+++ b/packages/primeng/src/contextmenu/contextmenu.ts
@@ -851,7 +851,11 @@ export class ContextMenu extends BaseComponent<ContextMenuPassThrough> {
     }
 
     isValidItem(processedItem: any): boolean {
-        return !!processedItem && !this.isItemDisabled(processedItem.item) && !this.isItemSeparator(processedItem.item);
+        return !!processedItem && !this.isItemDisabled(processedItem.item) && !this.isItemSeparator(processedItem.item) && this.isItemVisible(processedItem.item);
+    }
+
+    isItemVisible(item: any): boolean {
+        return this.getItemProp(item, 'visible') !== false;
     }
 
     isItemDisabled(item: any): boolean {

--- a/packages/primeng/src/megamenu/megamenu.ts
+++ b/packages/primeng/src/megamenu/megamenu.ts
@@ -970,7 +970,11 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     }
 
     isValidItem(processedItem: any): boolean {
-        return !!processedItem && !this.isItemDisabled(processedItem.item) && !this.isItemSeparator(processedItem.item);
+        return !!processedItem && !this.isItemDisabled(processedItem.item) && !this.isItemSeparator(processedItem.item) && this.isItemVisible(processedItem.item);
+    }
+
+    isItemVisible(item: any): boolean {
+        return this.getItemProp(item, 'visible') !== false;
     }
 
     isItemDisabled(item: any): boolean {

--- a/packages/primeng/src/menubar/menubar.ts
+++ b/packages/primeng/src/menubar/menubar.ts
@@ -1009,7 +1009,11 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
     }
 
     isValidItem(processedItem: any): boolean {
-        return !!processedItem && !this.isItemDisabled(processedItem.item) && !this.isItemSeparator(processedItem.item);
+        return !!processedItem && !this.isItemDisabled(processedItem.item) && !this.isItemSeparator(processedItem.item) && this.isItemVisible(processedItem.item);
+    }
+
+    isItemVisible(item: any): boolean {
+        return this.getItemProp(item, 'visible') !== false;
     }
 
     isItemDisabled(item: any): boolean {


### PR DESCRIPTION
This PR fixes the issue #866

> Migrated from `primefaces/primeng#19216` — originally by `@devsarfo` on 2025-12-16

---
*Original base: `master` @ `314af74`, head: `fix/bst/16300-visible-item-check` @ `4d84683`*