### PR TITLE
fix(panel-menu): Remove aria-controls attr when unneeded

### DIFF
--- a/packages/primeng/src/panelmenu/panelmenu.spec.ts
+++ b/packages/primeng/src/panelmenu/panelmenu.spec.ts
@@ -1050,6 +1050,7 @@ describe('PanelMenu', () => {
 
             const panelHeader = fixture.debugElement.query(By.css('[data-pc-section="header"]'));
             expect(panelHeader).toBeTruthy();
+            expect(panelHeader.nativeElement.getAttribute('aria-controls')).toBe(null);
 
             // Should not show expand/collapse icon for panels without items
             const headerIcons = panelHeader.queryAll(By.css('[data-p-icon]'));

--- a/packages/primeng/src/panelmenu/panelmenu.ts
+++ b/packages/primeng/src/panelmenu/panelmenu.ts
@@ -786,7 +786,7 @@ export class PanelMenuList extends BaseComponent {
                     [tooltipOptions]="getItemProp(item, 'tooltipOptions')"
                     [attr.aria-expanded]="isItemActive(item)"
                     [attr.aria-label]="getItemProp(item, 'label')"
-                    [attr.aria-controls]="getContentId(item, i)"
+                    [attr.aria-controls]="isItemGroup(item) ? getContentId(item, i) : null"
                     [attr.aria-disabled]="isItemDisabled(item)"
                     [attr.data-p-highlight]="isItemActive(item)"
                     [attr.data-p-disabled]="isItemDisabled(item)"


### PR DESCRIPTION
Remove unnecessary `aria-controls` attribute from the panel-menu if a panel has no items. This should prevent automated accessibility checkers like the one in the issue from flagging this

I've used the "ID reference" section on this page as reference: https://dequeuniversity.com/rules/axe/4.10/aria-valid-attr-value

Fixes issue: [#16447](https://github.com/primefaces/primeng/issues/16447)

> Migrated from `primefaces/primeng#19140` — originally by `@futa-ikeda` on 2025-12-01

---
*Original base: `master` @ `4eaef57`, head: `issue-16447` @ `3123f33`*