### PR TITLE
feat: add ng add support

### DIFF
--- a/packages/primeng/package.json
+++ b/packages/primeng/package.json
@@ -13,6 +13,7 @@
     "bugs": {
         "url": "https://github.com/primefaces/primeng/issues"
     },
+    "schematics": "./schematics/collection.json",
     "keywords": [
         "primeng",
         "angular",
@@ -30,9 +31,10 @@
     },
     "scripts": {
         "build": "cross-env NODE_ENV=production INPUT_DIR=src/ OUTPUT_DIR=dist/ pnpm run build:package",
-        "build:package": "pnpm run build:prebuild && ng build primeng && pnpm run build:postbuild",
+        "build:package": "pnpm run build:prebuild && ng build primeng && pnpm run build:schematics && pnpm run build:postbuild",
         "build:prebuild": "node ./scripts/prebuild.mjs",
         "build:postbuild": "node ./scripts/postbuild.mjs",
+        "build:schematics": "tsc -p tsconfig.schematics.json",
         "dev:link": "pnpm link --global && npm link",
         "lint": "ng lint",
         "test:unit": "ng test primeng --watch=false --browsers=ChromeHeadless",
@@ -40,6 +42,8 @@
         "test:unit:coverage": "ng test primeng --coverage"
     },
     "devDependencies": {
+        "@angular-devkit/core": "catalog:angular22",
+        "@angular-devkit/schematics": "catalog:angular22",
         "karma": "~6.4.4",
         "karma-chrome-launcher": "~3.2.0",
         "karma-coverage": "~2.2.1",

--- a/packages/primeng/schematics/collection.json
+++ b/packages/primeng/schematics/collection.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Add PrimeNG to an Angular project.",
+      "factory": "./ng-add/index#ngAdd",
+      "schema": "./ng-add/schema.json",
+      "aliases": ["ng-add-setup-project"]
+    }
+  }
+}

--- a/packages/primeng/schematics/ng-add/index.spec.ts
+++ b/packages/primeng/schematics/ng-add/index.spec.ts
@@ -1,0 +1,55 @@
+import { Tree } from '@angular-devkit/schematics';
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+
+const collectionPath = path.join(__dirname, '../collection.json');
+
+describe('ng-add', () => {
+    let runner: SchematicTestRunner;
+
+    beforeEach(() => {
+        runner = new SchematicTestRunner('schematics', collectionPath);
+    });
+
+    it('should add dependencies to package.json and update app.config.ts', async () => {
+        let appTree = Tree.empty() as UnitTestTree;
+        appTree.create('/package.json', JSON.stringify({ dependencies: {} }));
+        appTree.create('/src/app/app.config.ts', `import { ApplicationConfig } from '@angular/core';\n\nexport const appConfig: ApplicationConfig = {\n  providers: []\n};\n`);
+
+        const tree = await runner.runSchematic('ng-add', { theme: 'aura' }, appTree);
+
+        const packageJson = JSON.parse(tree.readContent('/package.json'));
+        expect(packageJson.dependencies['primeng']).toBeDefined();
+        expect(packageJson.dependencies['@primeuix/themes']).toBeDefined();
+
+        const appConfig = tree.readContent('/src/app/app.config.ts');
+        expect(appConfig).toContain(`import { providePrimeNG } from 'primeng/config';`);
+        expect(appConfig).toContain(`import Aura from '@primeuix/themes/aura';`);
+        expect(appConfig).toContain(`providePrimeNG({
+      theme: {
+        preset: Aura
+      }
+    })`);
+    });
+
+    it('should add dependencies to package.json and update app.module.ts', async () => {
+        let appTree = Tree.empty() as UnitTestTree;
+        appTree.create('/package.json', JSON.stringify({ dependencies: {} }));
+        appTree.create('/src/app/app.module.ts', `import { NgModule } from '@angular/core';\n\n@NgModule({\n  providers: []\n})\nexport class AppModule { }\n`);
+
+        const tree = await runner.runSchematic('ng-add', { theme: 'lora' }, appTree);
+
+        const packageJson = JSON.parse(tree.readContent('/package.json'));
+        expect(packageJson.dependencies['primeng']).toBeDefined();
+        expect(packageJson.dependencies['@primeuix/themes']).toBeDefined();
+
+        const appModule = tree.readContent('/src/app/app.module.ts');
+        expect(appModule).toContain(`import { providePrimeNG } from 'primeng/config';`);
+        expect(appModule).toContain(`import Lora from '@primeuix/themes/lora';`);
+        expect(appModule).toContain(`providePrimeNG({
+      theme: {
+        preset: Lora
+      }
+    })`);
+    });
+});

--- a/packages/primeng/schematics/ng-add/index.ts
+++ b/packages/primeng/schematics/ng-add/index.ts
@@ -1,0 +1,61 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { Schema } from './schema';
+import { addImportToModule, addProviderToAppConfig, addProviderToAppModule } from '../utils/ast-utils';
+
+export function ngAdd(options: Schema): Rule {
+    return (tree: Tree, context: SchematicContext) => {
+        // 1. Add packages to package.json
+        const packageJsonPath = '/package.json';
+        if (tree.exists(packageJsonPath)) {
+            const packageJsonContent = tree.read(packageJsonPath);
+            if (packageJsonContent) {
+                const packageJson = JSON.parse(packageJsonContent.toString('utf-8'));
+                if (!packageJson.dependencies) {
+                    packageJson.dependencies = {};
+                }
+
+                // Add dependencies
+                const pkgVersion = require('../../package.json').version;
+                packageJson.dependencies['primeng'] = `^${pkgVersion}`;
+                packageJson.dependencies['@primeuix/themes'] = '^2.0.3';
+
+                tree.overwrite(packageJsonPath, JSON.stringify(packageJson, null, 2));
+            }
+        }
+
+        // 2. Schedule npm install
+        context.addTask(new NodePackageInstallTask());
+
+        // 3. Update app.config.ts or app.module.ts
+        const theme = options.theme || 'aura';
+        const capitalizedTheme = theme.charAt(0).toUpperCase() + theme.slice(1);
+
+        const provideCode = `providePrimeNG({
+      theme: {
+        preset: ${capitalizedTheme}
+      }
+    })`;
+
+        const appConfigPath = '/src/app/app.config.ts';
+        const appModulePath = '/src/app/app.module.ts';
+
+        if (tree.exists(appConfigPath)) {
+            // Standalone
+            addImportToModule(tree, appConfigPath, `import { providePrimeNG } from 'primeng/config';`);
+            addImportToModule(tree, appConfigPath, `import ${capitalizedTheme} from '@primeuix/themes/${theme}';`);
+            addProviderToAppConfig(tree, appConfigPath, provideCode);
+            context.logger.info(`✅ Updated app.config.ts with PrimeNG and ${capitalizedTheme} theme.`);
+        } else if (tree.exists(appModulePath)) {
+            // Module-based
+            addImportToModule(tree, appModulePath, `import { providePrimeNG } from 'primeng/config';`);
+            addImportToModule(tree, appModulePath, `import ${capitalizedTheme} from '@primeuix/themes/${theme}';`);
+            addProviderToAppModule(tree, appModulePath, provideCode);
+            context.logger.info(`✅ Updated app.module.ts with PrimeNG and ${capitalizedTheme} theme.`);
+        } else {
+            context.logger.warn(`Could not find app.config.ts or app.module.ts to configure PrimeNG automatically.`);
+        }
+
+        return tree;
+    };
+}

--- a/packages/primeng/schematics/ng-add/schema.json
+++ b/packages/primeng/schematics/ng-add/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "PrimeNGNgAddSchema",
+  "title": "PrimeNG ng-add Options Schema",
+  "type": "object",
+  "properties": {
+    "theme": {
+      "type": "string",
+      "description": "Choose a PrimeNG theme.",
+      "enum": ["aura", "lora", "material", "nora"],
+      "default": "aura",
+      "x-prompt": {
+        "message": "Which PrimeNG theme would you like to use?",
+        "type": "list",
+        "items": [
+          { "value": "aura", "label": "Aura" },
+          { "value": "lora", "label": "Lora" },
+          { "value": "material", "label": "Material" },
+          { "value": "nora", "label": "Nora" }
+        ]
+      }
+    }
+  },
+  "required": []
+}

--- a/packages/primeng/schematics/ng-add/schema.ts
+++ b/packages/primeng/schematics/ng-add/schema.ts
@@ -1,0 +1,6 @@
+export interface Schema {
+    /**
+     * Choose a PrimeNG theme.
+     */
+    theme: 'aura' | 'lora' | 'material' | 'nora';
+}

--- a/packages/primeng/schematics/utils/ast-utils.ts
+++ b/packages/primeng/schematics/utils/ast-utils.ts
@@ -1,0 +1,115 @@
+import { Tree, SchematicsException } from '@angular-devkit/schematics';
+import * as ts from 'typescript';
+
+export function addImportToModule(tree: Tree, filePath: string, importStatement: string): void {
+    const fileContent = tree.read(filePath);
+    if (!fileContent) {
+        throw new SchematicsException(`File ${filePath} does not exist.`);
+    }
+    const sourceText = fileContent.toString('utf-8');
+    
+    // Simple check to avoid duplicates
+    if (sourceText.includes(importStatement)) {
+        return;
+    }
+
+    const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
+    
+    // Find the last import declaration
+    let lastImportEnd = 0;
+    ts.forEachChild(sourceFile, node => {
+        if (ts.isImportDeclaration(node)) {
+            lastImportEnd = node.getEnd();
+        }
+    });
+
+    const updateRecorder = tree.beginUpdate(filePath);
+    if (lastImportEnd === 0) {
+        updateRecorder.insertLeft(0, importStatement + '\n');
+    } else {
+        updateRecorder.insertRight(lastImportEnd, '\n' + importStatement);
+    }
+    tree.commitUpdate(updateRecorder);
+}
+
+export function addProviderToAppConfig(tree: Tree, filePath: string, providerCode: string): void {
+    const fileContent = tree.read(filePath);
+    if (!fileContent) {
+        throw new SchematicsException(`File ${filePath} does not exist.`);
+    }
+    const sourceText = fileContent.toString('utf-8');
+    const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
+    let providersNode: ts.ArrayLiteralExpression | undefined;
+
+    const visit = (node: ts.Node) => {
+        if (ts.isPropertyAssignment(node) && node.name.getText() === 'providers') {
+            if (ts.isArrayLiteralExpression(node.initializer)) {
+                providersNode = node.initializer;
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+
+    if (providersNode) {
+        const pNode = providersNode as ts.ArrayLiteralExpression;
+        const updateRecorder = tree.beginUpdate(filePath);
+        const elements = pNode.elements;
+        if (elements.length === 0) {
+            updateRecorder.insertRight(pNode.getStart() + 1, providerCode);
+        } else {
+            const lastElement = elements[elements.length - 1];
+            updateRecorder.insertRight(lastElement.getEnd(), `, ${providerCode}`);
+        }
+        tree.commitUpdate(updateRecorder);
+    } else {
+        throw new SchematicsException(`Could not find providers array in ${filePath}`);
+    }
+}
+
+export function addProviderToAppModule(tree: Tree, filePath: string, providerCode: string): void {
+    const fileContent = tree.read(filePath);
+    if (!fileContent) {
+        throw new SchematicsException(`File ${filePath} does not exist.`);
+    }
+    const sourceText = fileContent.toString('utf-8');
+    const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
+    let providersNode: ts.ArrayLiteralExpression | undefined;
+
+    const visit = (node: ts.Node) => {
+        if (ts.isDecorator(node) && ts.isCallExpression(node.expression)) {
+            const expression = node.expression;
+            if (ts.isIdentifier(expression.expression) && expression.expression.text === 'NgModule') {
+                const args = expression.arguments;
+                if (args.length > 0 && ts.isObjectLiteralExpression(args[0])) {
+                    for (const prop of args[0].properties) {
+                        if (ts.isPropertyAssignment(prop) && prop.name.getText() === 'providers') {
+                            if (ts.isArrayLiteralExpression(prop.initializer)) {
+                                providersNode = prop.initializer;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+
+    visit(sourceFile);
+
+    if (providersNode) {
+        const pNode = providersNode as ts.ArrayLiteralExpression;
+        const updateRecorder = tree.beginUpdate(filePath);
+        const elements = pNode.elements;
+        if (elements.length === 0) {
+            updateRecorder.insertRight(pNode.getStart() + 1, providerCode);
+        } else {
+            const lastElement = elements[elements.length - 1];
+            updateRecorder.insertRight(lastElement.getEnd(), `, ${providerCode}`);
+        }
+        tree.commitUpdate(updateRecorder);
+    } else {
+        throw new SchematicsException(`Could not find providers array in ${filePath}`);
+    }
+}

--- a/packages/primeng/scripts/postbuild.mjs
+++ b/packages/primeng/scripts/postbuild.mjs
@@ -6,3 +6,11 @@ const { __dirname, __workspace, OUTPUT_DIR } = resolvePath(import.meta.url);
 
 fs.copySync(path.resolve(__dirname, '../README.md'), `${OUTPUT_DIR}/README.md`);
 fs.copySync(path.resolve(__workspace, './LICENSE.md'), `${OUTPUT_DIR}/LICENSE.md`);
+
+// Copy Schematics JSON files
+if (fs.existsSync(path.resolve(__dirname, '../schematics/collection.json'))) {
+    fs.copySync(path.resolve(__dirname, '../schematics/collection.json'), `${OUTPUT_DIR}/schematics/collection.json`);
+}
+if (fs.existsSync(path.resolve(__dirname, '../schematics/ng-add/schema.json'))) {
+    fs.copySync(path.resolve(__dirname, '../schematics/ng-add/schema.json'), `${OUTPUT_DIR}/schematics/ng-add/schema.json`);
+}

--- a/packages/primeng/tsconfig.schematics.json
+++ b/packages/primeng/tsconfig.schematics.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es2018", "dom"],
+    "declaration": true,
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "target": "es2018",
+    "outDir": "./dist/schematics",
+    "rootDir": "./schematics",
+    "types": ["node", "jasmine"]
+  },
+  "include": [
+    "schematics/**/*"
+  ]
+}


### PR DESCRIPTION
## Description

Add `ng add` support to add the lib to an Angular project.
It allows choosing a theme and add the `providePrimeNg` in the app.config/app.module file

The PR content sticks with `PrimeNG` naming, waiting for the final decision about renaming the project.
I