### PR TITLE
fix: autocomplete form submit when pressing enter (take 2)

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -1383,25 +1383,20 @@ export class AutoComplete extends BaseInput implements AfterViewChecked, AfterCo
     }
 
     onEnterKey(event) {
-        if (!this.typeahead) {
-            if (this.multiple) {
-                if (!this.isSelected(event.target.value)) {
-                    this.updateModel([...(this.modelValue() || []), event.target.value]);
-                    this.inputEL.nativeElement.value = '';
-                }
-            }
+        if (this.overlayVisible || this.multiple) {
+            event.preventDefault();
         }
-        if (!this.overlayVisible) {
-            return;
-        } else {
+        if (this.typeahead) {
             if (this.focusedOptionIndex() !== -1) {
                 this.onOptionSelect(event, this.visibleOptions()[this.focusedOptionIndex()]);
             }
-
             this.hide();
+        } else if (this.multiple) {
+            if (!this.isSelected(event.target.value)) {
+                this.updateModel([...(this.modelValue() || []), event.target.value]);
+                this.inputEL.nativeElement.value = '';
+            }
         }
-
-        event.preventDefault();
     }
 
     onEscapeKey(event) {


### PR DESCRIPTION
Since #18373, [Enter] has triggered a form submit even if [multiple]="true". `event.preventDefault()` should be called not only when the overlay is visible, but also when multiple selections are allowed.

> Migrated from `primefaces/primeng#18896` — originally by `@perceptron8` on 2025-09-18

---
*Original base: `master` @ `677fc09`, head: `fix/autocomplete-onEnterKey` @ `95ea592`*