### PR TITLE
fix(table): respect explicit rowHover=false when selectionMode is set

### DIFF
--- a/packages/primeng/src/table/style/tablestyle.ts
+++ b/packages/primeng/src/table/style/tablestyle.ts
@@ -122,7 +122,7 @@ const classes = {
     root: ({ instance }) => [
         'p-datatable p-component',
         {
-            'p-datatable-hoverable': instance.rowHover() || instance.selectionMode(),
+            'p-datatable-hoverable': instance.rowHover() ?? instance.selectionMode(),
             'p-datatable-resizable': instance.resizableColumns(),
             'p-datatable-resizable-fit': instance.resizableColumns() && instance.columnResizeMode() === 'fit',
             'p-datatable-scrollable': instance.scrollable(),

--- a/packages/primeng/src/table/table-body.ts
+++ b/packages/primeng/src/table/table-body.ts
@@ -314,7 +314,7 @@ export class TableBody extends BaseComponent {
 
     dataP = computed(() => {
         return this.cn({
-            hoverable: this.dataTable.rowHover() || this.dataTable.selectionMode(),
+            hoverable: this.dataTable.rowHover() ?? this.dataTable.selectionMode(),
             frozen: this.frozen()
         });
     });

--- a/packages/primeng/src/table/table.spec.ts
+++ b/packages/primeng/src/table/table.spec.ts
@@ -340,6 +340,30 @@ describe('Table', () => {
         });
     });
 
+    describe('Row Hover', () => {
+        it('should add hoverable class when selectionMode is set and rowHover is not set', () => {
+            fixture.componentRef.setInput('selectionMode', 'single');
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.classList.contains('p-datatable-hoverable')).toBe(true);
+        });
+
+        it('should not add hoverable class when rowHover is explicitly false even with selectionMode', () => {
+            fixture.componentRef.setInput('selectionMode', 'single');
+            fixture.componentRef.setInput('rowHover', false);
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.classList.contains('p-datatable-hoverable')).toBe(false);
+        });
+
+        it('should add hoverable class when rowHover is true without selectionMode', () => {
+            fixture.componentRef.setInput('rowHover', true);
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.classList.contains('p-datatable-hoverable')).toBe(true);
+        });
+    });
+
     describe('Sorting Functionality', () => {
         let testComponent: TestSortingTableComponent;
         let testFixture: ComponentFixture<TestSortingTableComponent>;


### PR DESCRIPTION
## What was happening

With `selectionMode="single"` (or `"multiple"`), rows showed the hover style even when `[rowHover]="false"` was set explicitly.

## Root cause

The hoverable state is computed with a logical OR in two places:

- `tablestyle.ts` root classes: `'p-datatable-hoverable': instance.rowHover() || instance.selectionMode()`
- `table-body.ts` `dataP`: `hoverable: this.dataTable.rowHover() || this.dataTable.selectionMode()`

Since `rowHover` is declared as `input(undefined, { transform: booleanAttribute })`, an explicit `false` is indistinguishable from "not set" under `||`, so `selectionMode` always won and the `p-datatable-hoverable` class was applied.

## What changes

Both expressions now use the nullish coalescing operator: `rowHover() ?? selectionMode()`. The default behavior is preserved (when `rowHover` is not set, `selectionMode` still enables the hover style), but an explicit `[rowHover]="false"` now disables it.

## How it was verified

- Added three unit tests in `table.spec.ts` covering: selectionMode with rowHover unset (hoverable), selectionMode with explicit `rowHover=false` (not hoverable), and `rowHover=true` without selectionMode (hoverable).
- Ran the table spec suite before and after the change: same 6 preexisting "Cell Navigation" failures in both runs (also failing on master), no new failures; the 3 new tests pass.

Fixes #623