### PR TITLE
fix: p-select not propagating tab keyboard event

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -1970,7 +1970,6 @@ export class Select extends BaseComponent implements OnInit, AfterViewInit, Afte
                 this.overlayVisible && this.hide(this.filter);
             }
         }
-        event.stopPropagation();
     }
 
     onFirstHiddenFocus(event) {


### PR DESCRIPTION
In the Select component, `Tab` key press isn't propagating a keyboard event up.

This affects primeng v17, v18, and v19.

Fix to https://github.com/primefaces/primeng/issues/675

> Migrated from `primefaces/primeng#17247` — originally by `@JamesTheTerry` on 2024-12-29

---
*Original base: `master` @ `df74566`, head: `p-select-tab-keyboard-event` @ `f57cc8c`*