### PR TITLE
feat(multiselect): Add tooltip support for options

### DIFF
--- a/apps/showcase/doc/multiselect/tooltipdoc.ts
+++ b/apps/showcase/doc/multiselect/tooltipdoc.ts
@@ -1,0 +1,82 @@
+import { Code } from '@/domain/code';
+import { Component, OnInit } from '@angular/core';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { MultiSelectModule } from 'primeng/multiselect';
+import { FormsModule } from '@angular/forms';
+import { AppCode } from '@/components/doc/app.code';
+
+interface City {
+    name: string;
+    code: string;
+    disabled: boolean;
+    disabledTooltip?: string;
+}
+
+@Component({
+    selector: 'tooltip-doc',
+    imports: [MultiSelectModule, AppDocSectionText, FormsModule, AppCode],
+    template: `
+        <app-docsectiontext>
+            <p>Tooltips can be defined for specific options.</p>
+        </app-docsectiontext>
+        <div class="card flex justify-center">
+            <p-multiselect [options]="cities" [(ngModel)]="selectedCities" optionDisabled="disabled" optionTooltip="disabledTooltip" optionLabel="name" placeholder="Select Cities" [maxSelectedLabels]="4" styleClass="w-full md:w-80" />
+        </div>
+        <app-code [code]="code" selector="multi-select-tooltip-demo"></app-code>
+    `
+})
+export class TooltipDoc implements OnInit {
+    cities!: City[];
+
+    selectedCities!: any[];
+
+    ngOnInit() {
+        this.cities = [
+            { name: 'New York', code: 'NY', disabled: false },
+            { name: 'Rome', code: 'RM', disabled: false },
+            { name: 'London', code: 'LDN', disabled: false },
+            { name: 'Istanbul', code: 'IST', disabled: true, disabledTooltip: 'Currently in maintenance' },
+            { name: 'Paris', code: 'PRS', disabled: false }
+        ];
+    }
+
+    code: Code = {
+        html: `<div class="card flex justify-center">
+    <p-multiselect [options]="cities" [(ngModel)]="selectedCities" optionDisabled="disabled" optionTooltip="disabledTooltip" optionLabel="name" placeholder="Select Cities" [maxSelectedLabels]="4" styleClass="w-full md:w-80" />
+</div>`,
+
+        typescript: `import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MultiSelectModule } from 'primeng/multiselect';
+
+interface City {
+    name: string;
+    code: string;
+    disabled: boolean;
+    disabledTooltip?: string;
+}
+
+@Component({
+    selector: 'multi-select-tooltip-demo',
+    templateUrl: './multi-select-tooltip-demo.html',
+    standalone: true,
+    imports: [FormsModule, MultiSelectModule]
+})
+export class MultiSelectTooltipDemo implements OnInit {
+
+    cities!: City[];
+
+    selectedCities!: City[];
+
+    ngOnInit() {
+        this.cities = [
+            { name: 'New York', code: 'NY', disabled: false },
+            { name: 'Rome', code: 'RM', disabled: false },
+            { name: 'London', code: 'LDN', disabled: false },
+            { name: 'Istanbul', code: 'IST', disabled: true, disabledTooltip: 'Currently in maintenance' },
+            { name: 'Paris', code: 'PRS', disabled: false }
+        ];
+    }
+}`
+    };
+}

--- a/apps/showcase/pages/multiselect/index.ts
+++ b/apps/showcase/pages/multiselect/index.ts
@@ -20,6 +20,7 @@ import { FluidDoc } from '@/doc/multiselect/fluid-doc';
 import { PTComponent } from '@/doc/multiselect/pt/PTComponent';
 import { Component } from '@angular/core';
 import { AppDoc } from '@/components/doc/app.doc';
+import { TooltipDoc } from '@/doc/multiselect/tooltipdoc';
 
 @Component({
     template: `<app-doc
@@ -124,6 +125,11 @@ export class MultiSelectDemo {
                 { id: 'templatedriven', label: 'Template Driven', component: TemplateDrivenFormsDoc },
                 { id: 'reactive', label: 'Reactive Forms', component: ReactiveFormsDoc }
             ]
+        },
+        {
+            id: 'tooltip',
+            label: 'Tooltip',
+            component: TooltipDoc
         },
         {
             id: 'accessibility',

--- a/apps/showcase/public/llms/components/multiselect.md
+++ b/apps/showcase/public/llms/components/multiselect.md
@@ -849,6 +849,7 @@ MultiSelect is used to select multiple items from a collection.
 | optionLabel | string | - | Name of the label field of an option. |
 | optionValue | string | - | Name of the value field of an option. |
 | optionDisabled | string | - | Name of the disabled field of an option. |
+| optionTooltip  | string | - | Name of the tooltip field of an option. |
 | optionGroupLabel | string | label | Name of the label field of an option group. |
 | optionGroupChildren | string | items | Name of the options field of an option group. |
 | showHeader | boolean | true | Whether to show the header. |

--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -426,6 +426,8 @@ export class MultiSelectItem extends BaseComponent {
                                             [selected]="isSelected(option)"
                                             [label]="getOptionLabel(option)"
                                             [disabled]="isOptionDisabled(option)"
+                                            [pTooltip]="getOptionTooltip(option)"
+                                            tooltipPosition="top"
                                             [template]="itemTemplate || _itemTemplate"
                                             [itemCheckboxIconTemplate]="itemCheckboxIconTemplate || _itemCheckboxIconTemplate"
                                             [itemSize]="scrollerOptions.itemSize"
@@ -645,6 +647,11 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
      * @group Props
      */
     @Input() optionDisabled: string | undefined;
+    /**
+     * Name of the tooltip field of an option.
+     * @group Props
+     */
+    @Input() optionTooltip: string | undefined;
     /**
      * Name of the label field of an option group.
      * @group Props
@@ -1523,6 +1530,10 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
             return true;
         }
         return this.optionDisabled ? resolveFieldData(option, this.optionDisabled) : option && option.disabled !== undefined ? option.disabled : false;
+    }
+
+    getOptionTooltip(option: any) {
+        return this.optionTooltip ? resolveFieldData(option, this.optionTooltip) : null;
     }
 
     isSelected(option) {


### PR DESCRIPTION
I've created a feature request about this: https://github.com/orgs/primefaces/discussions/4063

> Migrated from `primefaces/primeng#18433` — originally by `@Will-Smith-007` on 2025-06-02

---
*Original base: `master` @ `22d9ca1`, head: `feature/support-tooltip-for-multiselect-items` @ `c793c87`*