### PR TITLE
fix(toast): restore visibility and animations in single mode

### DIFF
--- a/packages/primeng/src/toast/style/toaststyle.ts
+++ b/packages/primeng/src/toast/style/toaststyle.ts
@@ -2,6 +2,65 @@ import { Injectable } from '@angular/core';
 import { style } from '@primeuix/styles/toast';
 import { BaseStyle } from 'primeng/base';
 
+const singleStyle = `
+    .p-toast:not(.p-toast-stacked) .p-toast-message {
+        position: static;
+        opacity: 1;
+        transform: none;
+        margin: 0 0 1rem 0;
+        display: grid;
+        grid-template-rows: 1fr;
+    }
+
+    .p-toast:not(.p-toast-stacked) .p-toast-message:not([data-expanded]):not([data-front]) {
+        overflow: visible;
+        height: auto;
+        transform: none;
+    }
+
+    .p-toast:not(.p-toast-stacked) .p-toast-message:not([data-visible]) {
+        opacity: 1;
+        pointer-events: auto;
+        user-select: auto;
+    }
+
+    .p-toast:not(.p-toast-stacked) .p-toast-message-enter-active {
+        animation: p-animate-toast-enter 300ms ease-out;
+    }
+
+    .p-toast:not(.p-toast-stacked) .p-toast-message-leave-active {
+        animation: p-animate-toast-leave 250ms ease-in;
+    }
+
+    .p-toast:not(.p-toast-stacked) .p-toast-message-leave-to .p-toast-message-content {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+
+    @keyframes p-animate-toast-enter {
+        from {
+            opacity: 0;
+            transform: scale(0.6);
+        }
+        to {
+            opacity: 1;
+            grid-template-rows: 1fr;
+        }
+    }
+
+    @keyframes p-animate-toast-leave {
+        from {
+            opacity: 1;
+        }
+        to {
+            opacity: 0;
+            margin-bottom: 0;
+            grid-template-rows: 0fr;
+            transform: translateY(-100%) scale(0.6);
+        }
+    }
+`;
+
 const stackStyle = `
     /* pMotion enter */
     .p-toast-stack-enter-from {
@@ -124,7 +183,7 @@ const classes = {
 export class ToastStyle extends BaseStyle {
     name = 'toast';
 
-    style = style + stackStyle;
+    style = style + singleStyle + stackStyle;
 
     classes = classes;
 

--- a/packages/primeng/src/toast/toast.spec.ts
+++ b/packages/primeng/src/toast/toast.spec.ts
@@ -566,6 +566,29 @@ describe('Toast', () => {
 
             expect(toastInstance.breakpoints()).toEqual(component.breakpoints);
         });
+
+        it('should render a visible message in single mode', async () => {
+            const message: ToastMessageOptions = {
+                severity: 'info',
+                summary: 'Single Mode',
+                detail: 'Should be visible',
+                key: 'test'
+            };
+
+            messageService.add(message);
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            await new Promise((resolve) => setTimeout(resolve, 400));
+
+            const messageEl = fixture.debugElement.query(By.css('.p-toast-message'))?.nativeElement as HTMLElement;
+            expect(messageEl).toBeTruthy();
+
+            const computedStyle = getComputedStyle(messageEl);
+            expect(computedStyle.opacity).toBe('1');
+            expect(computedStyle.position).not.toBe('absolute');
+        });
     });
 
     describe('Animation and Lifecycle', () => {


### PR DESCRIPTION
Under @primeuix/styles rc.1 the toast CSS assumes the stacked model's data-mounted/data-visible attributes, so a toast in single mode stayed at opacity 0. Scoped overrides restore in-flow layout and the enter/leave keyframes for non-stacked toasts. Adds a spec.

Fixes #1228