### PR TITLE
fix: p-datepicker highlight selected year range

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -2010,9 +2010,11 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
 
     isYearSelected(year: number) {
         if (this.isComparable()) {
-            let value = this.isRangeSelection() ? this.value[0] : this.value;
-
-            return !this.isMultipleSelection() ? value.getFullYear() === year : false;
+            if (this.isRangeSelection()) {
+                return this.isDateBetween(this.value[0], this.value[1], { year: year, month: 0, day: 1 });
+            } else {
+                return !this.isMultipleSelection() ? this.value.getFullYear() === year : false;
+            }
         }
 
         return false;


### PR DESCRIPTION
Using the date picker with a range and view mode year or month does not highlight selected range.
It was only highlighting the first date.

![image](https://github.com/user-attachments/assets/6581157d-79d4-4307-b9ad-a1c28d955b1e)

> Migrated from `primefaces/primeng#17815` — originally by `@fxprunayre` on 2025-03-05

---
*Original base: `master` @ `fd48576`, head: `feature/datepicker-range-modeyearandmonth` @ `e9d8b10`*