### PR TITLE
feat(datepicker): Add support for using `aria-describedby` in datepicker

### DIFF
--- a/apps/showcase/doc/datepicker/accessibility-doc.ts
+++ b/apps/showcase/doc/datepicker/accessibility-doc.ts
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
         <app-docsectiontext>
             <h3>Screen Reader</h3>
             <p>
-                Value to describe the component can either be provided via <i>label</i> tag combined with <i>inputId</i> prop or using <i>aria-labelledby</i>, <i>aria-label</i>, <i>ariaDescribedBy</i> props. The input element has <i>combobox</i> role
+                Value to describe the component can either be provided via <i>label</i> tag combined with <i>inputId</i> prop or using <i>ariaLabelledBy</i>, <i>ariaLabel</i>, <i>ariaDescribedBy</i> props. The input element has <i>combobox</i> role
                 in addition to <i>aria-autocomplete</i> as "none", <i>aria-haspopup</i> as "dialog" and <i>aria-expanded</i> attributes. The relation between the input and the popup is created with <i>aria-controls</i> attribute that refers to the id
                 of the popup.
             </p>

--- a/apps/showcase/doc/datepicker/accessibility-doc.ts
+++ b/apps/showcase/doc/datepicker/accessibility-doc.ts
@@ -11,8 +11,9 @@ import { Component } from '@angular/core';
         <app-docsectiontext>
             <h3>Screen Reader</h3>
             <p>
-                Value to describe the component can either be provided via <i>label</i> tag combined with <i>inputId</i> prop or using <i>aria-labelledby</i>, <i>aria-label</i> props. The input element has <i>combobox</i> role in addition to
-                <i>aria-autocomplete</i> as "none", <i>aria-haspopup</i> as "dialog" and <i>aria-expanded</i> attributes. The relation between the input and the popup is created with <i>aria-controls</i> attribute that refers to the id of the popup.
+                Value to describe the component can either be provided via <i>label</i> tag combined with <i>inputId</i> prop or using <i>aria-labelledby</i>, <i>aria-label</i>, <i>ariaDescribedBy</i> props. The input element has <i>combobox</i> role
+                in addition to <i>aria-autocomplete</i> as "none", <i>aria-haspopup</i> as "dialog" and <i>aria-expanded</i> attributes. The relation between the input and the popup is created with <i>aria-controls</i> attribute that refers to the id
+                of the popup.
             </p>
             <p>
                 The optional DatePicker button requires includes <i>aria-haspopup</i>, <i>aria-expanded</i> for states along with <i>aria-controls</i> to define the relation between the popup and the button. The value to read is retrieved from the
@@ -240,6 +241,9 @@ export class AccessibilityDoc {
 <span id="date2">Date</span>
 <p-datepicker ariaLabelledBy="date2"/>
 
-<p-datepicker ariaLabel="Date"/>`
+<p-datepicker ariaLabel="Date"/>
+
+<p-datepicker ariaDescribedBy="describe" />
+<small id="describe">Information</small>`
     };
 }

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -92,6 +92,7 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                 [attr.aria-controls]="overlayVisible ? panelId : null"
                 [attr.aria-labelledby]="ariaLabelledBy"
                 [attr.aria-label]="ariaLabel"
+                [attr.aria-describedby]="ariaDescribedBy"
                 [value]="inputFieldValue"
                 (focus)="onInputFocus($event)"
                 (keydown)="onInputKeydown($event)"
@@ -581,6 +582,11 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
      * @group Props
      */
     @Input() ariaLabel: string | undefined;
+    /**
+     * Specifies one or more IDs in the DOM that describes the input field.
+     * @group Props
+     */
+    @Input() ariaDescribedBy: string | undefined;
 
     /**
      * Defines a string that labels the icon button for accessibility.


### PR DESCRIPTION
Fixes #494

> Migrated from `primefaces/primeng#18265` — originally by `@Will-Smith-007` on 2025-05-08

---
*Original base: `master` @ `22d9ca1`, head: `fix/add-datepicker-aria-describedby` @ `ba20873`*