### PR TITLE
fix(confirmdialog): show confirmation requested right after another one closes

### DIFF
--- a/packages/primeng/src/confirmdialog/confirmdialog.spec.ts
+++ b/packages/primeng/src/confirmdialog/confirmdialog.spec.ts
@@ -199,8 +199,23 @@ class TestPositionConfirmDialogComponent {
 class TestConfirmationServiceComponent {
     acceptClicked = false;
     rejectClicked = false;
+    secondAcceptClicked = false;
 
     constructor(private confirmationService: ConfirmationService) {}
+
+    confirmChained() {
+        this.confirmationService.confirm({
+            message: 'First confirmation',
+            accept: () => {
+                this.confirmationService.confirm({
+                    message: 'Second confirmation',
+                    accept: () => {
+                        this.secondAcceptClicked = true;
+                    }
+                });
+            }
+        });
+    }
 
     confirm() {
         this.confirmationService.confirm({
@@ -833,6 +848,33 @@ describe('ConfirmDialog', () => {
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             expect(serviceComponent.rejectClicked).toBe(true);
+        });
+
+        it('should show a confirmation requested from the accept callback of another confirmation', async () => {
+            const serviceFixture = TestBed.createComponent(TestConfirmationServiceComponent);
+            const serviceComponent = serviceFixture.componentInstance;
+            serviceFixture.changeDetectorRef.markForCheck();
+            await serviceFixture.whenStable();
+
+            serviceComponent.confirmChained();
+            serviceFixture.changeDetectorRef.markForCheck();
+            await serviceFixture.whenStable();
+
+            const confirmDialogInstance = serviceFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
+            expect(confirmDialogInstance.option('message')).toBe('First confirmation');
+
+            confirmDialogInstance.onAccept();
+            serviceFixture.changeDetectorRef.markForCheck();
+            await serviceFixture.whenStable();
+            await new Promise((resolve) => setTimeout(resolve, 100));
+
+            expect(confirmDialogInstance.visible()).toBe(true);
+            expect(confirmDialogInstance.option('message')).toBe('Second confirmation');
+
+            confirmDialogInstance.onAccept();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(serviceComponent.secondAcceptClicked).toBe(true);
         });
     });
 

--- a/packages/primeng/src/confirmdialog/confirmdialog.ts
+++ b/packages/primeng/src/confirmdialog/confirmdialog.ts
@@ -529,19 +529,28 @@ export class ConfirmDialog extends BaseComponent<ConfirmDialogPassThrough> {
     }
 
     close() {
-        this.confirmation()?.rejectEvent?.emit(ConfirmEventType.CANCEL);
-        this.hide(ConfirmEventType.CANCEL);
+        const confirmation = this.confirmation();
+        confirmation?.rejectEvent?.emit(ConfirmEventType.CANCEL);
+        this.hide(ConfirmEventType.CANCEL, confirmation);
     }
 
-    hide(type?: ConfirmEventType) {
+    hide(type?: ConfirmEventType, confirmation: Nullable<Confirmation> = this.confirmation()) {
         this.onHide.emit(type);
+        // A new confirmation may have been requested within the accept/reject callback, keep the dialog visible for it and only clean up the closed one.
+        if (confirmation !== this.confirmation()) {
+            confirmation?.acceptEvent?.unsubscribe();
+            confirmation?.rejectEvent?.unsubscribe();
+            return;
+        }
         this.visible.set(false);
         // Unsubscribe from confirmation events when the dialogue is closed, because events are created when the dialogue is opened.
         this.unsubscribeConfirmationEvents();
     }
 
     onDialogHide() {
-        this.confirmation.set(null);
+        if (!this.visible()) {
+            this.confirmation.set(null);
+        }
     }
 
     destroyStyle() {
@@ -572,13 +581,15 @@ export class ConfirmDialog extends BaseComponent<ConfirmDialogPassThrough> {
     }
 
     onAccept() {
-        this.confirmation()?.acceptEvent?.emit();
-        this.hide(ConfirmEventType.ACCEPT);
+        const confirmation = this.confirmation();
+        confirmation?.acceptEvent?.emit();
+        this.hide(ConfirmEventType.ACCEPT, confirmation);
     }
 
     onReject() {
-        this.confirmation()?.rejectEvent?.emit(ConfirmEventType.REJECT);
-        this.hide(ConfirmEventType.REJECT);
+        const confirmation = this.confirmation();
+        confirmation?.rejectEvent?.emit(ConfirmEventType.REJECT);
+        this.hide(ConfirmEventType.REJECT, confirmation);
     }
 
     unsubscribeConfirmationEvents() {


### PR DESCRIPTION
Chaining confirm() from another confirmation's accept callback killed the new subscription: hide() unsubscribed the events that the second confirmation had just created. hide() now only tears down the confirmation being closed, keeping the dialog visible for the new one. Adds a spec.

Fixes #591