### PR TITLE
feat(dynamic-dialog): let call sites specify custom providers

### DIFF
--- a/apps/showcase/doc/dynamicdialog/customprovidersdemo.ts
+++ b/apps/showcase/doc/dynamicdialog/customprovidersdemo.ts
@@ -1,0 +1,11 @@
+import { Component, inject, InjectionToken } from '@angular/core';
+
+export const VALUE_TOKEN = new InjectionToken<any>('VALUE_TOKEN');
+
+@Component({
+    standalone: false,
+    template: ` <p>{{ value }}</p> `
+})
+export class CustomProvidersDemo {
+    protected readonly value = inject(VALUE_TOKEN);
+}

--- a/apps/showcase/doc/dynamicdialog/customprovidersdoc.ts
+++ b/apps/showcase/doc/dynamicdialog/customprovidersdoc.ts
@@ -1,0 +1,106 @@
+import { Code, RouteFile } from '@/domain/code';
+import { Component } from '@angular/core';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { CustomProvidersDemo, VALUE_TOKEN } from './customprovidersdemo';
+
+@Component({
+    selector: 'dynamic-dialog-custom-providers-demo',
+    standalone: false,
+    template: `
+        <app-docsectiontext>
+            <p>You can setup custom providers for the target component.</p>
+        </app-docsectiontext>
+        <div class="card flex justify-center">
+            <p-button (click)="show()" icon="pi pi-search" label="Open Dialog" />
+        </div>
+        <app-code [code]="code" selector="dynamic-dialog-custom-providers-demo" [routeFiles]="routeFiles"></app-code>
+    `,
+    providers: [DialogService]
+})
+export class CustomProvidersDoc {
+    ref: DynamicDialogRef | undefined;
+
+    constructor(public dialogService: DialogService) {}
+
+    show() {
+        this.ref = this.dialogService.open(CustomProvidersDemo, {
+            header: 'Provider',
+            width: '50vw',
+            modal: true,
+            closable: true,
+            breakpoints: {
+                '960px': '75vw',
+                '640px': '90vw'
+            },
+            providers: [
+                {
+                    provide: VALUE_TOKEN,
+                    useValue: 'Hey'
+                }
+            ]
+        });
+    }
+
+    code: Code = {
+        basic: `<p-button (click)="show()" icon="pi pi-search" label="Select a Product" />`,
+        html: `<div class="card flex justify-center">
+    <p-button (click)="show()" icon="pi pi-search" label="Select a Product" />
+</div>`,
+        typescript: `
+import { Component } from '@angular/core';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { CustomProvidersDemo, VALUE_TOKEN } from './demo/customprovidersdemo';
+
+@Component({
+    selector: 'dynamic-dialog-custom-providers-demo',
+    templateUrl: './dynamic-dialog-custom-providers-demo.html',
+    imports: [DynamicDialogModule, ImportsModule],
+    providers: [DialogService],
+    standalone: true
+})
+export class DynamicDialogCustomProvidersDemo {
+
+    ref: DynamicDialogRef | undefined;
+
+    constructor(public dialogService: DialogService) {}
+
+    show() {
+        this.ref = this.dialogService.open(CustomProvidersDemo, {
+            header: 'Provider',
+            width: '50vw',
+            modal: true,
+            closable: true,
+            breakpoints: {
+                '960px': '75vw',
+                '640px': '90vw'
+            },
+            providers: [
+                {
+                    provide: VALUE_TOKEN,
+                    useValue: 'Hey'
+                }
+            ]
+        });
+    }
+}`
+    };
+
+    routeFiles: RouteFile[] = [
+        {
+            path: 'src/app/demo/customprovidersdemo.ts',
+            name: 'CustomProvidersDemo',
+            content: `import { Component, inject, InjectionToken } from '@angular/core';
+            
+export const VALUE_TOKEN = new InjectionToken<any>('VALUE_TOKEN');
+
+@Component({
+    standalone: false,
+    template: \` <p>{{ value }}</p> \`
+})
+export class CustomProvidersDemo {
+    protected readonly value = inject(VALUE_TOKEN);
+}
+            `
+        }
+    ];
+}

--- a/apps/showcase/doc/dynamicdialog/dynamicdialogdoc.module.ts
+++ b/apps/showcase/doc/dynamicdialog/dynamicdialogdoc.module.ts
@@ -11,6 +11,8 @@ import { Tag } from 'primeng/tag';
 import { ToastModule } from 'primeng/toast';
 import { CloseDoc } from './closedoc';
 import { CustomizationDoc } from './customizationdoc';
+import { CustomProvidersDemo } from './customprovidersdemo';
+import { CustomProvidersDoc } from './customprovidersdoc';
 import { ExampleDoc } from './exampledoc';
 import { Footer } from './footer';
 import { ImportDoc } from './importdoc';
@@ -23,7 +25,7 @@ import { UsageDoc } from './usagedoc';
 
 @NgModule({
     imports: [CommonModule, AppCodeModule, RouterModule, FormsModule, Tag, Dialog, ButtonModule, AppDocModule, ToastModule, TableModule],
-    declarations: [OpenDoc, Footer, ImportDoc, StyleDoc, ExampleDoc, ProductListDemo, UsageDoc, PassingDataDoc, CloseDoc, StyleDoc, InfoDemo, CustomizationDoc],
+    declarations: [OpenDoc, Footer, ImportDoc, StyleDoc, ExampleDoc, ProductListDemo, UsageDoc, PassingDataDoc, CloseDoc, StyleDoc, InfoDemo, CustomizationDoc, CustomProvidersDoc, CustomProvidersDemo],
     exports: [AppDocModule]
 })
 export class DynamicDialogDocModule {}

--- a/apps/showcase/pages/dynamicdialog/index.ts
+++ b/apps/showcase/pages/dynamicdialog/index.ts
@@ -1,5 +1,6 @@
 import { CloseDoc } from '@/doc/dynamicdialog/closedoc';
 import { CustomizationDoc } from '@/doc/dynamicdialog/customizationdoc';
+import { CustomProvidersDoc } from '@/doc/dynamicdialog/customprovidersdoc';
 import { DynamicDialogDocModule } from '@/doc/dynamicdialog/dynamicdialogdoc.module';
 import { ExampleDoc } from '@/doc/dynamicdialog/exampledoc';
 import { ImportDoc } from '@/doc/dynamicdialog/importdoc';
@@ -58,6 +59,11 @@ export class DynamicDialogDemo {
             id: 'example',
             label: 'Example',
             component: ExampleDoc
+        },
+        {
+            id: 'customproviders',
+            label: 'Custom Providers',
+            component: CustomProvidersDoc
         }
     ];
 }

--- a/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
@@ -1,4 +1,4 @@
-import { Type } from '@angular/core';
+import { StaticProvider, Type } from '@angular/core';
 
 /**
  * Dialogs can be created dynamically with any component as the content using a DialogService.
@@ -185,6 +185,11 @@ export class DynamicDialogConfig<DataType = any, InputValuesType extends Record<
      * @group Props
      */
     templates?: DynamicDialogTemplates;
+    /**
+     * Providers that will be exposed to the contents of the dialog.
+     * @group Props
+     */
+    providers?: StaticProvider[];
 }
 
 /**

--- a/packages/primeng/src/dynamicdialog/dynamicdialog-injector.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog-injector.ts
@@ -1,4 +1,4 @@
-import { InjectOptions, Injector, ProviderToken, InjectFlags } from '@angular/core';
+import { InjectFlags, InjectOptions, Injector, ProviderToken } from '@angular/core';
 
 export class DynamicDialogInjector implements Injector {
     constructor(


### PR DESCRIPTION
EDIT:

Would help address/workaround issues such as #759

This reflects the Angular CDK dialog (https://material.angular.io/cdk/dialog/api#DialogConfig) ability to specify custom providers per dialog #open call-site. Without this, callers could merely specify providers at the same level the dialog service is provided, however this does not allow to customize providers across #open calls.

This is blocked cause I can't regenerate api docs as the `npm run build:apidoc` fails for me. Posted more details in Discord https://discord.com/channels/787967399105134612/1350903788730322974.

I left the `DynamicDialogInjector` as is, cause deleting it would be breaking change and I would like for this to land earlier than next major version. I do not understand what problem that solved in the first place.

> Migrated from `primefaces/primeng#17887` — originally by `@Erbenos` on 2025-03-16

---
*Original base: `master` @ `c4eeaed`, head: `feat(dynamic-dialog)/custom-providers` @ `362d61b`*