### PR TITLE
fix(#16655): add handling for Tab key in input OTP component

### DIFF
--- a/packages/primeng/src/inputotp/inputotp.ts
+++ b/packages/primeng/src/inputotp/inputotp.ts
@@ -382,6 +382,9 @@ export class InputOtp extends BaseEditableHolder<InputOtpPassThrough> implements
 
                 break;
 
+            case 'Tab':
+                break;
+
             default:
                 if ((this.integerOnly && !(Number(event.key) >= 0 && Number(event.key) <= 9)) || (this.tokens.join('').length >= this.length && event.code !== 'Delete')) {
                     event.preventDefault();


### PR DESCRIPTION
This pull request resolves issue #16655. Although it had been merged previously, it appears the changes were not carried over to PrimeNG version 19 or later.

> Migrated from `primefaces/primeng#19073` — originally by `@ilcsikbence` on 2025-11-10

---
*Original base: `master` @ `61d82a6`, head: `patch-1` @ `d759e58`*