### PR TITLE
improve severity type for toast

### DIFF
--- a/packages/primeng/src/api/toastmessage.ts
+++ b/packages/primeng/src/api/toastmessage.ts
@@ -4,7 +4,7 @@
  */
 export interface ToastMessageOptions {
     text?: any;
-    severity?: string;
+    severity?: 'success' | 'info' | 'error' | 'warn';
     summary?: string;
     detail?: string;
     id?: any;


### PR DESCRIPTION
Improve `severity` field type for Toast/MessageService.

> Migrated from `primefaces/primeng#18550` — originally by `@imaksp` on 2025-07-03

---
*Original base: `master` @ `620ecb8`, head: `patch-3` @ `57670b3`*