### PR TITLE
fix(picklist): emit events for mouse and keyboard selection

### DIFF
--- a/packages/primeng/src/picklist/picklist.spec.ts
+++ b/packages/primeng/src/picklist/picklist.spec.ts
@@ -1,0 +1,101 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PickList } from './picklist';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+import { Component } from '@angular/core';
+import { PickListSourceSelectEvent, PickListTargetSelectEvent } from './picklist.interface';
+
+@Component({
+    imports: [PickList],
+    template: ` <p-pickList [source]="source" [target]="target">
+        <ng-template #item let-item>
+            {{ item.name }}
+        </ng-template>
+    </p-pickList>`
+})
+class TestPickListComponent {
+    source: any[];
+    target: any[];
+
+    ngOnInit() {
+        this.source = [
+            {
+                name: 'Item A'
+            },
+            {
+                name: 'Item B'
+            }
+        ];
+        this.target = [
+            {
+                name: 'Item C'
+            }
+        ];
+    }
+}
+
+describe('PickList', () => {
+    let component: PickList;
+    let fixture: ComponentFixture<TestPickListComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule]
+        });
+        fixture = TestBed.createComponent(TestPickListComponent);
+        fixture.detectChanges();
+        component = fixture.debugElement.children[0].componentInstance;
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    describe('selection', () => {
+        it('should emit onSourceSelect on mouse click', async () => {
+            const item = fixture.debugElement.query(By.css('.p-picklist-source-list-container .p-listbox-option')).nativeElement as HTMLElement;
+
+            let event: PickListSourceSelectEvent;
+            component.onSourceSelect.subscribe((e) => (event = e));
+
+            item.click();
+
+            expect(event.items).toEqual([{ name: 'Item A' }]);
+        });
+
+        it('should emit onSourceSelect on space key', async () => {
+            const item = fixture.debugElement.query(By.css('.p-picklist-source-list-container .p-listbox-option')).nativeElement as HTMLElement;
+            item.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown', bubbles: true })); // focus first element
+
+            let event: PickListSourceSelectEvent;
+            component.onSourceSelect.subscribe((e) => (event = e));
+
+            item.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', bubbles: true }));
+
+            expect(event.items).toEqual([{ name: 'Item A' }]);
+        });
+
+        it('should emit onTargetSelect on mouse click', async () => {
+            const item = fixture.debugElement.query(By.css('.p-picklist-target-list-container .p-listbox-option')).nativeElement as HTMLElement;
+
+            let event: PickListTargetSelectEvent;
+            component.onTargetSelect.subscribe((e) => (event = e));
+
+            item.click();
+
+            expect(event.items).toEqual([{ name: 'Item C' }]);
+        });
+
+        it('should emit onTargetSelect on space key', async () => {
+            const item = fixture.debugElement.query(By.css('.p-picklist-target-list-container .p-listbox-option')).nativeElement as HTMLElement;
+            item.dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown', bubbles: true })); // focus first element
+
+            let event: PickListTargetSelectEvent;
+            component.onTargetSelect.subscribe((e) => (event = e));
+
+            item.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space', bubbles: true }));
+
+            expect(event.items).toEqual([{ name: 'Item C' }]);
+        });
+    });
+});


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/660

This PR removes a lot of code from the PickList component that tries to deal with selection and focus - which is already done by the ListBox component itself. Also, some of this code was actually never used (like `onItemClick`).

After this PR the PickList component also emits events for selection changes again, which fixes the bug mentioned above.

> Migrated from `primefaces/primeng#17638` — originally by `@infe42` on 2025-02-11

---
*Original base: `master` @ `1bac192`, head: `feature/picklist-selection` @ `15927a6`*