### PR TITLE
fix(p-tabs): round scrollleft when scrolling to prevent comparison inaccuracy in button state

### DIFF
--- a/packages/primeng/src/tabs/tablist.ts
+++ b/packages/primeng/src/tabs/tablist.ts
@@ -1,6 +1,6 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { AfterContentInit, AfterViewInit, ChangeDetectionStrategy, Component, computed, ContentChild, ContentChildren, effect, ElementRef, forwardRef, inject, QueryList, signal, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
-import { findSingle, getHeight, getOffset, getOuterWidth, getWidth, isRTL } from '@primeuix/utils';
+import { findSingle, getOffset, getOuterWidth, getWidth, isRTL } from '@primeuix/utils';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { BaseComponent } from 'primeng/basecomponent';
 import { ChevronLeftIcon, ChevronRightIcon } from 'primeng/icons';
@@ -168,12 +168,17 @@ export class TabList extends BaseComponent implements AfterViewInit, AfterConten
         const _content = this.content?.nativeElement;
         const _list = this.el?.nativeElement;
 
-        const { scrollWidth, offsetWidth } = _content;
-        const scrollLeft = Math.abs(_content.scrollLeft);
-        const width = getWidth(_content);
+        if (_content && _list) {
+            const scrollWidth = _content.scrollWidth;
+            const scrollLeft = Math.round(_content.scrollLeft);
+            const offsetWidth = _list.offsetWidth;
 
-        this.isPrevButtonEnabled.set(scrollLeft !== 0);
-        this.isNextButtonEnabled.set(_list.offsetWidth >= offsetWidth && scrollLeft !== scrollWidth - width);
+            const isAtStart = scrollLeft === 0;
+            const isAtEnd = scrollLeft + offsetWidth >= scrollWidth;
+
+            this.isPrevButtonEnabled.set(!isAtStart);
+            this.isNextButtonEnabled.set(!isAtEnd);
+        }
     }
 
     updateInkBar() {


### PR DESCRIPTION
References: #17675

> Migrated from `primefaces/primeng#17797` — originally by `@ElgersNiels` on 2025-03-02

---
*Original base: `master` @ `fd48576`, head: `fix/p-tabs-scroll-update-button-state` @ `76efe0a`*