### PR TITLE
feat: Allow app to disable focusing input when interacting with InputNumber buttons

### DIFF
--- a/packages/primeng/src/button/button.ts
+++ b/packages/primeng/src/button/button.ts
@@ -29,9 +29,8 @@ import { BadgeModule } from 'primeng/badge';
 import { BaseComponent } from 'primeng/basecomponent';
 import { SpinnerIcon } from 'primeng/icons';
 import { Ripple } from 'primeng/ripple';
-import { ButtonProps } from './button.interface';
+import { ButtonProps, ButtonSeverity } from './button.interface';
 import { ButtonStyle } from './style/buttonstyle';
-import { ButtonSeverity } from './button.interface';
 
 type ButtonIconPosition = 'left' | 'right' | 'top' | 'bottom';
 

--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -422,6 +422,11 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
      */
     @Input({ transform: booleanAttribute }) fluid: boolean = false;
     /**
+     * When "showButton" is set to true, this allows you to disable focusing the input when a user interacts with the buttons.
+     * @group Props
+     */
+    @Input({ transform: booleanAttribute }) disableFocusOnButtonInteraction: boolean = false;
+    /**
      * Callback to invoke on input.
      * @param {InputNumberInputEvent} event - Custom input event.
      * @group Emits
@@ -808,7 +813,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
         }
 
         if (!this.disabled) {
-            this.input?.nativeElement.focus();
+            if (!this.disableFocusOnButtonInteraction) this.input?.nativeElement.focus();
             this.repeat(event, null, 1);
             event.preventDefault();
         }
@@ -844,7 +849,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
             return;
         }
         if (!this.disabled) {
-            this.input?.nativeElement.focus();
+            if (!this.disableFocusOnButtonInteraction) this.input?.nativeElement.focus();
             this.repeat(event, null, -1);
             event.preventDefault();
         }

--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -1553,7 +1553,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
 
     setSelectionRange(start: number, end: number) {
         // Calling setSelectionRange focuses the input element. Check to see if it's not disabled so we can call it
-        if (!this.disableFocusOnButtonInteraction) this.input?.nativeElement.setSelectionRange(start, end);
+        if (!this.disableFocusOnButtonInteraction || !this.showButtons) this.input?.nativeElement.setSelectionRange(start, end);
     }
 }
 

--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -925,7 +925,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
                 for (let index = selectionStart; index <= inputValue.length; index++) {
                     const previousCharIndex = index === 0 ? 0 : index - 1;
                     if (this.isNumeralChar(inputValue.charAt(previousCharIndex))) {
-                        this.input.nativeElement.setSelectionRange(index, index);
+                        this.setSelectionRange(index, index);
                         break;
                     }
                 }
@@ -934,7 +934,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
             case 'ArrowRight':
                 for (let index = selectionEnd; index >= 0; index--) {
                     if (this.isNumeralChar(inputValue.charAt(index))) {
-                        this.input.nativeElement.setSelectionRange(index, index);
+                        this.setSelectionRange(index, index);
                         break;
                     }
                 }
@@ -969,7 +969,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
                             this._decimal.lastIndex = 0;
 
                             if (decimalLength) {
-                                this.input?.nativeElement.setSelectionRange(selectionStart - 1, selectionStart - 1);
+                                this.setSelectionRange(selectionStart - 1, selectionStart - 1);
                             } else {
                                 newValueStr = inputValue.slice(0, selectionStart - 1) + inputValue.slice(selectionStart);
                             }
@@ -1015,7 +1015,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
                             this._decimal.lastIndex = 0;
 
                             if (decimalLength) {
-                                this.input?.nativeElement.setSelectionRange(selectionStart + 1, selectionStart + 1);
+                                this.setSelectionRange(selectionStart + 1, selectionStart + 1);
                             } else {
                                 newValueStr = inputValue.slice(0, selectionStart) + inputValue.slice(selectionStart + 1);
                             }
@@ -1282,7 +1282,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
         }
 
         if (index !== null) {
-            this.input?.nativeElement.setSelectionRange(index + 1, index + 1);
+            this.setSelectionRange(index + 1, index + 1);
         } else {
             i = selectionStart;
             while (i < valueLength) {
@@ -1296,7 +1296,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
             }
 
             if (index !== null) {
-                this.input?.nativeElement.setSelectionRange(index, index);
+                this.setSelectionRange(index, index);
             }
         }
 
@@ -1391,10 +1391,10 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
 
         if (currentLength === 0) {
             this.input.nativeElement.value = newValue;
-            this.input.nativeElement.setSelectionRange(0, 0);
+            this.setSelectionRange(0, 0);
             const index = this.initCursor();
             const selectionEnd = index + insertedValueStr.length;
-            this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+            this.setSelectionRange(selectionEnd, selectionEnd);
         } else {
             let selectionStart = this.input.nativeElement.selectionStart;
             let selectionEnd = this.input.nativeElement.selectionEnd;
@@ -1424,11 +1424,11 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
                 tRegex.test(newValue.slice(sRegex.lastIndex));
 
                 selectionEnd = sRegex.lastIndex + tRegex.lastIndex;
-                this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                this.setSelectionRange(selectionEnd, selectionEnd);
             } else if (newLength === currentLength) {
-                if (operation === 'insert' || operation === 'delete-back-single') this.input.nativeElement.setSelectionRange(selectionEnd + 1, selectionEnd + 1);
-                else if (operation === 'delete-single') this.input.nativeElement.setSelectionRange(selectionEnd - 1, selectionEnd - 1);
-                else if (operation === 'delete-range' || operation === 'spin') this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                if (operation === 'insert' || operation === 'delete-back-single') this.setSelectionRange(selectionEnd + 1, selectionEnd + 1);
+                else if (operation === 'delete-single') this.setSelectionRange(selectionEnd - 1, selectionEnd - 1);
+                else if (operation === 'delete-range' || operation === 'spin') this.setSelectionRange(selectionEnd, selectionEnd);
             } else if (operation === 'delete-back-single') {
                 let prevChar = inputValue.charAt(selectionEnd - 1);
                 let nextChar = inputValue.charAt(selectionEnd);
@@ -1442,15 +1442,15 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
                 }
 
                 this._group.lastIndex = 0;
-                this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                this.setSelectionRange(selectionEnd, selectionEnd);
             } else if (inputValue === '-' && operation === 'insert') {
-                this.input.nativeElement.setSelectionRange(0, 0);
+                this.setSelectionRange(0, 0);
                 const index = this.initCursor();
                 const selectionEnd = index + insertedValueStr.length + 1;
-                this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                this.setSelectionRange(selectionEnd, selectionEnd);
             } else {
                 selectionEnd = selectionEnd + (newLength - currentLength);
-                this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                this.setSelectionRange(selectionEnd, selectionEnd);
             }
         }
 
@@ -1549,6 +1549,11 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
         if (this.timer) {
             clearInterval(this.timer);
         }
+    }
+
+    setSelectionRange(start: number, end: number) {
+        // Calling setSelectionRange focuses the input element. Check to see if it's not disabled so we can call it
+        if (!this.disableFocusOnButtonInteraction) this.input?.nativeElement.setSelectionRange(start, end);
     }
 }
 


### PR DESCRIPTION
We have an issue where we do not want to allow the user to interact with the `<input>` on `InputNumber` component when there are buttons are present. The reason for this is because when the component is rendered on a Mobile device, the browser automatically opens up the virtual keyboard and scrolls the page so that the input is above the virtual keyboard. This causes lots of issues with our application.

To get around this, we added a new property called `disableFocusOnButtonInteraction`, so that the application can programatically disable focusing the input when they want.

By default, it will behave as it normally has, by focusing the input.

> Migrated from `primefaces/primeng#18181` — originally by `@tsteuwer-accesso` on 2025-04-28

---
*Original base: `master` @ `d929c05`, head: `allowing-disable-focusing-of-input` @ `01e9ce7`*