### PR TITLE
fix(#17033): tooltip render and alignment issues in scrolltop

### DIFF
--- a/packages/primeng/src/tooltip/tooltip.ts
+++ b/packages/primeng/src/tooltip/tooltip.ts
@@ -516,7 +516,7 @@ export class Tooltip extends BaseComponent implements AfterViewInit, OnDestroy {
 
     getHostOffset() {
         if (this.getOption('appendTo') === 'body' || this.getOption('appendTo') === 'target') {
-            let offset = this.el.nativeElement.getBoundingClientRect();
+            let offset = this.activeElement.getBoundingClientRect();
             let targetLeft = offset.left + getWindowScrollLeft();
             let targetTop = offset.top + getWindowScrollTop();
 
@@ -540,22 +540,25 @@ export class Tooltip extends BaseComponent implements AfterViewInit, OnDestroy {
 
     alignLeft() {
         this.preAlign('left');
+        const el = this.activeElement;
         let offsetLeft = getOuterWidth(this.container);
-        let offsetTop = (getOuterHeight(this.el.nativeElement) - getOuterHeight(this.container)) / 2;
+        let offsetTop = (getOuterHeight(el) - getOuterHeight(this.container)) / 2;
         this.alignTooltip(-offsetLeft, offsetTop);
     }
 
     alignTop() {
         this.preAlign('top');
-        let offsetLeft = (getOuterWidth(this.el.nativeElement) - getOuterWidth(this.container)) / 2;
+        const el = this.activeElement;
+        let offsetLeft = (getOuterWidth(el) - getOuterWidth(this.container)) / 2;
         let offsetTop = getOuterHeight(this.container);
         this.alignTooltip(offsetLeft, -offsetTop);
     }
 
     alignBottom() {
         this.preAlign('bottom');
-        let offsetLeft = (getOuterWidth(this.el.nativeElement) - getOuterWidth(this.container)) / 2;
-        let offsetTop = getOuterHeight(this.el.nativeElement);
+        const el = this.activeElement;
+        let offsetLeft = (getOuterWidth(el) - getOuterWidth(this.container)) / 2;
+        let offsetTop = getOuterHeight(el);
         this.alignTooltip(offsetLeft, offsetTop);
     }
 


### PR DESCRIPTION
fixes #700 

The issue stems from inconsistent designation of the target element for offset calculations in alignment. User should now be able to use the directive as expected like so:
```html
<div style="width: 250px; height: 200px; overflow: auto">
      <p>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae et leo duis ut diam. Ultricies mi quis hendrerit dolor magna eget est lorem. Amet consectetur adipiscing
          elit ut. Nam libero justo laoreet sit amet. Pharetra massa massa ultricies mi quis hendrerit dolor magna. Est ultricies integer quis auctor elit sed vulputate. Consequat ac felis donec et. Tellus orci ac auctor augue mauris. Semper
          feugiat nibh sed pulvinar proin gravida hendrerit lectus a. Tincidunt arcu non sodales neque sodales. Metus aliquam eleifend mi in nulla posuere sollicitudin aliquam ultrices. Sodales ut etiam sit amet nisl purus. Cursus sit amet
          dictum sit amet. Tristique senectus et netus et malesuada fames ac turpis egestas. Et tortor consequat id porta nibh venenatis cras sed. Diam maecenas ultricies mi eget mauris. Eget egestas purus viverra accumsan in nisl nisi.
          Suscipit adipiscing bibendum est ultricies integer. Mattis aliquam faucibus purus in massa tempor nec.
      </p>
      <p-scrollTop target="parent" [threshold]="100" pTooltip="bottom" tooltipPosition="bottom" />
</div>
```


# Changes
- `align{direction}` and `getHostOffset` methods all consistently use `activeElement`

# Remarks
- This bug also exists in V19. I wasn't sure if PrimeNG was still updating v18, I can backport to v18 if needed.
- I would be very interested in helping out with testing. #745 #733 I saw a lot of type inconsistencies that contribute to many other issues related to `Tooltip`.

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

> Migrated from `primefaces/primeng#17792` — originally by `@tbui17` on 2025-02-28

---
*Original base: `master` @ `fd48576`, head: `fix-tooltip-alignment` @ `f9a4848`*