### PR TITLE
fix: pnpm run build:apidoc

### DIFF
--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -9,8 +9,8 @@
         "e2e": "ng e2e",
         "lint": "ng lint",
         "build": "ng build",
-        "build:apidoc": "node ./scripts/build-apidoc.ts",
-        "build:themedoc": "node ./scripts/build-themedoc.ts",
+        "build:apidoc": "tsx ./scripts/build-apidoc.ts",
+        "build:themedoc": "tsx ./scripts/build-themedoc.ts",
         "build:docs": "npm run build:apidoc && npm run build:themedoc"
     },
     "repository": {
@@ -46,7 +46,7 @@
         "prismjs": "^1.29.0",
         "quill": "2.0.2",
         "rxjs": "~7.8.1",
-        "ts-node": "~10.9.1",
+        "tsx": "~4.19.2",
         "tslib": "^2.5.0",
         "typedoc": "0.27.4",
         "xlsx": "^0.18.5",

--- a/apps/showcase/scripts/build-themedoc.ts
+++ b/apps/showcase/scripts/build-themedoc.ts
@@ -1,16 +1,15 @@
-//@ts-ignore
-const TypeDoc = require('typedoc');
-//@ts-ignore
-const path = require('path');
-//@ts-ignore
-const fs = require('fs');
-//@ts-ignore
+import { Application } from 'typedoc';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import * as fs from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '../../../packages/themes');
-//@ts-ignore
 const outputPath = path.resolve(__dirname, '../../../apps/showcase/doc/apidoc/');
 
 async function themedoc() {
-    const app = await TypeDoc.Application.bootstrapWithPlugins({
+    const app = await Application.bootstrapWithPlugins({
         // themedoc options here
         name: 'PrimeNG',
         entryPoints: [`${rootDir}/types`],


### PR DESCRIPTION
### Defect Fixes
[#610 build:apidoc fails](https://github.com/primefaces/primeng/issues/610)

- replace `ts-node` with `tsx` to run the `.ts`-files
- refactor use `import` instead of `require`
- use matching `typescript types`

> Migrated from `primefaces/primeng#17551` — originally by `@mtrefzer` on 2025-01-31

---
*Original base: `master` @ `bd011b8`, head: `fix/#17550-build-apidoc-fails` @ `c98bac6`*