### PR TITLE
fix: #17750, SplitButton broken in Table body when screen is less tha…

### DIFF
--- a/packages/primeng/src/tieredmenu/style/tieredmenustyle.ts
+++ b/packages/primeng/src/tieredmenu/style/tieredmenustyle.ts
@@ -121,8 +121,10 @@ const theme = ({ dt }) => `
 }
 
 .p-tieredmenu-overlay {
-    position: absolute;
     box-shadow: ${dt('tieredmenu.shadow')};
+}
+.p-tieredmenu.p-tieredmenu-overlay{
+    position: absolute;
 }
 
 .p-tieredmenu-enter-from,


### PR DESCRIPTION
### Defect Fixes
there is a style fix, please refer to [SplitButton broken in Table body when screen is less than 960px wide](https://github.com/primefaces/primeng/issues/17750).

> Migrated from `primefaces/primeng#18015` — originally by `@zfyzjzzl` on 2025-04-02

---
*Original base: `master` @ `7ef7f7b`, head: `issue-17750` @ `ab9d96d`*