### PR TITLE
fix: #18983, Select: Select is not clearable with keyboard

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -194,7 +194,7 @@ export class SelectItem extends BaseComponent {
             [attr.disabled]="$disabled() ? '' : undefined"
         />
         <ng-container *ngIf="isVisibleClearIcon">
-            <svg data-p-icon="times" [class]="cx('clearIcon')" (click)="clear($event)" *ngIf="!clearIconTemplate && !_clearIconTemplate" [attr.data-pc-section]="'clearicon'" />
+            <svg data-p-icon="times" [class]="cx('clearIcon')" (click)="clear($event)" *ngIf="!clearIconTemplate && !_clearIconTemplate" [attr.data-pc-section]="'clearicon'" [attr.tabindex]="0" (keydown)="onClearIconKeyDown($event)"/>
             <span [class]="cx('clearIcon')" (click)="clear($event)" *ngIf="clearIconTemplate || _clearIconTemplate" [attr.data-pc-section]="'clearicon'">
                 <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate; context: { class: cx('clearIcon') }"></ng-template>
             </span>
@@ -1490,6 +1490,12 @@ export class Select extends BaseInput implements OnInit, AfterViewInit, AfterCon
         this.clicked.set(false);
     }
 
+    onClearIconKeyDown(event: KeyboardEvent) {
+        if (event.code === 'Enter' || event.code === 'Space') {
+            this.clear(event);
+        }
+    }
+    
     onFilterKeyDown(event) {
         switch (event.code) {
             case 'ArrowDown':

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -194,7 +194,7 @@ export class SelectItem extends BaseComponent {
             [attr.disabled]="$disabled() ? '' : undefined"
         />
         <ng-container *ngIf="isVisibleClearIcon">
-            <svg data-p-icon="times" [class]="cx('clearIcon')" (click)="clear($event)" *ngIf="!clearIconTemplate && !_clearIconTemplate" [attr.data-pc-section]="'clearicon'" [attr.tabindex]="0" (keydown)="onClearIconKeyDown($event)"/>
+            <svg data-p-icon="times" [class]="cx('clearIcon')" (click)="clear($event)" *ngIf="!clearIconTemplate && !_clearIconTemplate" [attr.data-pc-section]="'clearicon'" [attr.tabindex]="0" (keydown)="onClearIconKeyDown($event)" />
             <span [class]="cx('clearIcon')" (click)="clear($event)" *ngIf="clearIconTemplate || _clearIconTemplate" [attr.data-pc-section]="'clearicon'">
                 <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate; context: { class: cx('clearIcon') }"></ng-template>
             </span>
@@ -1495,7 +1495,7 @@ export class Select extends BaseInput implements OnInit, AfterViewInit, AfterCon
             this.clear(event);
         }
     }
-    
+
     onFilterKeyDown(event) {
         switch (event.code) {
             case 'ArrowDown':


### PR DESCRIPTION
fix: #253, Select: Select is not clearable with keyboard

When using a Select-component with showClear set to true, it is possible to clear the select by clicking the clear button. However, the clear button is not accessible with the keyboard. This means that keyboard-only users are not able to clear the select.

**Steps to reproduce the behavior**
Go to https://primeng.org/select#clearicon or Add a Select with the showClear property set to true.
Select a value in the Select.
Try to clear the value using the keyboard.
It is not possible to focus the clear button with the keyboard or to clear the select in any other way.
**Expected behavior**
It is possible to focus the clear button with the keyboard so that keyboard users get the same experience as mouse users.

> Migrated from `primefaces/primeng#18984` — originally by `@akshayaqburst` on 2025-10-06

---
*Original base: `master` @ `0a576c7`, head: `master` @ `c329757`*