### PR TITLE
fix(autocomplete): correctly handle label in case of object and not inputLabel

### DIFF
--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -6,9 +6,9 @@ import {
     computed,
     ContentChild,
     ContentChildren,
-    EmbeddedViewRef,
     effect,
     ElementRef,
+    EmbeddedViewRef,
     EventEmitter,
     forwardRef,
     HostListener,
@@ -16,7 +16,6 @@ import {
     InjectionToken,
     input,
     Input,
-    isDevMode,
     NgModule,
     NgZone,
     numberAttribute,
@@ -978,7 +977,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         private zone: NgZone
     ) {
         super();
-        if (isDevMode()) {
+        if (ngDevMode) {
             const refEffect = effect(() => {
                 const value = this.modelValue();
                 const label = this.optionLabel;

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -7,6 +7,7 @@ import {
     ContentChild,
     ContentChildren,
     EmbeddedViewRef,
+    effect,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -15,6 +16,7 @@ import {
     InjectionToken,
     input,
     Input,
+    isDevMode,
     NgModule,
     NgZone,
     numberAttribute,
@@ -910,7 +912,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
                 const label = this.getOptionLabel(selectedOption);
 
-                return label != null ? label : modelValue;
+                return label != null ? (typeof label === 'object' ? '' : label) : modelValue;
             } else {
                 return modelValue;
             }
@@ -976,6 +978,18 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         private zone: NgZone
     ) {
         super();
+        if (isDevMode()) {
+            const refEffect = effect(() => {
+                const value = this.modelValue();
+                const label = this.optionLabel;
+                const valueField = this.optionValue;
+                const isMultiple = this.multiple;
+                if (!isMultiple && isNotEmpty(value) && typeof value === 'object' && (!label || !valueField)) {
+                    console.warn('When using an object as a model value, you must define optionLabel and optionValue property to determine how to display the selected value.');
+                    refEffect.destroy();
+                }
+            });
+        }
     }
 
     onInit() {


### PR DESCRIPTION
Close #901 and added a "one time" warning, in dev mode, in case of value of type object and inputLabel or inputValue are falsy
