### PR TITLE
fix: Fixes #17260 Floatlabel overlaps placeholder

### DIFF
--- a/packages/primeng/src/floatlabel/style/floatlabelstyle.ts
+++ b/packages/primeng/src/floatlabel/style/floatlabelstyle.ts
@@ -47,6 +47,16 @@ const theme = ({ dt }) => `
     font-weight: ${dt('floatlabel.label.active.font.weight')};
 }
 
+.p-floatlabel:not(:has(input:focus)) input::placeholder,
+.p-floatlabel:not(:has(input.p-filled)) input::placeholder,
+.p-floatlabel:not(:has(input:-webkit-autofill)) input::placeholder,
+.p-floatlabel:not(:has(textarea:focus)) textarea::placeholder,
+.p-floatlabel:not(:has(textarea.p-filled)) textarea::placeholder,
+.p-floatlabel:not(:has(.p-inputwrapper-focus)) input::placeholder,
+.p-floatlabel:not(:has(.p-inputwrapper-filled)) input::placeholder {
+    visibility: hidden;
+}
+
 .p-floatlabel:has(input.p-filled) label,
 .p-floatlabel:has(textarea.p-filled) label,
 .p-floatlabel:has(.p-inputwrapper-filled) label {
@@ -58,6 +68,13 @@ const theme = ({ dt }) => `
 .p-floatlabel:has(textarea:focus) label,
 .p-floatlabel:has(.p-inputwrapper-focus) label {
     color: ${dt('floatlabel.focus.color')};
+}
+
+.p-floatlabel:has(input:focus) input::placeholder,
+.p-floatlabel:has(input:-webkit-autofill) input::placeholder,
+.p-floatlabel:has(textarea:focus) input::placeholder,
+.p-floatlabel:has(.p-inputwrapper-focus) input::placeholder {
+    visibility: visible;
 }
 
 .p-floatlabel-in .p-inputtext,


### PR DESCRIPTION
### Defect Fixes
Fixes [#17260](https://github.com/primefaces/primeng/issues/17260)

**Code**
` <p-floatLabel>
                <input type="text" pInputText id="website" placeholder="placeholder" />
                <label for="website">Sample Label</label>
  </p-floatLabel>`

**Issue**
![image](https://github.com/user-attachments/assets/4811dca5-e04e-435e-9a9e-44eb20990c79)

**Result**
![image](https://github.com/user-attachments/assets/6cd9fe4c-17c8-4fe4-947b-936d37337a74)
![image](https://github.com/user-attachments/assets/814ebc43-1d4f-47cd-982b-8fa51b3d000f)

The placeholder is now hidden when the floatlabel is displayed on the input field.

> Migrated from `primefaces/primeng#17298` — originally by `@wissamnoureddine` on 2025-01-05

---
*Original base: `master` @ `df74566`, head: `fix-floatlabel-overlaps-placeholder` @ `4e17a17`*