### PR TITLE
fix(datepicker): monthpicker now is getting selected (#17452)

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -1985,8 +1985,10 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
     isMonthSelected(month: number) {
         if (this.isComparable() && !this.isMultipleSelection()) {
             const [start, end] = this.isRangeSelection() ? this.value : [this.value, this.value];
-            const selected = new Date(this.currentYear, month, 1);
-            return selected >= start && selected <= (end ?? start);
+
+            const isSameMonth = (date: Date, month: number) => date.getFullYear() === this.currentYear && date.getMonth() === month;
+
+            return isSameMonth(start, month) || isSameMonth(end ?? start, month);
         }
         return false;
     }


### PR DESCRIPTION
### Problems identified during this fix:

1. Monthpicker was getting selected only when the 1st day of the month was chosen. The same problem exists in version 19,18 and 17. 

### Changes made in this fix:

1. Previuosly monthpicker was not getting selected when date was chosen other than the 1st day of the month. Now month will be selected for any date chosen within the month.

### Implementation Details:

1. The logic of `isMonthSelected` function in `datepicker.ts` file had a bug. Previously the logic was able to set to true only for the first day of the month. Now it will not check the date. Rather it will check whether the selected month and year is within the date range.

> Migrated from `primefaces/primeng#17655` — originally by `@farihaChowdhury` on 2025-02-12

---
*Original base: `master` @ `cd5848c`, head: `fix/#17452-datepicker-month-and-year-selection` @ `c276548`*