### PR TITLE
fix: Use checkboxicon template for checkbox custom templates

### DIFF
--- a/packages/primeng/src/listbox/listbox.ts
+++ b/packages/primeng/src/listbox/listbox.ts
@@ -85,7 +85,7 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
                     [binary]="true"
                 >
                     <ng-container *ngIf="checkIconTemplate || _checkIconTemplate">
-                        <ng-template #icon>
+                        <ng-template #checkboxicon>
                             <ng-template *ngTemplateOutlet="checkIconTemplate || _checkIconTemplate; context: { $implicit: allSelected() }"></ng-template>
                         </ng-template>
                     </ng-container>
@@ -238,7 +238,7 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
                                         [binary]="true"
                                     >
                                         <ng-container *ngIf="checkIconTemplate || _checkIconTemplate">
-                                            <ng-template #icon>
+                                            <ng-template #checkboxicon>
                                                 <ng-template *ngTemplateOutlet="checkIconTemplate || _checkIconTemplate; context: { $implicit: isSelected(option) }"></ng-template>
                                             </ng-template>
                                         </ng-container>

--- a/packages/primeng/src/tree/tree.ts
+++ b/packages/primeng/src/tree/tree.ts
@@ -128,7 +128,7 @@ import {
                         (click)="$event.preventDefault()"
                     >
                         <ng-container *ngIf="tree.checkboxIconTemplate || tree._checkboxIconTemplate">
-                            <ng-template #icon>
+                            <ng-template #checkboxicon>
                                 <ng-template
                                     *ngTemplateOutlet="
                                         tree.checkboxIconTemplate || tree._checkboxIconTemplate;


### PR DESCRIPTION
## Reason
The Checkbox component uses the template `checkboxicon` for templates. ([here](https://github.com/primefaces/primeng/blob/2eadd866d26c954285b600973e41085241ff25c1/packages/primeng/src/checkbox/checkbox.ts#L213)).
The template `icon` works only with the `pTemplate` template variant (which is [deprecated ](https://primeng.org/migration/v20#:~:text=ng%2Dtemplate%20with%20a%20template%20reference%20variable)with V20)
With that PR `checkboxIcon` templates in `listbox` and ``tree` will work again!


## Implementation
This pull request focuses on renaming template references in the `listbox` and `tree` components to improve code clarity and consistency. The most significant changes involve updating the `#icon` template references to `#checkboxicon` in multiple locations.

### Changes to template references:

* [`packages/primeng/src/listbox/listbox.ts`](diffhunk://#diff-6d97e1927ee35bfa5063b90341778f4ad0ca15e022cefa951a2d096a2141a8fdL88-R88): Renamed the `#icon` template reference to `#checkboxicon` in two instances, ensuring consistency when rendering the checkbox icon for selection states. [[1]](diffhunk://#diff-6d97e1927ee35bfa5063b90341778f4ad0ca15e022cefa951a2d096a2141a8fdL88-R88) [[2]](diffhunk://#diff-6d97e1927ee35bfa5063b90341778f4ad0ca15e022cefa951a2d096a2141a8fdL241-R241)
* [`packages/primeng/src/tree/tree.ts`](diffhunk://#diff-d48f02c9b168f4742ca24807a6a9b0c91dea071b139c6138125763215a7fe6fbL131-R131): Renamed the `#icon` template reference to `#checkboxicon` for the checkbox icon template in the tree component.

resolves #18675

> Migrated from `primefaces/primeng#18678` — originally by `@feitzi` on 2025-07-23

---
*Original base: `master` @ `2eadd86`, head: `primneng-bug-18675` @ `f01ee73`*