### PR TITLE
Including autoDisplay in condition for showing submenu of root menu

### DIFF
--- a/packages/primeng/src/tieredmenu/tieredmenu.ts
+++ b/packages/primeng/src/tieredmenu/tieredmenu.ts
@@ -742,7 +742,7 @@ export class TieredMenu extends BaseComponent implements OnInit, OnDestroy {
 
     onItemMouseEnter(event: any) {
         if (!isTouchDevice()) {
-            if (this.dirty) {
+            if (this.dirty || this.autoDisplay) {
                 this.onItemChange(event, 'hover');
             }
         } else {


### PR DESCRIPTION
This is a fix for [Issue 17341](https://github.com/primefaces/primeng/issues/655)

> Migrated from `primefaces/primeng#18608` — originally by `@SanzSeraph` on 2025-07-15

---
*Original base: `master` @ `d5bb989`, head: `tieredmenu-autoDisplay` @ `0be40f9`*