### PR TITLE
fix: datepicker touchui not displayed correctly

### DIFF
--- a/apps/showcase/doc/datepicker/touchuidoc.ts
+++ b/apps/showcase/doc/datepicker/touchuidoc.ts
@@ -7,6 +7,7 @@ import { Component } from '@angular/core';
     template: `
         <app-docsectiontext>
             <p>When <i>touchUI</i> is enabled, overlay is displayed as optimized for touch devices.</p>
+            <p>To use the <i>touchUI</i> inside of a <i>p-dialog</i> component, you need to set the <i>appendTo</i> property to <i>body</i>.</p>
         </app-docsectiontext>
         <div class="card flex justify-center">
             <p-datepicker [(ngModel)]="date" [touchUI]="true" [readonlyInput]="true" />

--- a/apps/showcase/pages/datepicker/index.ts
+++ b/apps/showcase/pages/datepicker/index.ts
@@ -23,6 +23,7 @@ import { SizesDoc } from '@/doc/datepicker/sizesdoc';
 import { TimeDoc } from '@/doc/datepicker/timedoc';
 import { YearDoc } from '@/doc/datepicker/yeardoc';
 import { Component } from '@angular/core';
+import { TouchUIDoc } from '../../doc/datepicker/touchuidoc';
 
 @Component({
     standalone: true,
@@ -31,121 +32,30 @@ import { Component } from '@angular/core';
 })
 export class DatePickerDemo {
     docs = [
-        {
-            id: 'import',
-            label: 'Import',
-            component: ImportDoc
-        },
-        {
-            id: 'basic',
-            label: 'Basic',
-            component: BasicDoc
-        },
-        {
-            id: 'reactive-forms',
-            label: 'Reactive Forms',
-            component: ReactiveFormsDoc
-        },
-        {
-            id: 'format',
-            label: 'Format',
-            component: FormatDoc
-        },
-        {
-            id: 'locale',
-            label: 'Locale',
-            component: LocaleDoc
-        },
-        {
-            id: 'icon',
-            label: 'Icon',
-            component: IconDoc
-        },
-        {
-            id: 'minmax',
-            label: 'Min / Max',
-            component: MinMaxDoc
-        },
-        {
-            id: 'multiple',
-            label: 'Multiple',
-            component: MultipleDoc
-        },
-        {
-            id: 'range',
-            label: 'Range',
-            component: RangeDoc
-        },
-        {
-            id: 'buttonbar',
-            label: 'Button Bar',
-            component: ButtonBarDoc
-        },
-        {
-            id: 'time',
-            label: 'Time',
-            component: TimeDoc
-        },
-        {
-            id: 'monthpicker',
-            label: 'Month Picker',
-            component: MonthDoc
-        },
-        {
-            id: 'yearpicker',
-            label: 'Year Picker',
-            component: YearDoc
-        },
-        {
-            id: 'multiplemonths',
-            label: 'Multiple Months',
-            component: MultipleMonthDoc
-        },
-        {
-            id: 'datetemplate',
-            label: 'Date Template',
-            component: DateTemplateDoc
-        },
-        {
-            id: 'inline',
-            label: 'Inline',
-            component: InlineDoc
-        },
-        {
-            id: 'floatlabel',
-            label: 'Float Label',
-            component: FloatLabelDoc
-        },
-        {
-            id: 'iftalabel',
-            label: 'Ifta Label',
-            component: IftaLabelDoc
-        },
-        {
-            id: 'sizes',
-            label: 'Sizes',
-            component: SizesDoc
-        },
-        {
-            id: 'filled',
-            label: 'Filled',
-            component: FilledDoc
-        },
-        {
-            id: 'invalid',
-            label: 'Invalid',
-            component: InvalidDoc
-        },
-        {
-            id: 'disabled',
-            label: 'Disabled',
-            component: DisabledDoc
-        },
+        { id: 'import', label: 'Import', component: ImportDoc },
+        { id: 'basic', label: 'Basic', component: BasicDoc },
+        { id: 'reactive-forms', label: 'Reactive Forms', component: ReactiveFormsDoc },
+        { id: 'format', label: 'Format', component: FormatDoc },
+        { id: 'locale', label: 'Locale', component: LocaleDoc },
+        { id: 'icon', label: 'Icon', component: IconDoc },
+        { id: 'minmax', label: 'Min / Max', component: MinMaxDoc },
+        { id: 'multiple', label: 'Multiple', component: MultipleDoc },
+        { id: 'range', label: 'Range', component: RangeDoc },
+        { id: 'buttonbar', label: 'Button Bar', component: ButtonBarDoc },
+        { id: 'time', label: 'Time', component: TimeDoc },
+        { id: 'monthpicker', label: 'Month Picker', component: MonthDoc },
+        { id: 'yearpicker', label: 'Year Picker', component: YearDoc },
+        { id: 'multiplemonths', label: 'Multiple Months', component: MultipleMonthDoc },
+        { id: 'datetemplate', label: 'Date Template', component: DateTemplateDoc },
+        { id: 'inline', label: 'Inline', component: InlineDoc },
+        { id: 'floatlabel', label: 'Float Label', component: FloatLabelDoc },
+        { id: 'iftalabel', label: 'Ifta Label', component: IftaLabelDoc },
+        { id: 'sizes', label: 'Sizes', component: SizesDoc },
+        { id: 'touchui', label: 'TouchUI', component: TouchUIDoc },
+        { id: 'filled', label: 'Filled', component: FilledDoc },
+        { id: 'invalid', label: 'Invalid', component: InvalidDoc },
+        { id: 'disabled', label: 'Disabled', component: DisabledDoc },
 
-        {
-            id: 'accessibility',
-            label: 'Accessibility',
-            component: AccessibilityDoc
-        }
+        { id: 'accessibility', label: 'Accessibility', component: AccessibilityDoc }
     ];
 }

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -59,11 +59,7 @@ import { Subscription } from 'rxjs';
 import { DatePickerMonthChangeEvent, DatePickerResponsiveOptions, DatePickerTypeView, DatePickerYearChangeEvent, LocaleSettings, Month, NavigationState } from './datepicker.interface';
 import { DatePickerStyle } from './style/datepickerstyle';
 
-export const DATEPICKER_VALUE_ACCESSOR: any = {
-    provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => DatePicker),
-    multi: true
-};
+export const DATEPICKER_VALUE_ACCESSOR: any = { provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => DatePicker), multi: true };
 /**
  * DatePicker is a form component to work with dates.
  * @group Components
@@ -136,13 +132,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                 </button>
                 <ng-container *ngIf="iconDisplay === 'input' && showIcon">
                     <span class="p-datepicker-input-icon-container">
-                        <CalendarIcon
-                            (click)="onButtonClick($event)"
-                            *ngIf="!inputIconTemplate && !_inputIconTemplate"
-                            [ngClass]="{
-                                'p-datepicker-input-icon': showOnFocus
-                            }"
-                        />
+                        <CalendarIcon (click)="onButtonClick($event)" *ngIf="!inputIconTemplate && !_inputIconTemplate" [ngClass]="{ 'p-datepicker-input-icon': showOnFocus }" />
 
                         <ng-container *ngTemplateOutlet="inputIconTemplate || _inputIconTemplate; context: { clickCallBack: onButtonClick.bind(this) }"></ng-container>
                     </span>
@@ -154,10 +144,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                 [class]="panelStyleClass"
                 [ngStyle]="panelStyle"
                 [ngClass]="panelClass"
-                [@overlayAnimation]="{
-                    value: 'visible',
-                    params: { showTransitionParams: showTransitionOptions, hideTransitionParams: hideTransitionOptions }
-                }"
+                [@overlayAnimation]="{ value: 'visible', params: { showTransitionParams: showTransitionOptions, hideTransitionParams: hideTransitionOptions } }"
                 [attr.aria-label]="getTranslation('chooseDate')"
                 [attr.role]="inline ? null : 'dialog'"
                 [attr.aria-modal]="inline ? null : 'true'"
@@ -254,15 +241,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                                                 {{ month.weekNumbers[j] }}
                                             </span>
                                         </td>
-                                        <td
-                                            *ngFor="let date of week"
-                                            [attr.aria-label]="date.day"
-                                            [ngClass]="{
-                                                'p-datepicker-day-cell': true,
-                                                'p-datepicker-other-month': date.otherMonth,
-                                                'p-datepicker-today': date.today
-                                            }"
-                                        >
+                                        <td *ngFor="let date of week" [attr.aria-label]="date.day" [ngClass]="{ 'p-datepicker-day-cell': true, 'p-datepicker-other-month': date.otherMonth, 'p-datepicker-today': date.today }">
                                             <ng-container *ngIf="date.otherMonth ? showOtherMonths : true">
                                                 <span
                                                     [ngClass]="dayClass(date)"
@@ -295,11 +274,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             *ngFor="let m of monthPickerValues(); let i = index"
                             (click)="onMonthSelect($event, i)"
                             (keydown)="onMonthCellKeydown($event, i)"
-                            [ngClass]="{
-                                'p-datepicker-month': true,
-                                'p-datepicker-month-selected': isMonthSelected(i),
-                                'p-disabled': isMonthDisabled(i)
-                            }"
+                            [ngClass]="{ 'p-datepicker-month': true, 'p-datepicker-month-selected': isMonthSelected(i), 'p-disabled': isMonthDisabled(i) }"
                             pRipple
                         >
                             {{ m }}
@@ -313,11 +288,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                             *ngFor="let y of yearPickerValues()"
                             (click)="onYearSelect($event, y)"
                             (keydown)="onYearCellKeydown($event, y)"
-                            [ngClass]="{
-                                'p-datepicker-year': true,
-                                'p-datepicker-year-selected': isYearSelected(y),
-                                'p-disabled': isYearDisabled(y)
-                            }"
+                            [ngClass]="{ 'p-datepicker-year': true, 'p-datepicker-year-selected': isYearSelected(y), 'p-disabled': isYearDisabled(y) }"
                             pRipple
                         >
                             {{ y }}
@@ -502,25 +473,11 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
     `,
     animations: [
         trigger('overlayAnimation', [
-            state(
-                'visibleTouchUI',
-                style({
-                    transform: 'translate(-50%,-50%)',
-                    opacity: 1
-                })
-            ),
+            state('visibleTouchUI', style({ transform: 'translate(-50%,-50%)', opacity: 1 })),
             transition('void => visible', [style({ opacity: 0, transform: 'scaleY(0.8)' }), animate('{{showTransitionParams}}', style({ opacity: 1, transform: '*' }))]),
             transition('visible => void', [animate('{{hideTransitionParams}}', style({ opacity: 0 }))]),
             transition('void => visibleTouchUI', [style({ opacity: 0, transform: 'translate3d(-50%, -40%, 0) scale(0.9)' }), animate('{{showTransitionParams}}')]),
-            transition('visibleTouchUI => void', [
-                animate(
-                    '{{hideTransitionParams}}',
-                    style({
-                        opacity: 0,
-                        transform: 'translate3d(-50%, -40%, 0) scale(0.9)'
-                    })
-                )
-            ])
+            transition('visibleTouchUI => void', [animate('{{hideTransitionParams}}', style({ opacity: 0, transform: 'translate3d(-50%, -40%, 0) scale(0.9)' }))])
         ])
     ],
     providers: [DATEPICKER_VALUE_ACCESSOR, DatePickerStyle],
@@ -1510,25 +1467,12 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
             if (i == 0) {
                 for (let j = prevMonthDaysLength - firstDay + 1; j <= prevMonthDaysLength; j++) {
                     let prev = this.getPreviousMonthAndYear(month, year);
-                    week.push({
-                        day: j,
-                        month: prev.month,
-                        year: prev.year,
-                        otherMonth: true,
-                        today: this.isToday(today, j, prev.month, prev.year),
-                        selectable: this.isSelectable(j, prev.month, prev.year, true)
-                    });
+                    week.push({ day: j, month: prev.month, year: prev.year, otherMonth: true, today: this.isToday(today, j, prev.month, prev.year), selectable: this.isSelectable(j, prev.month, prev.year, true) });
                 }
 
                 let remainingDaysLength = 7 - week.length;
                 for (let j = 0; j < remainingDaysLength; j++) {
-                    week.push({
-                        day: dayNo,
-                        month: month,
-                        year: year,
-                        today: this.isToday(today, dayNo, month, year),
-                        selectable: this.isSelectable(dayNo, month, year, false)
-                    });
+                    week.push({ day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year), selectable: this.isSelectable(dayNo, month, year, false) });
                     dayNo++;
                 }
             } else {
@@ -1544,13 +1488,7 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
                             selectable: this.isSelectable(dayNo - daysLength, next.month, next.year, true)
                         });
                     } else {
-                        week.push({
-                            day: dayNo,
-                            month: month,
-                            year: year,
-                            today: this.isToday(today, dayNo, month, year),
-                            selectable: this.isSelectable(dayNo, month, year, false)
-                        });
+                        week.push({ day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year), selectable: this.isSelectable(dayNo, month, year, false) });
                     }
 
                     dayNo++;
@@ -1564,12 +1502,7 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
             dates.push(week);
         }
 
-        return {
-            month: month,
-            year: year,
-            dates: <any>dates,
-            weekNumbers: weekNumbers
-        };
+        return { month: month, year: year, dates: <any>dates, weekNumbers: weekNumbers };
     }
 
     initTime(date: Date) {
@@ -2163,10 +2096,7 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
     }
 
     onOverlayClick(event: Event) {
-        this.overlayService.add({
-            originalEvent: event,
-            target: this.el.nativeElement
-        });
+        this.overlayService.add({ originalEvent: event, target: this.el.nativeElement });
     }
 
     getMonthName(index: number) {
@@ -3185,8 +3115,10 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
                     this.overlay = event.element;
                     this.overlay?.setAttribute(this.attributeSelector as string, '');
 
-                    const styles = !this.inline ? { position: 'absolute', top: '0', left: '0' } : undefined;
-                    addStyle(this.overlay, styles);
+                    if (!this.touchUI) {
+                        const styles = !this.inline ? { position: 'absolute', top: '0', left: '0' } : undefined;
+                        addStyle(this.overlay, styles);
+                    }
 
                     this.appendOverlay();
                     this.updateFocus();
@@ -3698,14 +3630,7 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
 
     onTodayButtonClick(event: any) {
         const date: Date = new Date();
-        const dateMeta = {
-            day: date.getDate(),
-            month: date.getMonth(),
-            year: date.getFullYear(),
-            otherMonth: date.getMonth() !== this.currentMonth || date.getFullYear() !== this.currentYear,
-            today: true,
-            selectable: true
-        };
+        const dateMeta = { day: date.getDate(), month: date.getMonth(), year: date.getFullYear(), otherMonth: date.getMonth() !== this.currentMonth || date.getFullYear() !== this.currentYear, today: true, selectable: true };
 
         this.createMonths(date.getMonth(), date.getFullYear());
         this.onDateSelect(event, dateMeta);
@@ -3874,8 +3799,5 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
     }
 }
 
-@NgModule({
-    imports: [DatePicker, SharedModule],
-    exports: [DatePicker, SharedModule]
-})
+@NgModule({ imports: [DatePicker, SharedModule], exports: [DatePicker, SharedModule] })
 export class DatePickerModule {}

--- a/packages/primeng/src/datepicker/style/datepickerstyle.ts
+++ b/packages/primeng/src/datepicker/style/datepickerstyle.ts
@@ -81,7 +81,7 @@ const theme = ({ dt }) => `
     width: 1%;
 }
 
-.p-datepicker .p-datepicker-panel {
+.p-datepicker .p-datepicker-panel: not(.p-datepicker-touchui) {
     min-width: 100%;
 }
 
@@ -254,6 +254,14 @@ const theme = ({ dt }) => `
     color: ${dt('datepicker.date.range.selected.color')};
 }
 
+.p-datepicker-touchui {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    min-width: 80vw;
+    transform: translate(-50%, -50%);
+}
+
 .p-datepicker-weeknumber {
     text-align: center
 }
@@ -409,9 +417,7 @@ p-datepicker.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext{
 }
 `;
 
-const inlineStyles = {
-    root: ({ props }) => ({ position: props.appendTo === 'self' ? 'relative' : undefined })
-};
+const inlineStyles = { root: ({ props }) => ({ position: props.appendTo === 'self' ? 'relative' : undefined }) };
 
 const classes = {
     root: ({ instance }) => ({
@@ -426,12 +432,7 @@ const classes = {
     dropdown: 'p-datepicker-dropdown',
     inputIconContainer: 'p-datepicker-input-icon-container',
     inputIcon: 'p-datepicker-input-icon',
-    panel: ({ instance }) => ({
-        'p-datepicker-panel p-component': true,
-        'p-datepicker-panel-inline': instance.inline,
-        'p-disabled': instance.disabled,
-        'p-datepicker-timeonly': instance.timeOnly
-    }),
+    panel: ({ instance }) => ({ 'p-datepicker-panel p-component': true, 'p-datepicker-panel-inline': instance.inline, 'p-disabled': instance.disabled, 'p-datepicker-timeonly': instance.timeOnly, 'p-datepicker-touchui': instance.touchUI }),
     calendarContainer: 'p-datepicker-calendar-container',
     calendar: 'p-datepicker-calendar',
     header: 'p-datepicker-header',
@@ -447,13 +448,7 @@ const classes = {
     weekLabelContainer: 'p-datepicker-weeklabel-container p-disabled',
     weekDayCell: 'p-datepicker-weekday-cell',
     weekDay: 'p-datepicker-weekday',
-    dayCell: ({ date }) => [
-        'p-datepicker-day-cell',
-        {
-            'p-datepicker-other-month': date.otherMonth,
-            'p-datepicker-today': date.today
-        }
-    ],
+    dayCell: ({ date }) => ['p-datepicker-day-cell', { 'p-datepicker-other-month': date.otherMonth, 'p-datepicker-today': date.today }],
     day: ({ instance, date }) => {
         let selectedDayClass = '';
 
@@ -461,29 +456,12 @@ const classes = {
             selectedDayClass = date.day === instance.value[0].getDate() || date.day === instance.value[1].getDate() ? 'p-datepicker-day-selected' : 'p-datepicker-day-selected-range';
         }
 
-        return {
-            'p-datepicker-day': true,
-            'p-datepicker-day-selected': !instance.isRangeSelection() && instance.isSelected(date) && date.selectable,
-            'p-disabled': instance.disabled || !date.selectable,
-            [selectedDayClass]: true
-        };
+        return { 'p-datepicker-day': true, 'p-datepicker-day-selected': !instance.isRangeSelection() && instance.isSelected(date) && date.selectable, 'p-disabled': instance.disabled || !date.selectable, [selectedDayClass]: true };
     },
     monthView: 'p-datepicker-month-view',
-    month: ({ instance, props, month, index }) => [
-        'p-datepicker-month',
-        {
-            'p-datepicker-month-selected': instance.isMonthSelected(index),
-            'p-disabled': props.disabled || !month.selectable
-        }
-    ],
+    month: ({ instance, props, month, index }) => ['p-datepicker-month', { 'p-datepicker-month-selected': instance.isMonthSelected(index), 'p-disabled': props.disabled || !month.selectable }],
     yearView: 'p-datepicker-year-view',
-    year: ({ instance, props, year }) => [
-        'p-datepicker-year',
-        {
-            'p-datepicker-year-selected': instance.isYearSelected(year.value),
-            'p-disabled': props.disabled || !year.selectable
-        }
-    ],
+    year: ({ instance, props, year }) => ['p-datepicker-year', { 'p-datepicker-year-selected': instance.isYearSelected(year.value), 'p-disabled': props.disabled || !year.selectable }],
     timePicker: 'p-datepicker-time-picker',
     hourPicker: 'p-datepicker-hour-picker',
     pcIncrementButton: 'p-datepicker-increment-button',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: catalog:angular19
-        version: 19.1.7(h5whjz7uufjdp3fy577dvyuwni)
+        version: 19.1.7(jtrmt4d4dw5yzi2p4ikvz3su2q)
       '@angular-eslint/eslint-plugin':
         specifier: catalog:angular19
         version: 19.1.0(@typescript-eslint/utils@8.24.0(eslint@9.20.1(jiti@2.4.2))(typescript@5.5.4))(eslint@9.20.1(jiti@2.4.2))(typescript@5.5.4)
@@ -173,7 +173,7 @@ importers:
         version: 12.5.0
       ng-packagr:
         specifier: catalog:angular19
-        version: 19.1.2(@angular/compiler-cli@19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.5.4)))(tslib@2.8.1)(typescript@5.5.4)
+        version: 19.1.2(@angular/compiler-cli@19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4))(tailwindcss@3.4.17)(tslib@2.8.1)(typescript@5.5.4)
       pnpm:
         specifier: ^9.6.0
         version: 9.15.5
@@ -3495,8 +3495,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.100:
-    resolution: {integrity: sha512-u1z9VuzDXV86X2r3vAns0/5ojfXBue9o0+JDUDBKYqGLjxLkSqsSUoPU/6kW0gx76V44frHaf6Zo+QF74TQCMg==}
+  electron-to-chromium@1.5.101:
+    resolution: {integrity: sha512-L0ISiQrP/56Acgu4/i/kfPwWSgrzYZUnQrC0+QPFuhqlLP1Ir7qzPPDVS9BcKIyWTRU8+o6CC8dKw38tSWhYIA==}
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -5548,8 +5548,8 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  readdirp@4.1.1:
-    resolution: {integrity: sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==}
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
   reflect-metadata@0.2.2:
@@ -6781,13 +6781,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@19.1.7(h5whjz7uufjdp3fy577dvyuwni)':
+  '@angular-devkit/build-angular@19.1.7(jtrmt4d4dw5yzi2p4ikvz3su2q)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1901.7(chokidar@4.0.3)
       '@angular-devkit/build-webpack': 0.1901.7(chokidar@4.0.3)(webpack-dev-server@5.2.0(webpack@5.97.1(esbuild@0.24.2)))(webpack@5.97.1(esbuild@0.24.2))
       '@angular-devkit/core': 19.1.7(chokidar@4.0.3)
-      '@angular/build': 19.1.7(y4om26ytc7zxdo4eelgapv24qq)
+      '@angular/build': 19.1.7(3youxeedwmlytptcqxwnfzgg6a)
       '@angular/compiler-cli': 19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4)
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.3
@@ -6845,7 +6845,7 @@ snapshots:
       '@angular/ssr': 19.1.7(ufzxe4wxd22z3jdz3d3mzy5roy)
       esbuild: 0.24.2
       karma: 6.4.4
-      ng-packagr: 19.1.2(@angular/compiler-cli@19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.5.4)))(tslib@2.8.1)(typescript@5.5.4)
+      ng-packagr: 19.1.2(@angular/compiler-cli@19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4))(tailwindcss@3.4.17)(tslib@2.8.1)(typescript@5.5.4)
       tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.5.4))
     transitivePeerDependencies:
       - '@angular/compiler'
@@ -6956,7 +6956,7 @@ snapshots:
       '@angular/core': 19.1.6(rxjs@7.8.1)(zone.js@0.15.0)
       tslib: 2.8.1
 
-  '@angular/build@19.1.7(y4om26ytc7zxdo4eelgapv24qq)':
+  '@angular/build@19.1.7(3youxeedwmlytptcqxwnfzgg6a)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1901.7(chokidar@4.0.3)
@@ -6992,7 +6992,7 @@ snapshots:
       '@angular/ssr': 19.1.7(ufzxe4wxd22z3jdz3d3mzy5roy)
       less: 4.2.1
       lmdb: 3.2.2
-      ng-packagr: 19.1.2(@angular/compiler-cli@19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.5.4)))(tslib@2.8.1)(typescript@5.5.4)
+      ng-packagr: 19.1.2(@angular/compiler-cli@19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4))(tailwindcss@3.4.17)(tslib@2.8.1)(typescript@5.5.4)
       postcss: 8.4.49
       tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.5.4))
     transitivePeerDependencies:
@@ -9484,7 +9484,7 @@ snapshots:
   browserslist@4.24.4:
     dependencies:
       caniuse-lite: 1.0.30001699
-      electron-to-chromium: 1.5.100
+      electron-to-chromium: 1.5.101
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
 
@@ -9587,7 +9587,7 @@ snapshots:
 
   chokidar@4.0.3:
     dependencies:
-      readdirp: 4.1.1
+      readdirp: 4.1.2
 
   chownr@2.0.0: {}
 
@@ -9996,7 +9996,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.100: {}
+  electron-to-chromium@1.5.101: {}
 
   emoji-regex@10.4.0: {}
 
@@ -11731,7 +11731,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  ng-packagr@19.1.2(@angular/compiler-cli@19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4))(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.4)(typescript@5.5.4)))(tslib@2.8.1)(typescript@5.5.4):
+  ng-packagr@19.1.2(@angular/compiler-cli@19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4))(tailwindcss@3.4.17)(tslib@2.8.1)(typescript@5.5.4):
     dependencies:
       '@angular/compiler-cli': 19.1.6(@angular/compiler@19.1.6(@angular/core@19.1.6(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.5.4)
       '@rollup/plugin-json': 6.1.0(rollup@4.34.7)
@@ -12311,7 +12311,7 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
-  readdirp@4.1.1: {}
+  readdirp@4.1.2: {}
 
   reflect-metadata@0.2.2: {}
 


### PR DESCRIPTION
#17635

## What was the issue?

The problem was that the position absolute was not correct. I fixed it by using the p-datepicker-touchui class and only adding it when its actually an touchui datepicker. Otherwise the position: absolute will be used.

Also I added the touchUI back to the showcase. I added a little extra info for usage inside of p-dialog. The [appendto]="'body'" is needed because the overlay-mask is added with zIndex=1103 on the root of body. If the datepicker is not on root of body as well it will be behind the overlay-mask.

Maybe some day I have the time to find a solution that this component is smart enough to know where it should append itself.

PS. I hope the formatting is okay. I ran 'pnpm format'

> Migrated from `primefaces/primeng#17689` — originally by `@jjs98` on 2025-02-15

---
*Original base: `master` @ `de7c494`, head: `fix/issue-17635` @ `2bf65a4`*