### PR TITLE
fix(context-menu): submenu position

### DIFF
--- a/packages/primeng/src/contextmenu/contextmenu.ts
+++ b/packages/primeng/src/contextmenu/contextmenu.ts
@@ -368,13 +368,17 @@ export class ContextMenuSub extends BaseComponent<ContextMenuPassThrough> implem
         const viewport = getViewport();
         const sublistWidth = sublist.offsetParent ? sublist.offsetWidth : getHiddenElementOuterWidth(sublist);
         const itemOuterWidth = <any>getOuterWidth(parentItem.children[0]);
-
-        sublist.style.top = '0px';
+        const sublistHeight = sublist.offsetParent ? sublist.offsetHeight : getHiddenElementOuterHeight(sublist);
 
         if (parseInt(containerOffset.left, 10) + itemOuterWidth + sublistWidth > viewport.width - calculateScrollbarWidth()) {
-            sublist.style.left = -1 * sublistWidth + 'px';
+            sublist.style.right = sublistWidth + 'px';
         } else {
             sublist.style.left = itemOuterWidth + 'px';
+        }
+        if (parseInt(containerOffset.top, 10) + sublistHeight > viewport.height - calculateScrollbarWidth()) {
+            sublist.style.bottom = '0px';
+        } else {
+            sublist.style.top = '0px';
         }
     }
 }


### PR DESCRIPTION
Compute the submenu position according to the remaining space between the parent item and the viewport edges
fix issue: https://github.com/primefaces/primeng/issues/221

> Migrated from `primefaces/primeng#19058` — originally by `@ftosolini` on 2025-11-03

---
*Original base: `master` @ `7bf0259`, head: `fix/contextMenu_submenu_position` @ `5eecaf5`*