### PR TITLE
fix(multiselect): add `disabled` binding to checkbox in disabled options

### DIFF
--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -82,7 +82,7 @@ export const MULTISELECT_VALUE_ACCESSOR: any = {
     standalone: true,
     imports: [CommonModule, Checkbox, FormsModule, SharedModule],
     template: `
-        <p-checkbox [ngModel]="selected" [binary]="true" [tabindex]="-1" [variant]="variant" [ariaLabel]="label" [pt]="getPTOptions('pcOptionCheckbox')" [unstyled]="unstyled()">
+        <p-checkbox [disabled]="disabled ?? false" [ngModel]="selected" [binary]="true" [tabindex]="-1" [variant]="variant" [ariaLabel]="label" [pt]="getPTOptions('pcOptionCheckbox')" [unstyled]="unstyled()">
             <ng-container *ngIf="itemCheckboxIconTemplate">
                 <ng-template #icon let-klass="class">
                     <ng-template *ngTemplateOutlet="itemCheckboxIconTemplate; context: { checked: selected, class: klass }"></ng-template>


### PR DESCRIPTION
Fixes primefaces#18449

> Migrated from `primefaces/primeng#18450` — originally by `@Will-Smith-007` on 2025-06-04

---
*Original base: `master` @ `22d9ca1`, head: `fix/multiselect-checkbox-option-disabling` @ `5c3b8e3`*