### PR TITLE
Fix stop characters from being shifted to the left on InputMask

### DIFF
--- a/packages/primeng/src/inputmask/inputmask.ts
+++ b/packages/primeng/src/inputmask/inputmask.ts
@@ -658,6 +658,12 @@ export class InputMask extends BaseInput implements OnInit, AfterContentInit {
                 this.buffer[i] = this.getPlaceholder(i);
                 while (pos++ < test.length) {
                     c = test.charAt(pos - 1);
+                    if (c === this.getPlaceholder(i)) {
+                        lastMatch = i;
+                        if (!this.keepBuffer) {
+                            i = this.len; // Empty slot. Stop processing.
+                        }
+                    }
                     if (this.tests[i].test(c)) {
                         if (!this.keepBuffer) {
                             this.buffer[i] = c;


### PR DESCRIPTION
## What is the purpose of this PR?
Fixes issue where characters entered in the middle of an input mask are shifted to the left when auto clear is on.

## This addresses the existing issue [#792 ]
## Changes made
Checks if the input character matches the placeholder and if so, does not continue through the input looking for a valid character.

> Migrated from `primefaces/primeng#18844` — originally by `@kandresJH` on 2025-09-04

---
*Original base: `master` @ `73c7593`, head: `issue-16605` @ `ce78c3f`*