### PR TITLE
DatePicker: Range that spans to previous / next month isn't completely shown

### DIFF
--- a/packages/primeng/src/datepicker/style/datepickerstyle.ts
+++ b/packages/primeng/src/datepicker/style/datepickerstyle.ts
@@ -65,7 +65,7 @@ const classes = {
     day: ({ instance, date }) => {
         let selectedDayClass = '';
 
-        if (instance.isRangeSelection() && instance.isSelected(date) && date.selectable) {
+        if (instance.isRangeSelection() && instance.isSelected(date)) {
             const startDate = instance.value[0];
             const endDate = instance.value[1];
 


### PR DESCRIPTION
See [GitHub issue 18666](https://github.com/primefaces/primeng/issues/379).

The other days shown in a month sheet, that aren't part of the currently shown month, but are part of the range, should have the same selected style as the other days.

I'm not super familiar with the code base, but I think just removing the one part of the `if` condition might work.

> Migrated from `primefaces/primeng#18716` — originally by `@nur-psoehnlein` on 2025-07-31

---
*Original base: `master` @ `d870d5f`, head: `feature/datepicker-range-styling` @ `51a86a0`*