### PR TITLE
fix(tooltip): use textContent instead of innerHTML for clearing escaped tooltip

### DIFF
--- a/packages/primeng/src/tooltip/tooltip.ts
+++ b/packages/primeng/src/tooltip/tooltip.ts
@@ -497,7 +497,7 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
             embeddedViewRef.detectChanges();
             embeddedViewRef.rootNodes.forEach((node) => this.tooltipText.appendChild(node));
         } else if (this.getOption('escape')) {
-            this.tooltipText.innerHTML = '';
+            this.tooltipText.textContent = '';
             this.tooltipText.appendChild(document.createTextNode(content));
         } else {
             this.tooltipText.innerHTML = content;


### PR DESCRIPTION
fixes https://github.com/primefaces/primeng/issues/223

> Migrated from `primefaces/primeng#19053` — originally by `@jase88` on 2025-11-01

---
*Original base: `master` @ `7bf0259`, head: `fix/tooltip-clearing` @ `728567f`*