### PR TITLE
fix(#19075): autocomplete optionLabel for selected item with string values correctly displayed

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -919,7 +919,7 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
     }
 
     get optionValueSelected() {
-        return typeof this.modelValue() === 'string' && this.optionValue;
+        return typeof this.modelValue() === 'string' || this.optionValue;
     }
 
     chipItemClass(index) {


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/212

The current implementation of `get optionValueSelected()` does not make sense since why would you set `optionValue` if the value is a string? The `optionValue` property only really makes sense for object values.    
Therefore, we change the logical AND to a OR to solve the issue. Now, `optionLabel` is also applied correctly to the selected item if the value is a string.

> Migrated from `primefaces/primeng#19076` — originally by `@gianluca-moro` on 2025-11-10

---
*Original base: `master` @ `61d82a6`, head: `fix/19075/autocomplete-optionLabel` @ `822179d`*