### PR TITLE
Datepicker aria label fix

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -342,7 +342,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             (keyup.enter)="onTimePickerElementMouseUp($event)"
                             (keyup.space)="onTimePickerElementMouseUp($event)"
                             (mouseleave)="onTimePickerElementMouseLeave()"
-                            [attr.aria-label]="getTranslation('nextHour')"
+                            [ariaLabel]="getTranslation('nextHour')"
                         >
                             <ChevronUpIcon *ngIf="!incrementIconTemplate && !_incrementIconTemplate" />
 
@@ -362,7 +362,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             (keyup.enter)="onTimePickerElementMouseUp($event)"
                             (keyup.space)="onTimePickerElementMouseUp($event)"
                             (mouseleave)="onTimePickerElementMouseLeave()"
-                            [attr.aria-label]="getTranslation('prevHour')"
+                            [ariaLabel]="getTranslation('prevHour')"
                         >
                             <ChevronDownIcon *ngIf="!decrementIconTemplate && !_decrementIconTemplate" />
 
@@ -386,7 +386,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             (keyup.enter)="onTimePickerElementMouseUp($event)"
                             (keyup.space)="onTimePickerElementMouseUp($event)"
                             (mouseleave)="onTimePickerElementMouseLeave()"
-                            [attr.aria-label]="getTranslation('nextMinute')"
+                            [ariaLabel]="getTranslation('nextMinute')"
                         >
                             <ChevronUpIcon *ngIf="!incrementIconTemplate && !_incrementIconTemplate" />
 
@@ -406,7 +406,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             (keyup.enter)="onTimePickerElementMouseUp($event)"
                             (keyup.space)="onTimePickerElementMouseUp($event)"
                             (mouseleave)="onTimePickerElementMouseLeave()"
-                            [attr.aria-label]="getTranslation('prevMinute')"
+                            [ariaLabel]="getTranslation('prevMinute')"
                         >
                             <ChevronDownIcon *ngIf="!decrementIconTemplate && !_decrementIconTemplate" />
                             <ng-container *ngIf="decrementIconTemplate || _decrementIconTemplate">
@@ -431,7 +431,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             (keyup.enter)="onTimePickerElementMouseUp($event)"
                             (keyup.space)="onTimePickerElementMouseUp($event)"
                             (mouseleave)="onTimePickerElementMouseLeave()"
-                            [attr.aria-label]="getTranslation('nextSecond')"
+                            [ariaLabel]="getTranslation('nextSecond')"
                         >
                             <ChevronUpIcon *ngIf="!incrementIconTemplate && !_incrementIconTemplate" />
 
@@ -451,7 +451,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             (keyup.enter)="onTimePickerElementMouseUp($event)"
                             (keyup.space)="onTimePickerElementMouseUp($event)"
                             (mouseleave)="onTimePickerElementMouseLeave()"
-                            [attr.aria-label]="getTranslation('prevSecond')"
+                            [ariaLabel]="getTranslation('prevSecond')"
                         >
                             <ChevronDownIcon *ngIf="!decrementIconTemplate && !_decrementIconTemplate" />
 
@@ -470,7 +470,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             (keydown)="onContainerButtonKeydown($event)"
                             (onClick)="toggleAMPM($event)"
                             (keydown.enter)="toggleAMPM($event)"
-                            [attr.aria-label]="getTranslation('am')"
+                            [ariaLabel]="getTranslation('am')"
                         >
                             <ChevronUpIcon *ngIf="!incrementIconTemplate && !_incrementIconTemplate" />
                             <ng-template *ngTemplateOutlet="incrementIconTemplate || _incrementIconTemplate"></ng-template>
@@ -484,7 +484,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             (keydown)="onContainerButtonKeydown($event)"
                             (click)="toggleAMPM($event)"
                             (keydown.enter)="toggleAMPM($event)"
-                            [attr.aria-label]="getTranslation('pm')"
+                            [ariaLabel]="getTranslation('pm')"
                         >
                             <ChevronDownIcon *ngIf="!decrementIconTemplate && !_decrementIconTemplate" />
                             <ng-template *ngTemplateOutlet="decrementIconTemplate || _decrementIconTemplate"></ng-template>


### PR DESCRIPTION
Places the aria-label on the button tag rather the p-button tag. This allows it to pass accessibility testing for ensuring buttons have an accessible label as well as preventing aria-label from being placed on a tag which isn't allowed.

> Migrated from `primefaces/primeng#18404` — originally by `@cvillella` on 2025-05-25

---
*Original base: `master` @ `3a33193`, head: `datepickerAcessibilityFix` @ `af2d28e`*