### PR TITLE
The class p-datatable-column-title should have "display: none" by default.

### DIFF
--- a/packages/primeng/src/table/style/tablestyle.ts
+++ b/packages/primeng/src/table/style/tablestyle.ts
@@ -333,6 +333,10 @@ const theme = ({ dt }) => `
 }
 */
 
+.p-datatable-column-title {
+    display: none;
+}
+
 .p-datatable-tbody > tr {
     outline-color: transparent;
     background: ${dt('datatable.row.background')};


### PR DESCRIPTION
There is a `@media` screen and (max-width) style that sets "display: block".

Contributes to #814

> Migrated from `primefaces/primeng#18004` — originally by `@zlatanov` on 2025-03-31

---
*Original base: `master` @ `7ef7f7b`, head: `p-datatable-column-title` @ `b9f3739`*