### PR TITLE
feat(split-button): expose type of the button

### DIFF
--- a/packages/primeng/src/splitbutton/splitbutton.spec.ts
+++ b/packages/primeng/src/splitbutton/splitbutton.spec.ts
@@ -1160,6 +1160,15 @@ describe('SplitButton', () => {
 
             expect(splitButtonInstance.buttonProps).toBeDefined();
             expect(splitButtonInstance.buttonProps['ariaLabel']).toBe('Custom aria label');
+            expect(splitButtonInstance.buttonProps['type']).toBe('button');
+
+            component.buttonProps = {
+                type: 'submit'
+            };
+            fixture.detectChanges();
+
+            expect(splitButtonInstance.buttonProps).toBeDefined();
+            expect(splitButtonInstance.buttonProps['type']).toBe('submit');
         });
 
         it('should handle menuButtonProps', () => {

--- a/packages/primeng/src/splitbutton/splitbutton.ts
+++ b/packages/primeng/src/splitbutton/splitbutton.ts
@@ -44,7 +44,7 @@ type SplitButtonIconPosition = 'left' | 'right';
         <ng-container *ngIf="contentTemplate || _contentTemplate; else defaultButton">
             <button
                 [class]="cx('pcButton')"
-                type="button"
+                [type]="buttonProps?.['type'] || 'button'"
                 pButton
                 pRipple
                 [severity]="severity"
@@ -68,7 +68,7 @@ type SplitButtonIconPosition = 'left' | 'right';
             <button
                 #defaultbtn
                 [class]="cx('pcButton')"
-                type="button"
+                [type]="buttonProps?.['type'] || 'button'"
                 pButton
                 pRipple
                 [severity]="severity"
@@ -88,7 +88,7 @@ type SplitButtonIconPosition = 'left' | 'right';
             ></button>
         </ng-template>
         <button
-            type="button"
+            [type]="buttonProps?.['type'] || 'button'"
             pButton
             pRipple
             [size]="size"


### PR DESCRIPTION
* Fixes #291.

Is it possible to also apply this change to branch v19?

Thank's

> Migrated from `primefaces/primeng#18914` — originally by `@Garfield-fr` on 2025-09-23

---
*Original base: `master` @ `b82ad00`, head: `split-button-expose-type` @ `12f0324`*