### PR TITLE
fix: fix dropdownStyle imports to avoid circular imports

### DIFF
--- a/packages/primeng/src/dropdown/style/dropdownstyle.ts
+++ b/packages/primeng/src/dropdown/style/dropdownstyle.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { css, dt } from '@primeng/themes';
+import { css, dt } from '@primeuix/styled';
 import { style } from '@primeuix/styles/select';
 import { BaseStyle } from 'primeng/base';
 /**


### PR DESCRIPTION
### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

> Migrated from `primefaces/primeng#18471` — originally by `@EphraimHaber` on 2025-06-09

---
*Original base: `master` @ `c950fd5`, head: `bugfix/dropdown-invalid-imports` @ `eaca26b`*