### PR TITLE
Autocomplete chip removal value update

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -1578,17 +1578,14 @@ export class AutoComplete extends BaseComponent implements AfterViewChecked, Aft
     }
 
     handleKeydown(event: KeyboardEvent, index: number): void {
-        console.log("object");
         if (event.key === 'Enter') {
             this.removeOption(event, index);
-            event.preventDefault(); // Prevents default behavior, if necessary
+            event.preventDefault();
         }
     }
 
     removeOption(event, index) {
         event.stopPropagation();
-
-        console.log(event);
 
         const removedOption = this.modelValue()[index];
         const value = this.modelValue()

--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -130,7 +130,8 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                     <p-chip styleClass="p-autocomplete-chip" *ngIf="!selectedItemTemplate && !_selectedItemTemplate" [label]="getOptionLabel(option)" [removable]="true">
                         <ng-container *ngIf="!removeIconTemplate && !_removeIconTemplate">
                             <ng-template #removeicon>
-                                <span class="p-autocomplete-chip-icon" (click)="!readonly ? removeOption($event, i) : ''">
+                                <span class="p-autocomplete-chip-icon" (click)="!readonly ? removeOption($event, i) : ''" (keydown)="handleKeydown($event, i)" tabindex="0"
+                                >
                                     <TimesCircleIcon [styleClass]="'p-autocomplete-chip-icon'" [attr.aria-hidden]="true" />
                                 </span>
                             </ng-template>
@@ -1576,8 +1577,18 @@ export class AutoComplete extends BaseComponent implements AfterViewChecked, Aft
         this.completeMethod.emit({ originalEvent: event, query });
     }
 
+    handleKeydown(event: KeyboardEvent, index: number): void {
+        console.log("object");
+        if (event.key === 'Enter') {
+            this.removeOption(event, index);
+            event.preventDefault(); // Prevents default behavior, if necessary
+        }
+    }
+
     removeOption(event, index) {
         event.stopPropagation();
+
+        console.log(event);
 
         const removedOption = this.modelValue()[index];
         const value = this.modelValue()


### PR DESCRIPTION
AutoComplete (multiple) value isn't updated when chip is removed using the keyboard

> Migrated from `primefaces/primeng#18017` — originally by `@Hardik-Dharmik` on 2025-04-02

---
*Original base: `master` @ `7ef7f7b`, head: `autocomplete-chip-removal-value-update` @ `bcc53dc`*