### PR TITLE
fix: Use p-footer content again in confirm dialogs if present

### DIFF
--- a/packages/primeng/src/confirmdialog/confirmdialog.ts
+++ b/packages/primeng/src/confirmdialog/confirmdialog.ts
@@ -98,7 +98,7 @@ const hideAnimation = animation([animate('{{transition}}', style({ transform: '{
                     <ng-content select="p-footer"></ng-content>
                     <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
                 }
-                @if (!footerTemplate && !_footerTemplate) {
+                @if (!footer && !footerTemplate && !_footerTemplate) {
                     <p-button
                         *ngIf="option('rejectVisible')"
                         [label]="rejectButtonLabel"

--- a/packages/primeng/src/confirmdialog/confirmdialog.ts
+++ b/packages/primeng/src/confirmdialog/confirmdialog.ts
@@ -94,7 +94,7 @@ const hideAnimation = animation([animate('{{transition}}', style({ transform: '{
                 </ng-template>
             }
             <ng-template #footer>
-                @if (footerTemplate || _footerTemplate) {
+                @if (footer || footerTemplate || _footerTemplate) {
                     <ng-content select="p-footer"></ng-content>
                     <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
                 }


### PR DESCRIPTION
Closes #290

> Migrated from `primefaces/primeng#18911` — originally by `@dgiessing` on 2025-09-23

---
*Original base: `master` @ `45037c5`, head: `patch-1` @ `84ad688`*