### PR TITLE
feat(select): allow to not display overlay when typing on editable input

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -403,6 +403,12 @@ export class Select extends BaseInput implements OnInit, AfterViewInit, AfterCon
      */
     @Input({ transform: booleanAttribute }) editable: boolean | undefined;
     /**
+     * Determines whether the overlay panel should automatically open when the user types into an editable input.
+     * When set to `false`, typing in the editable input will not display the overlay automatically.
+     * @group Props
+     */
+    @Input({ transform: booleanAttribute }) overlayOnTyping: boolean = true;
+    /**
      * Index of the element in tabbing order.
      * @group Props
      */
@@ -1305,7 +1311,7 @@ export class Select extends BaseInput implements OnInit, AfterViewInit, AfterCon
             this.onChange.emit({ originalEvent: event, value: value });
         }, 1);
 
-        !this.overlayVisible && isNotEmpty(value) && this.show();
+        this.overlayOnTyping && !this.overlayVisible && isNotEmpty(value) && this.show();
     }
     /**
      * Displays the panel.
@@ -1479,7 +1485,7 @@ export class Select extends BaseInput implements OnInit, AfterViewInit, AfterCon
                 break;
 
             default:
-                if (!event.metaKey && isPrintableCharacter(event.key)) {
+                if (!event.metaKey && isPrintableCharacter(event.key) && this.overlayOnTyping) {
                     !this.overlayVisible && this.show();
                     !this.editable && this.searchOptions(event, event.key);
                 }
@@ -1728,7 +1734,7 @@ export class Select extends BaseInput implements OnInit, AfterViewInit, AfterCon
     onEnterKey(event, pressedInInput = false) {
         if (!this.overlayVisible) {
             this.focusedOptionIndex.set(-1);
-            this.onArrowDownKey(event);
+            this.overlayOnTyping && this.onArrowDownKey(event);
         } else {
             if (this.focusedOptionIndex() !== -1) {
                 const option = this.visibleOptions()[this.focusedOptionIndex()];
@@ -1783,7 +1789,7 @@ export class Select extends BaseInput implements OnInit, AfterViewInit, AfterCon
 
     onBackspaceKey(event: KeyboardEvent, pressedInInputText = false) {
         if (pressedInInputText) {
-            !this.overlayVisible && this.show();
+            this.overlayOnTyping && !this.overlayVisible && this.show();
         }
     }
 


### PR DESCRIPTION
Hello everyone,

In my project, I’ve been using the Dropdown component in editable mode, which is really handy.
However, after upgrading from version 16 to 17, 18, 19, and now 20, I noticed that the behavior of the Select component in editable mode has changed quite a bit.

Example in v16:
![Dropdown16](https://github.com/user-attachments/assets/a42abcdd-d023-47f5-ba9d-71fbb401ef86)

Example in v20:
![Dropdown20](https://github.com/user-attachments/assets/3cebc247-4bf0-4ad9-aa9b-31eb5dd257fe)

As you can see, the overlay now opens automatically as soon as you start typing in the input, which wasn’t the case in v16.
In my use case, this behavior isn’t ideal, and I believe it would be great to have an option to preserve the previous behavior while keeping the current one as the default.

That’s why I created this simple input property to control this behavior.

Thanks for your review

> Migrated from `primefaces/primeng#19003` — originally by `@Wadoks` on 2025-10-13

---
*Original base: `master` @ `2a26b6f`, head: `feat/p-select-overlay-on-typing` @ `3ae4fc9`*