### PR TITLE
Fixed a problem inside tabpanel component

### DIFF
--- a/packages/primeng/src/tabs/tabpanel.ts
+++ b/packages/primeng/src/tabs/tabpanel.ts
@@ -12,12 +12,13 @@ import { Tabs } from './tabs';
     selector: 'p-tabpanel',
     standalone: true,
     imports: [CommonModule],
-    template: `@if (active()) {
+    template: `
         <ng-content></ng-content>
-    }`,
+    `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
+        '[class.hidden]': '!active()',
         '[class.p-tabpanel]': 'true',
         '[class.p-component]': 'true',
         '[attr.data-pc-name]': '"tabpanel"',


### PR DESCRIPTION
#630

### Problems
The if inside tabpanel template made a problem in some components, When i use amcharts graphs(https://www.amcharts.com/demos-v4/) inside tabs, they need to draw graphs again.

> Migrated from `primefaces/primeng#17445` — originally by `@akbardoosti` on 2025-01-21

---
*Original base: `master` @ `8266fe0`, head: `patch-2` @ `9e449e7`*