### PR TITLE
dynamic-dialog-noFocusOnClose 

### DIFF
--- a/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
@@ -185,6 +185,11 @@ export class DynamicDialogConfig<DataType = any, InputValuesType extends Record<
      * @group Props
      */
     templates?: DynamicDialogTemplates;
+    /**
+     * A boolean to determine if it should focus on first element in parent component when closing the dialog.
+     * @group Props
+     */
+    focusFirstElementOnClose?: boolean = false;
 }
 
 /**

--- a/packages/primeng/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.ts
@@ -402,7 +402,7 @@ export class DynamicDialogComponent extends BaseComponent implements AfterViewIn
 
     onAnimationEnd(event: AnimationEvent) {
         if (event.toState === 'void') {
-            if (this.parentContent) {
+            if (this.parentContent && this.ddconfig.focusFirstElementOnClose) {
                 this.focus(this.parentContent);
             }
             this.onContainerDestroy();


### PR DESCRIPTION
fixes #878 

The problem is well documented by `@jonnomk` in #878 and completed by me at trailing [comment](https://github.com/primefaces/primeng/issues/878#issuecomment-2726457441).

The problem seems to be there from version 17.

Thanks to PrimeNG team for the excellent library. Thanks to `@jonnomk` for oppening the issue.

> Migrated from `primefaces/primeng#17886` — originally by `@ngsaeed` on 2025-03-15

---
*Original base: `master` @ `c4eeaed`, head: `dynamic-dialog-noFocusOnClose` @ `3e2d704`*