### PR TITLE
fix(treetable): support shift key range selection in multiple selection mode

### DIFF
--- a/packages/primeng/src/treetable/treetable.spec.ts
+++ b/packages/primeng/src/treetable/treetable.spec.ts
@@ -399,6 +399,44 @@ describe('TreeTable', () => {
             expect(treetable.selectionChange.emit).toHaveBeenCalled();
         });
 
+        it('should select range of nodes with shift key in multiple selection mode', async () => {
+            const ttFixture = TestBed.createComponent(TreeTable);
+            const tt = ttFixture.componentInstance;
+            ttFixture.componentRef.setInput('value', basicTreeData);
+            ttFixture.componentRef.setInput('selectionMode', 'multiple');
+            await ttFixture.whenStable();
+            ttFixture.detectChanges();
+
+            const node1 = basicTreeData[0];
+            const node2 = basicTreeData[1];
+
+            const mockTarget = {
+                nodeName: 'TD',
+                closest: jasmine.createSpy('closest').and.returnValue(null)
+            };
+
+            tt.handleRowClick({
+                originalEvent: {
+                    target: mockTarget,
+                    button: 0
+                } as any,
+                rowNode: { node: node1 }
+            });
+
+            tt.handleRowClick({
+                originalEvent: {
+                    target: mockTarget,
+                    button: 0,
+                    shiftKey: true
+                } as any,
+                rowNode: { node: node2 }
+            });
+
+            expect(tt._selection.length).toBe(2);
+            expect(tt._selection).toContain(node1);
+            expect(tt._selection).toContain(node2);
+        });
+
         it('should emit selection change event', async () => {
             spyOn(treetable.selectionChange, 'emit');
 

--- a/packages/primeng/src/treetable/treetable.ts
+++ b/packages/primeng/src/treetable/treetable.ts
@@ -858,6 +858,10 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
 
     toggleRowIndex: Nullable<number>;
 
+    anchorRowIndex: Nullable<number>;
+
+    rangeRowIndex: Nullable<number>;
+
     serializedValue: any[] | undefined | null;
 
     filteredNodes: Nullable<any[]>;
@@ -1559,9 +1563,26 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
         if (this.selectionMode()) {
             this.preventSelectionSetterPropagation = true;
             let rowNode = event.rowNode;
+
+            if (this.isMultipleSelectionMode() && (<KeyboardEvent>event.originalEvent).shiftKey && this.anchorRowIndex != null) {
+                DomHandler.clearSelection();
+                if (this.rangeRowIndex != null) {
+                    this.clearSelectionRange(event.originalEvent);
+                }
+
+                this.rangeRowIndex = this.findVisibleRowIndex(rowNode);
+                this.selectRange(event.originalEvent, this.rangeRowIndex);
+
+                this.tableService.onSelectionChange();
+                this.rowTouched = false;
+                return;
+            }
+
             let selected = this.isSelected((<any>rowNode).node);
             let metaSelection = this.rowTouched ? false : this.metaKeySelection();
             let dataKeyValue = this.dataKey() ? String(resolveFieldData((<TreeTableNode>rowNode.node).data, this.dataKey())) : null;
+            this.anchorRowIndex = this.findVisibleRowIndex(rowNode);
+            this.rangeRowIndex = this.anchorRowIndex;
 
             if (metaSelection) {
                 let keyboardEvent = <KeyboardEvent>event.originalEvent;
@@ -1698,6 +1719,91 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
             showContextMenu();
             this.onContextMenuSelect.emit({ originalEvent: event.originalEvent, node: node });
         }
+    }
+
+    getVisibleSerializedNodes() {
+        return (this.serializedValue || []).filter((rowNode) => rowNode.visible);
+    }
+
+    findVisibleRowIndex(rowNode: any) {
+        return this.getVisibleSerializedNodes().findIndex((serializedNode) => serializedNode.node === rowNode.node);
+    }
+
+    selectRange(event: MouseEvent | KeyboardEvent, rowIndex: number) {
+        let rangeStart, rangeEnd;
+
+        if (<number>this.anchorRowIndex > rowIndex) {
+            rangeStart = rowIndex;
+            rangeEnd = this.anchorRowIndex;
+        } else if (<number>this.anchorRowIndex < rowIndex) {
+            rangeStart = this.anchorRowIndex;
+            rangeEnd = rowIndex;
+        } else {
+            rangeStart = rowIndex;
+            rangeEnd = rowIndex;
+        }
+
+        let visibleRows = this.getVisibleSerializedNodes();
+        this._selection = this._selection || [];
+        for (let i = <number>rangeStart; i <= <number>rangeEnd; i++) {
+            let rangeRowNode = visibleRows[i];
+            if (rangeRowNode && !this.isSelected(rangeRowNode.node)) {
+                this._selection = [...this._selection, rangeRowNode.node];
+                let dataKeyValue = this.dataKey() ? String(resolveFieldData((<TreeTableNode>rangeRowNode.node).data, this.dataKey())) : null;
+                if (dataKeyValue) {
+                    this.selectedKeys[dataKeyValue] = 1;
+                }
+
+                this.onNodeSelect.emit({
+                    originalEvent: event,
+                    node: rangeRowNode.node,
+                    type: 'row',
+                    index: i
+                });
+            }
+        }
+        this.selectionChange.emit(this._selection);
+    }
+
+    clearSelectionRange(event: MouseEvent | KeyboardEvent) {
+        let rangeStart, rangeEnd;
+        let rangeRowIndex = <number>this.rangeRowIndex;
+        let anchorRowIndex = <number>this.anchorRowIndex;
+
+        if (rangeRowIndex > anchorRowIndex) {
+            rangeStart = anchorRowIndex;
+            rangeEnd = rangeRowIndex;
+        } else if (rangeRowIndex < anchorRowIndex) {
+            rangeStart = rangeRowIndex;
+            rangeEnd = anchorRowIndex;
+        } else {
+            rangeStart = rangeRowIndex;
+            rangeEnd = rangeRowIndex;
+        }
+
+        let visibleRows = this.getVisibleSerializedNodes();
+        for (let i = rangeStart; i <= rangeEnd; i++) {
+            let rangeRowNode = visibleRows[i];
+            if (!rangeRowNode) {
+                continue;
+            }
+
+            let selectionIndex = this.findIndexInSelection(rangeRowNode.node);
+            if (selectionIndex != -1) {
+                this._selection = this._selection.filter((val: TreeTableNode, index: number) => index != selectionIndex);
+                let dataKeyValue = this.dataKey() ? String(resolveFieldData((<TreeTableNode>rangeRowNode.node).data, this.dataKey())) : null;
+                if (dataKeyValue) {
+                    delete this.selectedKeys[dataKeyValue];
+                }
+
+                this.onNodeUnselect.emit({
+                    originalEvent: event,
+                    node: rangeRowNode.node,
+                    type: 'row'
+                });
+            }
+        }
+        this.selectionChange.emit(this._selection);
     }
 
     toggleNodeWithCheckbox(event: any) {


### PR DESCRIPTION
TreeTable had no shift-key range selection; it now mirrors Table's anchor/range logic over the visible flattened rows, updating selectedKeys and emitting the usual selection events. Adds a spec.

Fixes #935