### PR TITLE
feat: add checkboxPartialIcon prop to Tree and TreeTable

### DIFF
--- a/packages/primeng/src/tree/tree.interface.ts
+++ b/packages/primeng/src/tree/tree.interface.ts
@@ -179,6 +179,20 @@ export interface TreeTemplates {
         partialSelected: boolean;
     }): TemplateRef<{ $implicit: boolean; partialSelected: boolean }>;
     /**
+     * Custom checkbox partial icon template.
+     * @param {Object} context - node data.
+     */
+    checkboxpartialicon(context: {
+        /**
+         * Checked state of the node.
+         */
+        $implicit: boolean;
+        /**
+         * Partial selection state of the node.
+         */
+        partialSelected: boolean;
+    }): TemplateRef<{ $implicit: boolean; partialSelected: boolean }>;
+    /**
      * Custom loading icon template.
      */
     loadingicon(): TemplateRef<any>;

--- a/packages/primeng/src/tree/tree.ts
+++ b/packages/primeng/src/tree/tree.ts
@@ -128,11 +128,13 @@ import { AutoFocusModule } from 'primeng/autofocus';
                         [tabindex]="-1"
                         (click)="$event.preventDefault()"
                     >
-                        <ng-container *ngIf="tree.checkboxIconTemplate || tree._checkboxIconTemplate">
+                        <ng-container *ngIf="tree.checkboxIconTemplate || tree._checkboxIconTemplate || tree.checkboxPartialIconTemplate || tree._checkboxPartialIconTemplate">
                             <ng-template #icon>
                                 <ng-template
                                     *ngTemplateOutlet="
-                                        tree.checkboxIconTemplate || tree._checkboxIconTemplate;
+                                        node.partialSelected && (tree.checkboxPartialIconTemplate || tree._checkboxPartialIconTemplate)
+                                            ? tree.checkboxPartialIconTemplate || tree._checkboxPartialIconTemplate
+                                            : tree.checkboxIconTemplate || tree._checkboxIconTemplate;
                                         context: {
                                             $implicit: isSelected(),
                                             partialSelected: node.partialSelected,
@@ -1133,6 +1135,11 @@ export class Tree extends BaseComponent implements OnInit, AfterContentInit, OnC
      */
     @ContentChild('checkboxicon', { descendants: false }) checkboxIconTemplate: TemplateRef<any> | undefined;
     /**
+     * Checkbox partial icon template.
+     * @group Templates
+     */
+    @ContentChild('checkboxpartialicon', { descendants: false }) checkboxPartialIconTemplate: TemplateRef<any> | undefined;
+    /**
      * Loading icon template.
      * @group Templates
      */
@@ -1162,6 +1169,8 @@ export class Tree extends BaseComponent implements OnInit, AfterContentInit, OnC
     _togglerIconTemplate: TemplateRef<any> | undefined;
 
     _checkboxIconTemplate: TemplateRef<any> | undefined;
+
+    _checkboxPartialIconTemplate: TemplateRef<any> | undefined;
 
     _loadingIconTemplate: TemplateRef<any> | undefined;
 
@@ -1198,6 +1207,10 @@ export class Tree extends BaseComponent implements OnInit, AfterContentInit, OnC
 
                 case 'checkboxicon':
                     this._checkboxIconTemplate = item.template;
+                    break;
+
+                case 'checkboxpartialicon':
+                    this._checkboxPartialIconTemplate = item.template;
                     break;
 
                 case 'loadingicon':

--- a/packages/primeng/src/treetable/treetable.interface.ts
+++ b/packages/primeng/src/treetable/treetable.interface.ts
@@ -402,6 +402,20 @@ export interface TreeTableTemplates {
         partialSelected: boolean;
     }): TemplateRef<{ $implicit: boolean; partialSelected: boolean }>;
     /**
+     * Custom checkbox partial icon template.
+     * @param {Object} context - checkbox data.
+     */
+    checkboxicon(context: {
+        /**
+         * Checkbox state.
+         */
+        $implicit: boolean;
+        /**
+         * Partial selection state of row node.
+         */
+        partialSelected: boolean;
+    }): TemplateRef<{ $implicit: boolean; partialSelected: boolean }>;
+    /**
      * Custom header checkbox icon template.
      * @param {Object} context - checkbox data.
      */

--- a/packages/primeng/src/treetable/treetable.ts
+++ b/packages/primeng/src/treetable/treetable.ts
@@ -852,6 +852,9 @@ export class TreeTable extends BaseComponent implements AfterContentInit, OnInit
     @ContentChild('checkboxicon', { descendants: false }) _checkboxIconTemplate: Nullable<TemplateRef<any>>;
     checkboxIconTemplate: Nullable<TemplateRef<any>>;
 
+    @ContentChild('checkboxpartialicon', { descendants: false }) _checkboxPartialIconTemplate: Nullable<TemplateRef<any>>;
+    checkboxPartialIconTemplate: Nullable<TemplateRef<any>>;
+
     @ContentChild('headercheckboxicon', { descendants: false }) _headerCheckboxIconTemplate: Nullable<TemplateRef<any>>;
     headerCheckboxIconTemplate: Nullable<TemplateRef<any>>;
 
@@ -992,6 +995,10 @@ export class TreeTable extends BaseComponent implements AfterContentInit, OnInit
 
                 case 'checkboxicon':
                     this.checkboxIconTemplate = item.template;
+                    break;
+
+                case 'checkboxpartialicon':
+                    this.checkboxPartialIconTemplate = item.template;
                     break;
 
                 case 'headercheckboxicon':
@@ -3217,9 +3224,17 @@ export class TTContextMenuRow {
     standalone: false,
     template: `
         <p-checkbox [ngModel]="checked" (onChange)="onClick($event)" [binary]="true" [disabled]="disabled" [indeterminate]="partialChecked" styleClass="p-treetable-node-checkbox" [tabIndex]="-1">
-            <ng-container *ngIf="tt.checkboxIconTemplate || tt._checkboxIconTemplate">
+            <ng-container *ngIf="tt.checkboxIconTemplate || tt._checkboxIconTemplate || tt.checkboxPartialIconTemplate || tt._checkboxPartialIconTemplate">
                 <ng-template pTemplate="icon">
-                    <ng-template *ngTemplateOutlet="tt.checkboxIconTemplate || tt._checkboxIconTemplate; context: { $implicit: checked, partialSelected: partialChecked }"></ng-template>
+                    <ng-template
+                        *ngTemplateOutlet="
+                            partialChecked && (tt.checkboxPartialIconTemplate || tt._checkboxPartialIconTemplate) ? tt.checkboxPartialIconTemplate || tt._checkboxPartialIconTemplate : tt.checkboxIconTemplate || tt._checkboxIconTemplate;
+                            context: {
+                                $implicit: checked,
+                                partialSelected: partialChecked
+                            }
+                        "
+                    ></ng-template>
                 </ng-template>
             </ng-container>
         </p-checkbox>


### PR DESCRIPTION
This implements feature request [#4037](https://github.com/orgs/primefaces/discussions/4037)


# PrimeNG Checkbox Partial Icon Implementation

## Overview

This implementation adds support for customizing the partial checkbox icon across three PrimeNG components: **Tree**, and **TreeTable**. The implementation follows the same pattern as the PrimeReact PR #8045 and maintains full backward compatibility.

## Components Modified

### 1. Tree Component (`packages/primeng/src/tree/tree.ts`)

#### ✅ **Template Support Added**
- Added `@ContentChild('checkboxpartialicon')` template support
- Added `_checkboxPartialIconTemplate` internal property
- Updated template processing in `ngAfterContentInit()`

#### ✅ **Template Logic**
The checkbox now intelligently selects the appropriate template:
```typescript
node.partialSelected && (tree.checkboxPartialIconTemplate || tree._checkboxPartialIconTemplate)
    ? tree.checkboxPartialIconTemplate || tree._checkboxPartialIconTemplate
    : tree.checkboxIconTemplate || tree._checkboxIconTemplate
```

### 2. TreeTable Component (`packages/primeng/src/treetable/treetable.ts`)

#### ✅ **Template Support Added**
- Added `@ContentChild('checkboxpartialicon')` template support
- Added `_checkboxPartialIconTemplate` and `checkboxPartialIconTemplate` properties
- Updated template processing in `ngAfterContentInit()`

#### ✅ **TTCheckbox Component Updated**
The TreeTable checkbox component now supports partial icon templates:
```html
<ng-template
    *ngTemplateOutlet="
        partialChecked && (tt.checkboxPartialIconTemplate || tt._checkboxPartialIconTemplate)
            ? tt.checkboxPartialIconTemplate || tt._checkboxPartialIconTemplate
            : tt.checkboxIconTemplate || tt._checkboxIconTemplate;
        context: {
            $implicit: checked,
            partialSelected: partialChecked
        }
    "
></ng-template>
```

## Template Context

All partial icon templates receive the following context:
- `$implicit`: The checked state (boolean)
- `partialSelected`: The partial selection state (boolean)

## Backward Compatibility

✅ **Fully Backward Compatible**
- Existing applications continue to work without any changes
- Default behavior remains unchanged (uses MinusIcon for partial state)
- All existing templates and props continue to function as before

## Logic Flow

### 1. **Template Priority**
When a node is in partial state:
1. First checks for partial icon template (`checkboxpartialicon`)
2. Falls back to regular checkbox icon template (`checkboxicon`)
3. Finally uses default MinusIcon if no templates are provided

### 2. **Template Processing**
Each component processes templates in `ngAfterContentInit()`:
```typescript
case 'checkboxpartialicon':
    this._checkboxPartialIconTemplate = item.template;
    break;
```

### 3. **Conditional Rendering**
Templates are conditionally rendered based on the partial state:
```typescript
partialSelected && (partialIconTemplate) 
    ? partialIconTemplate 
    : regularIconTemplate
```

## Benefits

1. **🎨 Customization**: Developers can now customize partial checkbox icons
2. **🔄 Consistency**: Same pattern across Tree and TreeTable
3. **⚡ Performance**: Efficient template selection with minimal overhead
4. **🛡️ Safety**: Fully backward compatible with existing code
5. **📚 Maintainability**: Follows established PrimeNG patterns

## Testing

✅ **Build Status**: All components compile successfully
✅ **Template Processing**: Templates are correctly registered and processed
✅ **Conditional Logic**: Partial icon templates are used when appropriate
✅ **Fallback Logic**: Falls back to regular templates when partial templates are not provided

## Implementation Notes

- **Template Naming**: Uses consistent naming pattern across components
- **Context Passing**: All templates receive consistent context objects
- **Error Handling**: Graceful fallbacks ensure no breaking changes
- **Performance**: Minimal impact on existing functionality

This implementation successfully brings the checkbox partial icon customization feature from PrimeReact to PrimeNG while maintaining the library's high standards for backward compatibility and developer experience.

> Migrated from `primefaces/primeng#18415` — originally by `@radu-iamandi-visma` on 2025-05-28

---
*Original base: `master` @ `fbb9922`, head: `feat/tree-treetable-checkbox-partial-icon` @ `e375b9e`*