### PR TITLE
fix(multiselect): display the correct icons when chips are enabled

### DIFF
--- a/apps/showcase/doc/api-generator/index.json
+++ b/apps/showcase/doc/api-generator/index.json
@@ -20447,6 +20447,13 @@
                             "description": "Icon class of the chip icon."
                         },
                         {
+                            "name": "removeTokenIcon",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "string",
+                            "description": "Icon class of the remove token icon."
+                        },
+                        {
                             "name": "optionLabel",
                             "optional": false,
                             "readonly": false,

--- a/apps/showcase/doc/apidoc/index.json
+++ b/apps/showcase/doc/apidoc/index.json
@@ -18315,6 +18315,13 @@
                             "description": "Icon class of the chip icon."
                         },
                         {
+                            "name": "removeTokenIcon",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "string",
+                            "description": "Icon class of the remove token icon."
+                        },
+                        {
                             "name": "optionLabel",
                             "optional": false,
                             "readonly": false,

--- a/apps/showcase/doc/multiselect/chipsdoc.ts
+++ b/apps/showcase/doc/multiselect/chipsdoc.ts
@@ -14,7 +14,7 @@ interface City {
             <p>Selected values are displayed as a comma separated list by default, setting <i>display</i> as <i>chip</i> displays them as chips.</p>
         </app-docsectiontext>
         <div class="card flex justify-center">
-            <p-multiselect [options]="cities" [(ngModel)]="selectedCities" placeholder="Select Cities" optionLabel="name" display="chip" class="w-full md:w-80" />
+            <p-multiselect [options]="cities" [(ngModel)]="selectedCities" placeholder="Select Cities" optionLabel="name" display="chip" chipIcon="pi pi-map" removeTokenIcon="pi pi-times" class="w-full md:w-80" />
         </div>
         <app-code [code]="code" selector="multi-select-chips-demo"></app-code>
     `
@@ -35,10 +35,10 @@ export class ChipsDoc implements OnInit {
     }
 
     code: Code = {
-        basic: `<p-multiselect [options]="cities" [(ngModel)]="selectedCities" placeholder="Select Cities" optionLabel="name" display="chip" class="w-full md:w-80" />`,
+        basic: `<p-multiselect [options]="cities" [(ngModel)]="selectedCities" placeholder="Select Cities" optionLabel="name" display="chip" chipIcon="pi pi-map" removeTokenIcon="pi pi-times" class="w-full md:w-80" />`,
 
         html: `<div class="card flex justify-center">
-    <p-multiselect [options]="cities" [(ngModel)]="selectedCities" placeholder="Select Cities" optionLabel="name" display="chip" class="w-full md:w-80" />
+    <p-multiselect [options]="cities" [(ngModel)]="selectedCities" placeholder="Select Cities" optionLabel="name" display="chip" chipIcon="pi pi-map" removeTokenIcon="pi pi-times" class="w-full md:w-80" />
 </div>`,
 
         typescript: `import { Component, OnInit } from '@angular/core';

--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -201,13 +201,26 @@ export class MultiSelectItem extends BaseComponent {
                             {{ getSelectedItemsLabel() }}
                         } @else {
                             <div #token *ngFor="let item of chipSelectedItems(); let i = index" [class]="cx('chipItem')">
-                                <p-chip [class]="cx('pcChip')" [label]="getLabelByValue(item)" [removable]="!$disabled() && !readonly" (onRemove)="removeOption(item, $event)" [removeIcon]="chipIcon">
-                                    <ng-container *ngIf="chipIconTemplate || _chipIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate">
+                                <p-chip [class]="cx('pcChip')" [label]="getLabelByValue(item)" [removable]="!disabled() && !readonly" (onRemove)="removeOption(item, $event)" [icon]="chipIcon" [removeIcon]="removeTokenIcon">
+                                    <ng-container *ngIf="chipIconTemplate || _chipIconTemplate">
+                                        <ng-template #chipicon>
+                                            <ng-container *ngIf="!disabled() && !readonly">
+                                                <span
+                                                    [class]="cx('chipIcon')"
+                                                    *ngIf="chipIconTemplate || _chipIconTemplate"
+                                                    [attr.aria-hidden]="true"
+                                                >
+                                                    <ng-container *ngTemplateOutlet="chipIconTemplate || _chipIconTemplate; context: { class: 'p-multiselect-chip-icon' }"></ng-container>
+                                                </span>
+                                            </ng-container>
+                                        </ng-template>
+                                    </ng-container>
+                                    <ng-container *ngIf="removeTokenIconTemplate || _removeTokenIconTemplate">
                                         <ng-template #removeicon>
                                             <ng-container *ngIf="!$disabled() && !readonly">
                                                 <span
                                                     [class]="cx('chipIcon')"
-                                                    *ngIf="chipIconTemplate || _chipIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate"
+                                                    *ngIf="removeTokenIconTemplate || _removeTokenIconTemplate"
                                                     (click)="removeOption(item, $event)"
                                                     [attr.data-pc-section]="'clearicon'"
                                                     [attr.aria-hidden]="true"
@@ -565,10 +578,15 @@ export class MultiSelect extends BaseEditableHolder implements OnInit, AfterView
      */
     @Input() dropdownIcon: string | undefined;
     /**
-     * Icon class of the chip icon.
+     * Icon class of the chip component.
      * @group Props
      */
     @Input() chipIcon: string | undefined;
+    /**
+     * Icon class of the remove token of the chip component.
+     * @group Props
+     */
+    @Input() removeTokenIcon: string | undefined;
     /**
      * Name of the label field of an option.
      * @group Props


### PR DESCRIPTION
Currently when using `display="chip"` with the multiselect and passing in an icon to the `chipIcon` input the multiselect will render the icon as the remove icon instead.

Adding a new input for `removeTokenIcon` and adjusting the template to properly handle a custom chip icon as well as custom remove icon

### Defect Fixes
https://github.com/primefaces/primeng/issues/399

> Migrated from `primefaces/primeng#18548` — originally by `@dangelojesse` on 2025-07-02

---
*Original base: `master` @ `54d7d43`, head: `feature/multiselectChipIcons` @ `5bda042`*