### PR TITLE
feat(select): Add tooltip support for options

### DIFF
--- a/apps/showcase/doc/select/tooltipdoc.ts
+++ b/apps/showcase/doc/select/tooltipdoc.ts
@@ -1,0 +1,82 @@
+import { Code } from '@/domain/code';
+import { Component, OnInit } from '@angular/core';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { SelectModule } from 'primeng/select';
+import { AppCode } from '@/components/doc/app.code';
+import { FormsModule } from '@angular/forms';
+
+interface City {
+    name: string;
+    code: string;
+    disabled: boolean;
+    disabledTooltip?: string;
+}
+
+@Component({
+    selector: 'select-tooltip-demo',
+    standalone: true,
+    imports: [AppDocSectionText, SelectModule, AppCode, FormsModule],
+    template: `
+        <app-docsectiontext>
+            <p>Tooltips can be defined for specific options.</p>
+        </app-docsectiontext>
+        <div class="card flex justify-center">
+            <p-select [options]="cities" [(ngModel)]="selectedCity" optionDisabled="disabled" optionTooltip="disabledTooltip" optionLabel="name" placeholder="Select a City" class="w-full md:w-56" />
+        </div>
+        <app-code [code]="code" selector="select-tooltip-demo"></app-code>
+    `
+})
+export class TooltipDoc implements OnInit {
+    cities: City[];
+
+    selectedCity: City | undefined;
+
+    ngOnInit() {
+        this.cities = [
+            { name: 'New York', code: 'NY', disabled: false },
+            { name: 'Rome', code: 'RM', disabled: false },
+            { name: 'London', code: 'LDN', disabled: false },
+            { name: 'Istanbul', code: 'IST', disabled: true, disabledTooltip: 'Currently in maintenance' },
+            { name: 'Paris', code: 'PRS', disabled: false }
+        ];
+    }
+
+    code: Code = {
+        html: `<div class="card flex justify-center">
+    <p-select [options]="cities" [(ngModel)]="selectedCity" optionDisabled="disabled" optionTooltip="disabledTooltip" optionLabel="name" placeholder="Select a City" class="w-full md:w-56" />
+</div>`,
+
+        typescript: `import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Select } from 'primeng/select';
+
+interface City {
+    name: string;
+    code: string;
+    disabled: boolean;
+    disabledTooltip?: string
+}
+
+@Component({
+    selector: 'select-tooltip-demo',
+    templateUrl: './select-tooltip-demo.html',
+    standalone: true,
+    imports: [FormsModule, Select]
+})
+export class SelectTooltipDemo implements OnInit {
+    cities: City[];
+
+    selectedCity: City | undefined;
+
+    ngOnInit() {
+        this.cities = [
+            { name: 'New York', code: 'NY', disabled: false },
+            { name: 'Rome', code: 'RM', disabled: false },
+            { name: 'London', code: 'LDN', disabled: false },
+            { name: 'Istanbul', code: 'IST', disabled: true, disabledTooltip: 'Currently in maintenance' },
+            { name: 'Paris', code: 'PRS', disabled: false }
+        ];
+    }
+}`
+    };
+}

--- a/apps/showcase/pages/select/index.ts
+++ b/apps/showcase/pages/select/index.ts
@@ -22,6 +22,7 @@ import { TemplateDrivenFormsDoc } from '@/doc/select/templatedrivenforms-doc';
 import { VirtualScrollDoc } from '@/doc/select/virtualscroll-doc';
 import { AppDoc } from '@/components/doc/app.doc';
 import { Component } from '@angular/core';
+import { TooltipDoc } from '@/doc/select/tooltipdoc';
 
 @Component({
     template: `<app-doc docTitle="Angular Select Component" header="Select" description="Select is used to choose an item from a collection of options." [docs]="docs" [apiDocs]="['Select']" [ptDocs]="ptComponent" themeDocs="select"></app-doc> `,
@@ -129,6 +130,11 @@ export class SelectDemo {
                 { id: 'templatedriven', label: 'Template Driven', component: TemplateDrivenFormsDoc },
                 { id: 'reactive', label: 'Reactive Forms', component: ReactiveFormsDoc }
             ]
+        },
+        {
+            id: 'tooltip',
+            label: 'Tooltip',
+            component: TooltipDoc
         },
         {
             id: 'accessibility',

--- a/apps/showcase/public/llms/components/select.md
+++ b/apps/showcase/public/llms/components/select.md
@@ -1016,6 +1016,7 @@ Select is used to choose an item from a collection of options.
 | optionLabel | string | - | Name of the label field of an option. |
 | optionValue | string | - | Name of the value field of an option. |
 | optionDisabled | string | - | Name of the disabled field of an option. |
+| optionTooltip | string | - | Name of the tooltip field of an option. |
 | optionGroupLabel | string | label | Name of the label field of an option group. |
 | optionGroupChildren | string | items | Name of the options field of an option group. |
 | group | boolean | false | Whether to display options as grouped when nested options are provided. |

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -375,6 +375,8 @@ export class SelectItem extends BaseComponent {
                                             [selected]="isSelected(option)"
                                             [label]="getOptionLabel(option)"
                                             [disabled]="isOptionDisabled(option)"
+                                            [pTooltip]="getOptionTooltip(option)"
+                                            tooltipPosition="top"
                                             [template]="itemTemplate || _itemTemplate"
                                             [focused]="focusedOptionIndex() === getOptionIndex(i, scrollerOptions)"
                                             [ariaPosInset]="getAriaPosInset(getOptionIndex(i, scrollerOptions))"
@@ -565,6 +567,11 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
      * @group Props
      */
     @Input() optionDisabled: string | undefined;
+    /**
+     * Name of the tooltip field of an option.
+     * @group Props
+     */
+    @Input() optionTooltip: string | undefined;
     /**
      * Name of the label field of an option group.
      * @group Props
@@ -1325,6 +1332,10 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
     isOptionDisabled(option: any) {
         return this.optionDisabled ? resolveFieldData(option, this.optionDisabled) : option && option.disabled !== undefined ? option.disabled : false;
+    }
+
+    getOptionTooltip(option: any) {
+        return this.optionTooltip ? resolveFieldData(option, this.optionTooltip) : undefined;
     }
 
     getOptionGroupLabel(optionGroup: any) {


### PR DESCRIPTION
I've created a feature request about this: https://github.com/orgs/primefaces/discussions/4062

> Migrated from `primefaces/primeng#18432` — originally by `@Will-Smith-007` on 2025-06-02

---
*Original base: `master` @ `22d9ca1`, head: `feature/support-tooltip-for-select-items` @ `ffadec6`*