### PR TITLE
fix( #16837): fix: month selection issue in Calendar component (new pr)

### DIFF
--- a/packages/primeng/src/calendar/calendar.ts
+++ b/packages/primeng/src/calendar/calendar.ts
@@ -1976,12 +1976,21 @@ export class Calendar extends BaseComponent implements OnInit, AfterContentInit,
     }
 
     isMonthSelected(month: number) {
-        if (this.isComparable() && !this.isMultipleSelection()) {
-            const [start, end] = this.isRangeSelection() ? this.value : [this.value, this.value];
-            const selected = new Date(this.currentYear, month, 1);
-            return selected >= start && selected <= (end ?? start);
+        if (!this.isComparable() || this.isMultipleSelection()) {
+            return false;
         }
-        return false;
+
+        if (this.isRangeSelection()) {
+            const selected = new Date(this.currentYear, month, 1);
+            const start = this.value[0];
+            const end = this.value[1];
+
+            start.setDate(1);
+            end.setDate(1);
+
+            return selected >= start && selected <= end;
+        }
+        return (this.value ? this.value.getMonth() === month : false) && this.value.getFullYear() == this.currentYear;
     }
 
     isMonthDisabled(month: number, year?: number) {


### PR DESCRIPTION
New pull request was created, as asked in https://github.com/primefaces/primeng/pull/16841.

fix for https://github.com/primefaces/primeng/issues/738

This pull requests fixes two things in "isMonthSelected(month: number)" method:

    Selected month in "Reactive Forms" is being highlighted.
    Correct range of months in "Range" is being highlighted.

> Migrated from `primefaces/primeng#17845` — originally by `@pointers-enjoyer` on 2025-03-08

---
*Original base: `master` @ `fc3d837`, head: `issue/16837` @ `f4fb3d5`*