### PR TITLE
Pass row data so customFilters can utilize rowData

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -2337,7 +2337,7 @@ export class Table extends BaseComponent implements OnInit, AfterViewInit, After
         let dataFieldValue = ObjectUtils.resolveFieldData(rowData, field);
         let filterConstraint = (<any>this.filterService).filters[filterMatchMode];
 
-        return filterConstraint(dataFieldValue, filterValue, this.filterLocale);
+        return filterConstraint(dataFieldValue, filterValue, this.filterLocale, rowData);
     }
 
     hasFilter() {


### PR DESCRIPTION
This commit is an enhancement to table CustomFilter where the rowData can be passed and inspected for more advanced filtering scenarios.



[3625](https://github.com/orgs/primefaces/discussions/3625)

> Migrated from `primefaces/primeng#17703` — originally by `@zatchgordon` on 2025-02-18

---
*Original base: `master` @ `a16ef0c`, head: `customFilterPassRow` @ `7d9daf3`*