### PR TITLE
fix: Popover arrow dynamic alignment

### DIFF
--- a/packages/primeng/src/popover/popover.ts
+++ b/packages/primeng/src/popover/popover.ts
@@ -22,7 +22,7 @@ import {
     ViewEncapsulation,
     ViewRef
 } from '@angular/core';
-import { absolutePosition, addClass, appendChild, findSingle, getOffset, isIOS, isTouchDevice } from '@primeuix/utils';
+import { absolutePosition, addClass, appendChild, findSingle, getOffset, isIOS, isTouchDevice, removeClass } from '@primeuix/utils';
 import { OverlayService, PrimeTemplate, SharedModule } from 'primeng/api';
 import { BaseComponent } from 'primeng/basecomponent';
 import { ConnectedOverlayScrollHandler } from 'primeng/dom';
@@ -336,9 +336,12 @@ export class Popover extends BaseComponent implements AfterContentInit, OnDestro
         }
         this.container?.style.setProperty($dt('popover.arrow.left').name, `${arrowLeft}px`);
 
-        if (containerOffset.top < targetOffset.top) {
-            this.container.setAttribute('data-p-popover-flipped', 'true');
+        const flipped = containerOffset.top < targetOffset.top;
+        this.container.setAttribute('data-p-popover-flipped', Boolean(flipped).toString());
+        if (flipped) {
             addClass(this.container, 'p-popover-flipped');
+        } else {
+            removeClass(this.container, 'p-popover-flipped');
         }
     }
 


### PR DESCRIPTION
When dynamically positioning a popover (via calling `align()` - as per https://primeng.org/popover#datatable). It is possible that the popover arrow is rendered on the wrong end of the popover. The offset of the popover is also affected.

This PR adjusts what end of the popover to display the arrow on when `.align()`is called.

### Defect Fixes
(https://github.com/primefaces/primeng/issues/398)

> Migrated from `primefaces/primeng#18565` — originally by `@blakejolley` on 2025-07-07

---
*Original base: `master` @ `0f68211`, head: `feature/fix-18565-Popover-dynamic-arrow-alignment` @ `2bc9d05`*