### PR TITLE
fix(table): respect explicit rowHover=false when selectionMode is set

### DIFF
--- a/packages/primeng/src/table/style/tablestyle.ts
+++ b/packages/primeng/src/table/style/tablestyle.ts
@@ -122,7 +122,7 @@ const classes = {
     root: ({ instance }) => [
         'p-datatable p-component',
         {
-            'p-datatable-hoverable': instance.rowHover() || instance.selectionMode(),
+            'p-datatable-hoverable': instance.rowHover() ?? instance.selectionMode(),
             'p-datatable-resizable': instance.resizableColumns(),
             'p-datatable-resizable-fit': instance.resizableColumns() && instance.columnResizeMode() === 'fit',
             'p-datatable-scrollable': instance.scrollable(),

--- a/packages/primeng/src/table/table-body.ts
+++ b/packages/primeng/src/table/table-body.ts
@@ -314,7 +314,7 @@ export class TableBody extends BaseComponent {
 
     dataP = computed(() => {
         return this.cn({
-            hoverable: this.dataTable.rowHover() || this.dataTable.selectionMode(),
+            hoverable: this.dataTable.rowHover() ?? this.dataTable.selectionMode(),
             frozen: this.frozen()
         });
     });

--- a/packages/primeng/src/table/table.spec.ts
+++ b/packages/primeng/src/table/table.spec.ts
@@ -340,6 +340,30 @@ describe('Table', () => {
         });
     });
 
+    describe('Row Hover', () => {
+        it('should add hoverable class when selectionMode is set and rowHover is not set', () => {
+            fixture.componentRef.setInput('selectionMode', 'single');
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.classList.contains('p-datatable-hoverable')).toBe(true);
+        });
+
+        it('should not add hoverable class when rowHover is explicitly false even with selectionMode', () => {
+            fixture.componentRef.setInput('selectionMode', 'single');
+            fixture.componentRef.setInput('rowHover', false);
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.classList.contains('p-datatable-hoverable')).toBe(false);
+        });
+
+        it('should add hoverable class when rowHover is true without selectionMode', () => {
+            fixture.componentRef.setInput('rowHover', true);
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.classList.contains('p-datatable-hoverable')).toBe(true);
+        });
+    });
+
     describe('Sorting Functionality', () => {
         let testComponent: TestSortingTableComponent;
         let testFixture: ComponentFixture<TestSortingTableComponent>;


### PR DESCRIPTION
Row hover styling was applied whenever `selectionMode` was set, even with `[rowHover]="false"`. The hoverable state used `||` with `selectionMode`, so an explicit `false` was indistinguishable from unset. Switched to `??` so the explicit value wins; default behavior (rowHover unset + selectionMode → hover) is unchanged. Adds specs.

Fixes #623