### PR TITLE
fix(datepicker): fix locales strings "AM"/"PM" in 12hr format

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -405,7 +405,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                         <ChevronUpIcon *ngIf="!incrementIconTemplate && !_incrementIconTemplate" />
                         <ng-template *ngTemplateOutlet="incrementIconTemplate || _incrementIconTemplate"></ng-template>
                     </p-button>
-                    <span>{{ pm ? 'PM' : 'AM' }}</span>
+                    <span>{{ pm ? getTranslation('pm') : getTranslation('am') }}</span>
                     <p-button size="small" text rounded [styleClass]="cx('pcDecrementButton')" (keydown)="onContainerButtonKeydown($event)" (click)="toggleAMPM($event)" (keydown.enter)="toggleAMPM($event)" [attr.aria-label]="getTranslation('pm')">
                         <ChevronDownIcon *ngIf="!decrementIconTemplate && !_decrementIconTemplate" />
                         <ng-template *ngTemplateOutlet="decrementIconTemplate || _decrementIconTemplate"></ng-template>
@@ -3373,7 +3373,7 @@ export class DatePicker extends BaseInput implements OnInit, AfterContentInit, A
         }
 
         if (this.hourFormat == '12') {
-            output += date.getHours() > 11 ? ' PM' : ' AM';
+            output += date.getHours() > 11 ? ` this.getTranslation('pm')` : ` this.getTranslation('am')`;
         }
 
         return output;


### PR DESCRIPTION
Fix locales of 12 hour format (word 'AM' and 'PM')

fixes: #437

> Migrated from `primefaces/primeng#18453` — originally by `@Jimmy-sheep` on 2025-06-05

---
*Original base: `master` @ `4319cfc`, head: `patch-1` @ `28ba98e`*