### PR TITLE
feat(fileupload): add locale and improve formatSize functionality

### DIFF
--- a/packages/primeng/src/fileupload/fileupload.ts
+++ b/packages/primeng/src/fileupload/fileupload.ts
@@ -317,6 +317,11 @@ export class FileUpload extends BaseComponent implements AfterViewInit, AfterCon
      */
     @Input() invalidFileLimitMessageSummary: string = 'Maximum number of files exceeded, ';
     /**
+     * Locale used to format the maxFileSize within invalidFileSizeMessageDetail accordingly
+     * @group Props
+     */
+    @Input() locale: string = 'en-US';
+    /**
      * Inline style of the element.
      * @group Props
      */
@@ -1046,7 +1051,6 @@ export class FileUpload extends BaseComponent implements AfterViewInit, AfterCon
 
     formatSize(bytes: number) {
         const k = 1024;
-        const dm = 3;
         const sizes = this.getTranslation(TranslationKeys.FILE_SIZE_TYPES);
 
         if (bytes === 0) {
@@ -1054,7 +1058,10 @@ export class FileUpload extends BaseComponent implements AfterViewInit, AfterCon
         }
 
         const i = Math.floor(Math.log(bytes) / Math.log(k));
-        const formattedSize = (bytes / Math.pow(k, i)).toFixed(dm);
+        const formattedSize = (bytes / Math.pow(k, i)).toLocaleString(this.locale, {
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 3
+        });
 
         return `${formattedSize} ${sizes[i]}`;
     }


### PR DESCRIPTION
Implements: https://github.com/primefaces/primeng/issues/587

`formatSize()` shows with this change the decimal points only if they are needed and only as many as needed.
Further, a locale can be defined so that the decimal is properly formatted depending on the language.

> Migrated from `primefaces/primeng#17662` — originally by `@gregorwinkler` on 2025-02-12

---
*Original base: `master` @ `cd5848c`, head: `feat/fileupload-filesize-improvements-17659` @ `db0df71`*