### PR TITLE
fix(Tooltip): #17868 - Ensure disabling the fitContent option prevents re-positioning

### DIFF
--- a/packages/primeng/src/tooltip/tooltip.ts
+++ b/packages/primeng/src/tooltip/tooltip.ts
@@ -588,6 +588,8 @@ export class Tooltip extends BaseComponent implements AfterViewInit, OnDestroy {
     }
 
     isOutOfBounds(): boolean {
+        if (!this.fitContent) return false;
+
         let offset = this.container.getBoundingClientRect();
         let targetTop = offset.top;
         let targetLeft = offset.left;


### PR DESCRIPTION
fixes #556 

Documentation: https://primeng.org/tooltip#api.tooltip.props.fitContent

Default value: true

`Automatically adjusts the element position when there is not enough space on the selected position.`

Based on the description of this prop, setting this option to false should stop the tooltip form repositioning itself automatically. There are scenarios where the position needs to be preserved, even if it doesn't comfortably fit on the screen.

> Migrated from `primefaces/primeng#18120` — originally by `@mlpepper` on 2025-04-19

---
*Original base: `master` @ `5c1e54d`, head: `issues/fix-#556` @ `ff4a301`*