### PR TITLE
Full height for p-button within an inputgroup

### DIFF
--- a/packages/primeng/src/inputgroup/style/inputgroupstyle.ts
+++ b/packages/primeng/src/inputgroup/style/inputgroupstyle.ts
@@ -18,6 +18,10 @@ const theme = /*css*/ `
         margin: 0;
     }
 
+    .p-inputgroup p-button {
+        height: 100%;
+    }
+
     .p-inputgroup p-button:first-child,
     .p-inputgroup p-button:last-child {
         display: inline-flex;


### PR DESCRIPTION
Before:
<img width="1004" height="122" alt="image" src="https://github.com/user-attachments/assets/ee8b12da-86c1-4885-a1ef-40438ff14fe4" />

After:
<img width="1000" height="122" alt="image" src="https://github.com/user-attachments/assets/2c0c625c-ff7d-4a4c-9efc-fd6eb4a42a57" />

closes #298

> Migrated from `primefaces/primeng#18887` — originally by `@chdanielmueller` on 2025-09-18

---
*Original base: `master` @ `40c82bc`, head: `feature/InputGroupAddonButtonStyle` @ `acfdf29`*