### PR TITLE
Fix #16835: Improve Calendar Component Typing

### DIFF
--- a/src/app/components/calendar/calendar.interface.ts
+++ b/src/app/components/calendar/calendar.interface.ts
@@ -164,8 +164,8 @@ export interface CalendarDate {
     day: number;
     month: number;
     year: number;
-    today: boolean;
     selectable: boolean;
+    today?: boolean;
     otherMonth?: boolean;
 }
 

--- a/src/app/components/calendar/calendar.interface.ts
+++ b/src/app/components/calendar/calendar.interface.ts
@@ -133,9 +133,9 @@ export interface Month {
      */
     year?: number;
     /**
-     * Array of dates.
+     * Array of weeks, which are arrays of dates
      */
-    dates?: Date[];
+    dates?: CalendarDate[][];
     /**
      * Array of week numbers.
      */
@@ -155,6 +155,20 @@ export interface CalendarResponsiveOptions {
      */
     numMonths?: number;
 }
+
+/**
+ * Custom Date object for Calendar display
+ * @group Interface
+ */
+export interface CalendarDate {
+    day: number;
+    month: number;
+    year: number;
+    today: boolean;
+    selectable: boolean;
+    otherMonth?: boolean;
+}
+
 /**
  * Custom type for the calendar views.
  * @group Types

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -37,7 +37,7 @@ import { ChevronDownIcon } from 'primeng/icons/chevrondown';
 import { TimesIcon } from 'primeng/icons/times';
 import { CalendarIcon } from 'primeng/icons/calendar';
 import { Nullable, VoidListener } from 'primeng/ts-helpers';
-import { CalendarMonthChangeEvent, CalendarResponsiveOptions, CalendarTypeView, CalendarYearChangeEvent, LocaleSettings, Month, NavigationState } from './calendar.interface';
+import { CalendarDate, CalendarMonthChangeEvent, CalendarResponsiveOptions, CalendarTypeView, CalendarYearChangeEvent, LocaleSettings, Month, NavigationState } from './calendar.interface';
 import { AutoFocusModule } from 'primeng/autofocus';
 
 export const CALENDAR_VALUE_ACCESSOR: any = {
@@ -1349,7 +1349,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
     }
 
     createMonth(month: number, year: number): Month {
-        let dates = [];
+        let dates: CalendarDate[][] = [];
         let firstDay = this.getFirstDayOfMonthIndex(month, year);
         let daysLength = this.getDaysCountInMonth(month, year);
         let prevMonthDaysLength = this.getDaysCountInPrevMonth(month, year);
@@ -1359,7 +1359,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         let monthRows = Math.ceil((daysLength + firstDay) / 7);
 
         for (let i = 0; i < monthRows; i++) {
-            let week = [];
+            let week: CalendarDate[] = [];
 
             if (i == 0) {
                 for (let j = prevMonthDaysLength - firstDay + 1; j <= prevMonthDaysLength; j++) {
@@ -1399,12 +1399,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
             dates.push(week);
         }
 
-        return {
-            month: month,
-            year: year,
-            dates: <any>dates,
-            weekNumbers: weekNumbers
-        };
+        return { month, year, dates, weekNumbers };
     }
 
     initTime(date: Date) {
@@ -1882,7 +1877,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         return today.getDate() === day && today.getMonth() === month && today.getFullYear() === year;
     }
 
-    isSelectable(day: any, month: any, year: any, otherMonth: any): boolean {
+    isSelectable(day: number, month: number, year: number, otherMonth: boolean): boolean {
         let validMin = true;
         let validMax = true;
         let validDate = true;

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1071,7 +1071,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
 
     filled: Nullable<boolean>;
 
-    inputFieldValue: Nullable<string> = null;
+    inputFieldValue: Nullable<string | Date> = null;
 
     _minDate?: Date | null;
 
@@ -1580,7 +1580,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
     }
 
     updateInputfield() {
-        let formattedValue = '';
+        let formattedValue: Date | string = '';
 
         if (this.value) {
             if (this.isSingleSelection()) {
@@ -1613,8 +1613,8 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         }
     }
 
-    formatDateTime(date: any) {
-        let formattedValue = this.keepInvalid ? date : null;
+    formatDateTime(date: Date): string | Date {
+        let formattedValue: string | Date = this.keepInvalid ? date : null;
         const isDateValid = this.isValidDateForTimeConstraints(date);
 
         if (this.isValidDate(date)) {
@@ -3269,7 +3269,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         return output;
     }
 
-    formatTime(date: any) {
+    formatTime(date: Date) {
         if (!date) {
             return '';
         }

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1516,7 +1516,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         event.preventDefault();
     }
 
-    onDateSelect(event: Event, dateMeta: any) {
+    onDateSelect(event: Event, dateMeta: CalendarDate) {
         if (this.disabled || !dateMeta.selectable) {
             event.preventDefault();
             return;
@@ -1531,7 +1531,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
             }
             this.updateModel(this.value);
         } else {
-            if (this.shouldSelectDate(dateMeta)) {
+            if (this.shouldSelectDate()) {
                 this.selectDate(dateMeta);
             }
         }
@@ -1553,7 +1553,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         event.preventDefault();
     }
 
-    shouldSelectDate(dateMeta: any) {
+    shouldSelectDate() {
         if (this.isMultipleSelection()) return this.maxDateCount != null ? this.maxDateCount > (this.value ? this.value.length : 0) : true;
         else return true;
     }
@@ -1633,7 +1633,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         return formattedValue;
     }
 
-    formatDateMetaToDate(dateMeta: any): Date {
+    formatDateMetaToDate(dateMeta: CalendarDate): Date {
         return new Date(dateMeta.year, dateMeta.month, dateMeta.day);
     }
 
@@ -1660,7 +1660,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         this.alignOverlay();
     }
 
-    selectDate(dateMeta: any) {
+    selectDate(dateMeta: CalendarDate) {
         let date = this.formatDateMetaToDate(dateMeta);
 
         if (this.showTime) {
@@ -1785,7 +1785,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         return firstDayOfWeek > 0 ? 7 - firstDayOfWeek : 0;
     }
 
-    isSelected(dateMeta: any): boolean | undefined {
+    isSelected(dateMeta: CalendarDate): boolean | undefined {
         if (this.value) {
             if (this.isSingleSelection()) {
                 return this.isDateEquals(this.value, dateMeta);
@@ -1846,12 +1846,12 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         return value ? value.getFullYear() === year : false;
     }
 
-    isDateEquals(value: any, dateMeta: any) {
+    isDateEquals(value: any, dateMeta: CalendarDate) {
         if (value && ObjectUtils.isDate(value)) return value.getDate() === dateMeta.day && value.getMonth() === dateMeta.month && value.getFullYear() === dateMeta.year;
         else return false;
     }
 
-    isDateBetween(start: Date, end: Date, dateMeta: any) {
+    isDateBetween(start: Date, end: Date, dateMeta: CalendarDate) {
         let between: boolean = false;
         if (ObjectUtils.isDate(start) && ObjectUtils.isDate(end)) {
             let date: Date = this.formatDateMetaToDate(dateMeta);
@@ -2071,7 +2071,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         }
     }
 
-    onDateCellKeydown(event: any, dateMeta: any, groupIndex: number) {
+    onDateCellKeydown(event: any, dateMeta: CalendarDate, groupIndex: number) {
         const cellContent = event.currentTarget;
         const cell = cellContent.parentElement;
         const currentDate = this.formatDateMetaToDate(dateMeta);
@@ -3524,7 +3524,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
 
     onTodayButtonClick(event: any) {
         const date: Date = new Date();
-        const dateMeta = { day: date.getDate(), month: date.getMonth(), year: date.getFullYear(), otherMonth: date.getMonth() !== this.currentMonth || date.getFullYear() !== this.currentYear, today: true, selectable: true };
+        const dateMeta: CalendarDate = { day: date.getDate(), month: date.getMonth(), year: date.getFullYear(), otherMonth: date.getMonth() !== this.currentMonth || date.getFullYear() !== this.currentYear, today: true, selectable: true };
 
         this.createMonths(date.getMonth(), date.getFullYear());
         this.onDateSelect(event, dateMeta);


### PR DESCRIPTION
Fix for #739
Improve typing on calendar component by creating an interface for the date object.

Update types to use new interface

> Migrated from `primefaces/primeng#17489` — originally by `@zachary-svoboda-accesso` on 2025-01-24

---
*Original base: `master` @ `248249e`, head: `16835` @ `efde6f5`*