### PR TITLE
fix(panelmenu): style menu item separators so they are visible inside submenus

### DIFF
--- a/packages/primeng/src/panelmenu/panelmenu.spec.ts
+++ b/packages/primeng/src/panelmenu/panelmenu.spec.ts
@@ -187,6 +187,29 @@ class TestEmptyPanelMenuComponent {}
 
 @Component({
     standalone: false,
+    selector: 'test-separator-panelmenu',
+    template: ` <p-panelmenu [model]="model"> </p-panelmenu> `
+})
+class TestSeparatorPanelMenuComponent {
+    model: MenuItem[] = [
+        {
+            label: 'Panel',
+            expanded: true,
+            items: [
+                { label: 'Item 1' },
+                { separator: true },
+                {
+                    label: 'Group',
+                    expanded: true,
+                    items: [{ label: 'Sub Item 1' }, { separator: true }, { label: 'Sub Item 2' }]
+                }
+            ]
+        }
+    ];
+}
+
+@Component({
+    standalone: false,
     selector: 'test-dynamic-panelmenu',
     template: ` <p-panelmenu [model]="model"> </p-panelmenu> `
 })
@@ -259,6 +282,7 @@ describe('PanelMenu', () => {
                 TestDisabledPanelMenuComponent,
                 TestStyledPanelMenuComponent,
                 TestEmptyPanelMenuComponent,
+                TestSeparatorPanelMenuComponent,
                 TestDynamicPanelMenuComponent,
                 TestCommandPanelMenuComponent,
                 TestKeyboardPanelMenuComponent
@@ -504,6 +528,18 @@ describe('PanelMenu', () => {
 
             const separators = fixture.debugElement.queryAll(By.css('li[role="separator"]'));
             expect(separators.length).toBe(1);
+        });
+
+        it('should render separators inside submenu items', async () => {
+            const separatorFixture = TestBed.createComponent(TestSeparatorPanelMenuComponent);
+            separatorFixture.detectChanges();
+            await separatorFixture.whenStable();
+
+            const separators = separatorFixture.debugElement.queryAll(By.css('li[role="separator"]'));
+            expect(separators.length).toBe(2);
+            separators.forEach((separator) => {
+                expect(separator.nativeElement.classList.contains('p-menuitem-separator')).toBe(true);
+            });
         });
     });
 

--- a/packages/primeng/src/panelmenu/style/panelmenustyle.ts
+++ b/packages/primeng/src/panelmenu/style/panelmenustyle.ts
@@ -12,6 +12,10 @@ const style = /*css*/ `
     .p-panelmenu-item-link {
         outline: 0 none;
     }
+
+    .p-panelmenu-submenu .p-menuitem-separator {
+        border-block-start: 1px solid dt('content.border.color');
+    }
 `;
 
 const classes = {


### PR DESCRIPTION
PanelMenu rendered separator <li>s inside submenus, but the theme had no CSS for .p-menuitem-separator, so they were invisible. Adds the missing border rule (token-aligned with Menu's separator). Adds a spec.

Fixes #635