### PR TITLE
fix: Keyfilter with regex on Android matches whole input instead of s…

### DIFF
--- a/packages/primeng/src/keyfilter/keyfilter.ts
+++ b/packages/primeng/src/keyfilter/keyfilter.ts
@@ -158,46 +158,28 @@ export class KeyFilter implements Validator {
         return delta;
     }
 
-    isValidChar(c: string) {
-        return (<RegExp>this.regex).test(c);
-    }
-
     isValidString(str: string) {
-        for (let i = 0; i < str.length; i++) {
-            if (!this.isValidChar(str.substr(i, 1))) {
-                return false;
-            }
-        }
-
-        return true;
+        return (<RegExp>this.regex).test(str);
     }
 
     @HostListener('input', ['$event'])
-    onInput(e: KeyboardEvent) {
+    onInput() {
         if (this.isAndroid && !this.pValidateOnly) {
             let val = this.el.nativeElement.value;
-            let lastVal = this.lastValue || '';
+            const lastVal = this.lastValue || '';
 
-            let inserted = this.findDelta(val, lastVal);
-            let removed = this.findDelta(lastVal, val);
-            let pasted = inserted.length > 1 || (!inserted && !removed);
+            const isValidString = (<RegExp>this.regex).test(val);
+            // Clearing the input shouldn't be blocked
+            const isInputEmpty = val.length == 0;
 
-            if (pasted) {
-                if (!this.isValidString(val)) {
-                    this.el.nativeElement.value = lastVal;
-                    this.ngModelChange.emit(lastVal);
-                }
-            } else if (!removed) {
-                if (!this.isValidChar(inserted)) {
-                    this.el.nativeElement.value = lastVal;
-                    this.ngModelChange.emit(lastVal);
-                }
+            if (!isValidString && !isInputEmpty) {
+                this.el.nativeElement.value = lastVal;
+                this.ngModelChange.emit(lastVal);
+                return;
             }
 
             val = this.el.nativeElement.value;
-            if (this.isValidString(val)) {
-                this.lastValue = val;
-            }
+            this.lastValue = val;
         }
     }
 


### PR DESCRIPTION
…ingle characters

### Defect Fixes
Fixes https://github.com/primefaces/primeng/issues/191

Note: This can only be tested on Android. I tested it on a Pixel 10 Android 16 Emulator, both on Chrome and in a custom Capacitor App.

> Migrated from `primefaces/primeng#19160` — originally by `@Thessi` on 2025-12-04

---
*Original base: `master` @ `1c57c58`, head: `keyfilter-android` @ `cd1d0ef`*