### PR TITLE
fix(input-otp): remove unnecessary logic to auto focus last input on backspace

### DIFF
--- a/packages/primeng/src/inputotp/inputotp.ts
+++ b/packages/primeng/src/inputotp/inputotp.ts
@@ -240,9 +240,7 @@ export class InputOtp extends BaseComponent implements AfterContentInit {
         this.tokens[index] = value;
         this.updateModel(event);
 
-        if (event.inputType === 'deleteContentBackward') {
-            this.moveToPrev(event);
-        } else if (event.inputType === 'insertText' || event.inputType === 'deleteContentForward') {
+        if (event.inputType === 'insertText' || event.inputType === 'deleteContentForward') {
             this.moveToNext(event);
         }
     }


### PR DESCRIPTION
fix #663

> Migrated from `primefaces/primeng#17805` — originally by `@AlexFHer` on 2025-03-03

---
*Original base: `master` @ `fd48576`, head: `17313-otp-input-change-focus-on-backspace-unnecesary` @ `2c81256`*