### PR TITLE
Add ngStyle binding to content wrapper div

### DIFF
--- a/packages/primeng/src/message/message.ts
+++ b/packages/primeng/src/message/message.ts
@@ -21,7 +21,7 @@ const MESSAGE_INSTANCE = new InjectionToken<Message>('MESSAGE_INSTANCE');
     standalone: true,
     imports: [CommonModule, TimesIcon, Ripple, SharedModule, Bind, MotionModule],
     template: `
-        <div [pBind]="ptm('contentWrapper')" [class]="cx('contentWrapper')" [attr.data-p]="dataP">
+        <div [pBind]="ptm('contentWrapper')" [ngStyle]="style" [class]="cx('contentWrapper')" [attr.data-p]="dataP">
             <div [pBind]="ptm('content')" [class]="cx('content')" [attr.data-p]="dataP">
                 @if (iconTemplate || _iconTemplate) {
                     <ng-container *ngTemplateOutlet="iconTemplate || _iconTemplate"></ng-container>


### PR DESCRIPTION
## Problem
The `style` input property is declared but never applied in the template. The `styleClass` input is applied to the host element, but users typically want to style the visible content wrapper.

## Current Behavior
```html

  Content

```
- `style` is ignored completely
- `styleClass="mt-2"` applies to `<p-message>` host, not the visible content div

## Expected Behavior
- `style` should apply inline styles to the content wrapper
- `styleClass` should apply classes to the content wrapper (where it's visually effective)

## Changes
- Added `[ngStyle]="style"` to content wrapper div
- Moved `styleClass` from host binding to content wrapper
- Host element retains only base component classes

## Breaking Changes
None - this fixes currently non-functional behavior

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

> Migrated from `primefaces/primeng#19121` — originally by `@Alex-stack-cell` on 2025-11-26

---
*Original base: `master` @ `66761b4`, head: `patch-1` @ `5203604`*