### PR TITLE
Fixed an issue that the drawer always opens from the left after fulls…

### DIFF
--- a/packages/primeng/src/drawer/drawer.ts
+++ b/packages/primeng/src/drawer/drawer.ts
@@ -266,6 +266,8 @@ export class Drawer extends BaseComponent implements AfterViewInit, AfterContent
 
     container: Nullable<HTMLDivElement>;
 
+    defaultTransformOptions: any = 'translate3d(-100%, 0px, 0px)';
+
     transformOptions: any = defaultTransformOptions;
 
     mask: Nullable<HTMLDivElement>;
@@ -277,8 +279,6 @@ export class Drawer extends BaseComponent implements AfterViewInit, AfterContent
     animationEndListener: VoidListener;
 
     _componentStyle = inject(DrawerStyle);
-
-    defaultTransformOptions = 'translate3d(-100%, 0px, 0px)';
 
     ngAfterViewInit() {
         super.ngAfterViewInit();

--- a/packages/primeng/src/drawer/drawer.ts
+++ b/packages/primeng/src/drawer/drawer.ts
@@ -35,7 +35,6 @@ const showAnimation = animation([style({ transform: '{{transform}}', opacity: 0 
 
 const hideAnimation = animation([animate('{{transition}}', style({ transform: '{{transform}}', opacity: 0 }))]);
 
-const defaultTransformOptions = 'translate3d(-100%, 0px, 0px)';
 /**
  * Sidebar is a panel component displayed as an overlay at the edges of the screen.
  * @group Components
@@ -217,7 +216,7 @@ export class Drawer extends BaseComponent implements AfterViewInit, AfterContent
         if (value === true) {
             this.transformOptions = 'none';
         } else {
-            this.transformOptions = defaultTransformOptions;
+            this.transformOptions = this.defaultTransformOptions;
         }
     }
     /**
@@ -278,6 +277,8 @@ export class Drawer extends BaseComponent implements AfterViewInit, AfterContent
     animationEndListener: VoidListener;
 
     _componentStyle = inject(DrawerStyle);
+
+    defaultTransformOptions = 'translate3d(-100%, 0px, 0px)';
 
     ngAfterViewInit() {
         super.ngAfterViewInit();

--- a/packages/primeng/src/drawer/drawer.ts
+++ b/packages/primeng/src/drawer/drawer.ts
@@ -191,18 +191,19 @@ export class Drawer extends BaseComponent implements AfterViewInit, AfterContent
         }
         switch (value) {
             case 'left':
-                this.transformOptions = 'translate3d(-100%, 0px, 0px)';
+                this.defaultTransformOptions  = 'translate3d(-100%, 0px, 0px)';
                 break;
             case 'right':
-                this.transformOptions = 'translate3d(100%, 0px, 0px)';
+                this.defaultTransformOptions  = 'translate3d(100%, 0px, 0px)';
                 break;
             case 'bottom':
-                this.transformOptions = 'translate3d(0px, 100%, 0px)';
+                this.defaultTransformOptions  = 'translate3d(0px, 100%, 0px)';
                 break;
             case 'top':
-                this.transformOptions = 'translate3d(0px, -100%, 0px)';
+                this.defaultTransformOptions  = 'translate3d(0px, -100%, 0px)';
                 break;
         }
+        this.transformOptions = this.defaultTransformOptions;
     }
     /**
      * Adds a close icon to the header to hide the dialog.

--- a/packages/primeng/src/drawer/drawer.ts
+++ b/packages/primeng/src/drawer/drawer.ts
@@ -268,7 +268,7 @@ export class Drawer extends BaseComponent implements AfterViewInit, AfterContent
 
     defaultTransformOptions: any = 'translate3d(-100%, 0px, 0px)';
 
-    transformOptions: any = defaultTransformOptions;
+    transformOptions: any = this.defaultTransformOptions;
 
     mask: Nullable<HTMLDivElement>;
 


### PR DESCRIPTION
…creen.

Adds on https://github.com/primefaces/primeng/pull/18512 to fix an issue that the drawer defaults to opening from the left after fullscreen.

Issue: https://github.com/primefaces/primeng/issues/264

> Migrated from `primefaces/primeng#18964` — originally by `@mabakl` on 2025-10-01

---
*Original base: `master` @ `9255fd4`, head: `master` @ `7874cfc`*