### PR TITLE
docs(#18733): fix DatePicker Stackblitz demos

### DIFF
--- a/apps/showcase/components/doc/codeeditor/templates.ts
+++ b/apps/showcase/components/doc/codeeditor/templates.ts
@@ -1057,6 +1057,7 @@ import { DynamicDialogModule } from 'primeng/dynamicdialog';
 import { EditorModule } from 'primeng/editor';
 import { FieldsetModule } from 'primeng/fieldset';
 import { FileUploadModule } from 'primeng/fileupload';
+import { FluidModule } from 'primeng/fluid';
 import { FocusTrapModule } from 'primeng/focustrap';
 import { GalleriaModule } from 'primeng/galleria';
 import { IftaLabelModule } from 'primeng/iftalabel';
@@ -1122,6 +1123,7 @@ import { InputIconModule } from 'primeng/inputicon';
 import { DrawerModule } from 'primeng/drawer';
 import { KeyFilterModule } from 'primeng/keyfilter';
 import { ThemeSwitcher } from './themeswitcher';
+import { MessageService } from 'primeng/api';
 
     ${serviceImports}
 
@@ -1163,6 +1165,7 @@ import { ThemeSwitcher } from './themeswitcher';
     EditorModule,
     FieldsetModule,
     FileUploadModule,
+    FluidModule,
     FocusTrapModule,
     GalleriaModule,
     IftaLabelModule,
@@ -1265,6 +1268,7 @@ import { ThemeSwitcher } from './themeswitcher';
     EditorModule,
     FieldsetModule,
     FileUploadModule,
+    FluidModule,
     FocusTrapModule,
     GalleriaModule,
     IftaLabelModule,
@@ -1330,7 +1334,10 @@ import { ThemeSwitcher } from './themeswitcher';
     AutoFocusModule,
     OverlayBadgeModule,
           ],
-      providers: [ ${providers} ]
+      providers: [
+        MessageService,
+        ${providers}
+      ]
     })
     export class ImportsModule {}
     `;

--- a/apps/showcase/doc/datepicker/basicdoc.ts
+++ b/apps/showcase/doc/datepicker/basicdoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-basic-demo',
+    selector: 'date-picker-basic-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" />
         </div>
-        <app-code [code]="code" selector="datepicker-basic-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-basic-demo"></app-code>
     `
 })
 export class BasicDoc {
@@ -29,8 +29,8 @@ import { DatePicker } from 'primeng/datepicker';
 import { FormsModule } from '@angular/forms';
 
 @Component({
-    selector: 'datepicker-basic-demo',
-    templateUrl: './datepicker-basic-demo.html',
+    selector: 'date-picker-basic-demo',
+    templateUrl: './date-picker-basic-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/buttonbardoc.ts
+++ b/apps/showcase/doc/datepicker/buttonbardoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-buttonbar-demo',
+    selector: 'date-picker-buttonbar-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" [showButtonBar]="true" />
         </div>
-        <app-code [code]="code" selector="datepicker-buttonbar-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-buttonbar-demo"></app-code>
     `
 })
 export class ButtonBarDoc {
@@ -29,8 +29,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-buttonbar-demo',
-    templateUrl: './datepicker-buttonbar-demo.html',
+    selector: 'date-picker-buttonbar-demo',
+    templateUrl: './date-picker-buttonbar-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/datetemplatedoc.ts
+++ b/apps/showcase/doc/datepicker/datetemplatedoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-datetemplate-demo',
+    selector: 'date-picker-datetemplate-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -16,7 +16,7 @@ import { Component } from '@angular/core';
                 </ng-template>
             </p-datepicker>
         </div>
-        <app-code [code]="code" selector="datepicker-datetemplate-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-datetemplate-demo"></app-code>
     `
 })
 export class DateTemplateDoc {
@@ -44,8 +44,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePickerModule } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-datetemplate-demo',
-    templateUrl: './datepicker-datetemplate-demo.html',
+    selector: 'date-picker-datetemplate-demo',
+    templateUrl: './date-picker-datetemplate-demo.html',
     standalone: true,
     imports: [FormsModule, DatePickerModule]
 })

--- a/apps/showcase/doc/datepicker/disableddoc.ts
+++ b/apps/showcase/doc/datepicker/disableddoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-disabled-demo',
+    selector: 'date-picker-disabled-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" [disabled]="true" />
         </div>
-        <app-code [code]="code" selector="datepicker-disabled-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-disabled-demo"></app-code>
     `
 })
 export class DisabledDoc {
@@ -29,8 +29,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-disabled-demo',
-    templateUrl: './datepicker-disabled-demo.html',
+    selector: 'date-picker-disabled-demo',
+    templateUrl: './date-picker-disabled-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/filleddoc.ts
+++ b/apps/showcase/doc/datepicker/filleddoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-filled-demo',
+    selector: 'date-picker-filled-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" variant="filled" />
         </div>
-        <app-code [code]="code" selector="datepicker-filled-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-filled-demo"></app-code>
     `
 })
 export class FilledDoc {
@@ -29,8 +29,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-filled-demo',
-    templateUrl: './datepicker-filled-demo.html',
+    selector: 'date-picker-filled-demo',
+    templateUrl: './date-picker-filled-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/floatlabeldoc.ts
+++ b/apps/showcase/doc/datepicker/floatlabeldoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-float-label-demo',
+    selector: 'date-picker-float-label-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -27,7 +27,7 @@ import { Component } from '@angular/core';
                 <label for="on_label">On Label</label>
             </p-floatlabel>
         </div>
-        <app-code [code]="code" selector="datepicker-float-label-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-float-label-demo"></app-code>
     `
 })
 export class FloatLabelDoc {
@@ -76,8 +76,8 @@ import { DatePicker } from 'primeng/datepicker';
 import { FloatLabel } from 'primeng/floatlabel';
 
 @Component({
-    selector: 'datepicker-float-label-demo',
-    templateUrl: './datepicker-float-label-demo.html',
+    selector: 'date-picker-float-label-demo',
+    templateUrl: './date-picker-float-label-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker, FloatLabel]
 })

--- a/apps/showcase/doc/datepicker/formatdoc.ts
+++ b/apps/showcase/doc/datepicker/formatdoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-format-demo',
+    selector: 'date-picker-format-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -30,7 +30,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" dateFormat="dd.mm.yy" />
         </div>
-        <app-code [code]="code" selector="datepicker-format-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-format-demo"></app-code>
     `
 })
 export class FormatDoc {
@@ -48,8 +48,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-format-demo',
-    templateUrl: './datepicker-format-demo.html',
+    selector: 'date-picker-format-demo',
+    templateUrl: './date-picker-format-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/icondoc.ts
+++ b/apps/showcase/doc/datepicker/icondoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-icon-demo',
+    selector: 'date-picker-icon-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -28,7 +28,7 @@ import { Component } from '@angular/core';
                 </p-datepicker>
             </div>
         </p-fluid>
-        <app-code [code]="code" selector="datepicker-icon-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-icon-demo"></app-code>
     `
 })
 export class IconDoc {
@@ -76,8 +76,8 @@ import { FormsModule } from '@angular/forms';
 import { FluidModule } from 'primeng/fluid';
 
 @Component({
-    selector: 'datepicker-icon-demo',
-    templateUrl: './datepicker-icon-demo.html',
+    selector: 'date-picker-icon-demo',
+    templateUrl: './date-picker-icon-demo.html',
     standalone: true,
     imports: [DatePickerModule, FormsModule, FluidModule]
 })

--- a/apps/showcase/doc/datepicker/iftalabeldoc.ts
+++ b/apps/showcase/doc/datepicker/iftalabeldoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-ifta-label-demo',
+    selector: 'date-picker-ifta-label-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -14,7 +14,7 @@ import { Component } from '@angular/core';
                 <label for="date">Date</label>
             </p-iftalabel>
         </div>
-        <app-code [code]="code" selector="datepicker-ifta-label-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-ifta-label-demo"></app-code>
     `
 })
 export class IftaLabelDoc {
@@ -39,12 +39,12 @@ import { DatePickerModule } from 'primeng/datepicker';
 import { IftaLabelModule } from 'primeng/iftalabel';
 
 @Component({
-    selector: 'datepicker-ifta-label-demo',
-    templateUrl: './datepicker-ifta-label-demo.html',
+    selector: 'date-picker-ifta-label-demo',
+    templateUrl: './date-picker-ifta-label-demo.html',
     standalone: true,
     imports: [FormsModule, DatePickerModule, IftaLabelModule]
 })
-export class DatepickerIftaLabelDemo {
+export class DatePickerIftaLabelDemo {
     value: Date | undefined;
 }`
     };

--- a/apps/showcase/doc/datepicker/importdoc.ts
+++ b/apps/showcase/doc/datepicker/importdoc.ts
@@ -1,7 +1,7 @@
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 @Component({
-    selector: 'datepicker-import-doc',
+    selector: 'date-picker-import-doc',
     standalone: false,
     template: ` <app-code [code]="code" [hideToggleCode]="true"></app-code> `
 })

--- a/apps/showcase/doc/datepicker/inlinedoc.ts
+++ b/apps/showcase/doc/datepicker/inlinedoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-inline-demo',
+    selector: 'date-picker-inline-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker class="max-w-full" [(ngModel)]="date" [inline]="true" [showWeek]="true" />
         </div>
-        <app-code [code]="code" selector="datepicker-inline-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-inline-demo"></app-code>
     `
 })
 export class InlineDoc {
@@ -29,8 +29,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-inline-demo',
-    templateUrl: './datepicker-inline-demo.html',
+    selector: 'date-picker-inline-demo',
+    templateUrl: './date-picker-inline-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/invaliddoc.ts
+++ b/apps/showcase/doc/datepicker/invaliddoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-invalid-demo',
+    selector: 'date-picker-invalid-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -12,7 +12,7 @@ import { Component } from '@angular/core';
             <p-datepicker [(ngModel)]="date1" [invalid]="!date1" placeholder="Date" />
             <p-datepicker [(ngModel)]="date2" [invalid]="!date2" variant="filled" placeholder="Date" />
         </div>
-        <app-code [code]="code" selector="datepicker-invalid-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-invalid-demo"></app-code>
     `
 })
 export class InvalidDoc {
@@ -34,14 +34,13 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-invalid-demo',
-    templateUrl: './datepicker-invalid-demo.html',
+    selector: 'date-picker-invalid-demo',
+    templateUrl: './date-picker-invalid-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })
 export class DatePickerInvalidDemo {
     date1: Date | undefined;
-    
     date2: Date | undefined;
 }`
     };

--- a/apps/showcase/doc/datepicker/localedoc.ts
+++ b/apps/showcase/doc/datepicker/localedoc.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-local-demo',
+    selector: 'date-picker-local-demo',
     standalone: false,
     template: `
         <app-docsectiontext>

--- a/apps/showcase/doc/datepicker/minmaxdox.ts
+++ b/apps/showcase/doc/datepicker/minmaxdox.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-minmax-demo',
+    selector: 'date-picker-minmax-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" [minDate]="minDate" [maxDate]="maxDate" [readonlyInput]="true" />
         </div>
-        <app-code [code]="code" selector="datepicker-minmax-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-minmax-demo"></app-code>
     `
 })
 export class MinMaxDoc {
@@ -49,8 +49,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-minmax-demo',
-    templateUrl: './datepicker-minmax-demo.html',
+    selector: 'date-picker-minmax-demo',
+    templateUrl: './date-picker-minmax-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/monthdoc.ts
+++ b/apps/showcase/doc/datepicker/monthdoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-month-demo',
+    selector: 'date-picker-month-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" view="month" dateFormat="mm/yy" [readonlyInput]="true" />
         </div>
-        <app-code [code]="code" selector="datepicker-month-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-month-demo"></app-code>
     `
 })
 export class MonthDoc {
@@ -29,8 +29,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-month-demo',
-    templateUrl: './datepicker-month-demo.html',
+    selector: 'date-picker-month-demo',
+    templateUrl: './date-picker-month-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/multipledoc.ts
+++ b/apps/showcase/doc/datepicker/multipledoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-multiple-demo',
+    selector: 'date-picker-multiple-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="dates" selectionMode="multiple" [readonlyInput]="true" />
         </div>
-        <app-code [code]="code" selector="datepicker-multiple-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-multiple-demo"></app-code>
     `
 })
 export class MultipleDoc {
@@ -29,8 +29,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-multiple-demo',
-    templateUrl: './datepicker-multiple-demo.html',
+    selector: 'date-picker-multiple-demo',
+    templateUrl: './date-picker-multiple-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/multiplemonths.doc.ts
+++ b/apps/showcase/doc/datepicker/multiplemonths.doc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-multiplemonths-demo',
+    selector: 'date-picker-multiplemonths-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" [numberOfMonths]="2" />
         </div>
-        <app-code [code]="code" selector="datepicker-multiplemonths-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-multiplemonths-demo"></app-code>
     `
 })
 export class MultipleMonthDoc {
@@ -28,8 +28,8 @@ export class MultipleMonthDoc {
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-multiplemonths-demo',
-    templateUrl: './datepicker-multiplemonths-demo.html',
+    selector: 'date-picker-multiplemonths-demo',
+    templateUrl: './date-picker-multiplemonths-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/rangedoc.ts
+++ b/apps/showcase/doc/datepicker/rangedoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-range-demo',
+    selector: 'date-picker-range-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="rangeDates" selectionMode="range" [readonlyInput]="true" />
         </div>
-        <app-code [code]="code" selector="datepicker-range-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-range-demo"></app-code>
     `
 })
 export class RangeDoc {
@@ -29,8 +29,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-range-demo',
-    templateUrl: './datepicker-range-demo.html',
+    selector: 'date-picker-range-demo',
+    templateUrl: './date-picker-range-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/reactiveformsdoc.ts
+++ b/apps/showcase/doc/datepicker/reactiveformsdoc.ts
@@ -22,7 +22,7 @@ import { MessageService } from 'primeng/api';
                 <button pButton severity="secondary" type="submit"><span pButtonLabel>Submit</span></button>
             </form>
         </div>
-        <app-code [code]="code" selector="datepicker-reactive-forms-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-reactive-forms-demo"></app-code>
     `
 })
 export class ReactiveFormsDoc {
@@ -63,7 +63,8 @@ export class ReactiveFormsDoc {
     <button pButton severity="secondary" type="submit"><span pButtonLabel>Submit</span></button>
 </form>`,
 
-        html: `<div class="card flex justify-center">
+        html: `<p-toast />
+<div class="card flex justify-center">
     <form [formGroup]="exampleForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-4">
         <div class="flex flex-col gap-1">
             <p-datepicker formControlName="selectedDate" [invalid]="isInvalid('selectedDate')" />
@@ -81,10 +82,11 @@ import { DatePickerModule } from 'primeng/datepicker';
 import { MessageModule } from 'primeng/message';
 import { ToastModule } from 'primeng/toast';
 import { ButtonModule } from 'primeng/button';
+import { MessageService } from 'primeng/api';
 
 @Component({
-    selector: 'datepicker-reactive-forms-demo',
-    templateUrl: './datepicker-reactive-forms-demo.html',
+    selector: 'date-picker-reactive-forms-demo',
+    templateUrl: './date-picker-reactive-forms-demo.html',
     standalone: true,
     imports: [ReactiveFormsModule, DatePickerModule, MessageModule, ToastModule, ButtonModule]
 })

--- a/apps/showcase/doc/datepicker/sizesdoc.ts
+++ b/apps/showcase/doc/datepicker/sizesdoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-sizes-demo',
+    selector: 'date-picker-sizes-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -13,7 +13,7 @@ import { Component } from '@angular/core';
             <p-datepicker [(ngModel)]="value2" placeholder="Normal" showIcon iconDisplay="input" />
             <p-datepicker [(ngModel)]="value3" size="large" placeholder="Large" showIcon iconDisplay="input" />
         </div>
-        <app-code [code]="code" selector="datepicker-sizes-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-sizes-demo"></app-code>
     `
 })
 export class SizesDoc {
@@ -39,8 +39,8 @@ import { DatePicker } from 'primeng/datepicker';
 import { FormsModule } from '@angular/forms';
 
 @Component({
-    selector: 'datepicker-sizes-demo',
-    templateUrl: './datepicker-sizes-demo.html',
+    selector: 'date-picker-sizes-demo',
+    templateUrl: './date-picker-sizes-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/styledoc.ts
+++ b/apps/showcase/doc/datepicker/styledoc.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-style-doc',
+    selector: 'date-picker-style-doc',
     standalone: false,
     template: `
         <app-docsectiontext>

--- a/apps/showcase/doc/datepicker/templatedrivenformsdoc.ts
+++ b/apps/showcase/doc/datepicker/templatedrivenformsdoc.ts
@@ -20,7 +20,7 @@ import { MessageService } from 'primeng/api';
             </form>
         </div>
 
-        <app-code [code]="code" selector="datepicker-template-driven-forms-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-template-driven-forms-demo"></app-code>
     `
 })
 export class TemplateDrivenFormsDoc {
@@ -68,8 +68,8 @@ import { MessageService } from 'primeng/api';
 import { FormsModule } from '@angular/forms';
 
 @Component({
-    selector: 'datepicker-template-driven-forms-demo',
-    templateUrl: './datepicker-template-driven-forms-demo.html',
+    selector: 'date-picker-template-driven-forms-demo',
+    templateUrl: './date-picker-template-driven-forms-demo.html',
     standalone: true,
     imports: [FormsModule, DatePickerModule, MessageModule, ToastModule, ButtonModule]
 })

--- a/apps/showcase/doc/datepicker/timedoc.ts
+++ b/apps/showcase/doc/datepicker/timedoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-time-demo',
+    selector: 'date-picker-time-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -12,11 +12,11 @@ import { Component } from '@angular/core';
         <p-fluid class="card flex flex-wrap gap-4">
             <div class="flex-auto">
                 <label for="calendar-12h" class="font-bold block mb-2"> 12h Format </label>
-                <p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" [hourFormat]="12" />
+                <p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" hourFormat="12" />
             </div>
             <div class="flex-auto">
                 <label for="calendar-24h" class="font-bold block mb-2"> 24h Format </label>
-                <p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" [hourFormat]="24" />
+                <p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" hourFormat="24" />
             </div>
             <div class="flex-auto">
                 <label for="calendar-timeonly" class="font-bold block mb-2"> Time Only </label>
@@ -24,7 +24,7 @@ import { Component } from '@angular/core';
             </div>
         </p-fluid>
 
-        <app-code [code]="code" selector="datepicker-time-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-time-demo"></app-code>
     `
 })
 export class TimeDoc {
@@ -44,11 +44,11 @@ export class TimeDoc {
         html: `<p-fluid class="card flex flex-wrap gap-4">
     <div class="flex-auto">
         <label for="calendar-12h" class="font-bold block mb-2"> 12h Format </label>
-        <p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" [hourFormat]="12" />
+        <p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" hourFormat="12" />
     </div>
     <div class="flex-auto">
         <label for="calendar-24h" class="font-bold block mb-2"> 24h Format </label>
-        <p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" [hourFormat]="24" />
+        <p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" hourFormat="24" />
     </div>
     <div class="flex-auto">
         <label for="calendar-timeonly" class="font-bold block mb-2"> Time Only </label>
@@ -62,8 +62,8 @@ import { DatePicker } from 'primeng/datepicker';
 import { Fluid } from 'primeng/fluid';
 
 @Component({
-    selector: 'datepicker-time-demo',
-    templateUrl: './datepicker-time-demo.html',
+    selector: 'date-picker-time-demo',
+    templateUrl: './date-picker-time-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker, Fluid]
 })

--- a/apps/showcase/doc/datepicker/touchuidoc.ts
+++ b/apps/showcase/doc/datepicker/touchuidoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-touchui-demo',
+    selector: 'date-picker-touchui-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" [touchUI]="true" [readonlyInput]="true" />
         </div>
-        <app-code [code]="code" selector="datepicker-touchui-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-touchui-demo"></app-code>
     `
 })
 export class TouchUIDoc {
@@ -35,8 +35,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-touchui-demo',
-    templateUrl: './datepicker-touchui-demo.html',
+    selector: 'date-picker-touchui-demo',
+    templateUrl: './date-picker-touchui-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })

--- a/apps/showcase/doc/datepicker/yeardoc.ts
+++ b/apps/showcase/doc/datepicker/yeardoc.ts
@@ -2,7 +2,7 @@ import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'datepicker-year-demo',
+    selector: 'date-picker-year-demo',
     standalone: false,
     template: `
         <app-docsectiontext>
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" view="year" dateFormat="yy" />
         </div>
-        <app-code [code]="code" selector="datepicker-year-demo"></app-code>
+        <app-code [code]="code" selector="date-picker-year-demo"></app-code>
     `
 })
 export class YearDoc {
@@ -29,8 +29,8 @@ import { FormsModule } from '@angular/forms';
 import { DatePicker } from 'primeng/datepicker';
 
 @Component({
-    selector: 'datepicker-year-demo',
-    templateUrl: './datepicker-year-demo.html',
+    selector: 'date-picker-year-demo',
+    templateUrl: './date-picker-year-demo.html',
     standalone: true,
     imports: [FormsModule, DatePicker]
 })


### PR DESCRIPTION
Fixes #18733 

The DatePicker stackblitz demos used to fail to compile because it was using a wrong class name (e.g., `DatepickerIconDemo` instead of `DatePickerIconDemo`) and thus the import in `main.ts` would fail.

Note that the selector naming matters because the class name will be derived from it when creating the stackblitz demo. See: https://github.com/primefaces/primeng/blob/d870d5f7c47d557634d85f75f4662441e0cf6a36/apps/showcase/components/doc/codeeditor/templates.ts#L65-L70

I also added the `MessageService` to the `providers` in the `imports.ts` class because many demos use this service but would currently fail since it was nowhere injected.

> Migrated from `primefaces/primeng#18738` — originally by `@gianluca-moro` on 2025-08-09

---
*Original base: `master` @ `d870d5f`, head: `docs/18733/datepicker-stackblitz-demo` @ `fee0617`*