### PR TITLE
fix(button): update directive style classes when variant inputs change dynamically

### DIFF
--- a/packages/primeng/src/button/button.spec.ts
+++ b/packages/primeng/src/button/button.spec.ts
@@ -1,4 +1,4 @@
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { Component, provideZonelessChangeDetection, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -179,6 +179,17 @@ class TestButtonDirectiveComponent {
     `
 })
 class TestButtonWithIconLabelDirectiveComponent {}
+
+// Button directive with dynamic properties
+@Component({
+    standalone: false,
+    template: ` <button pButton [outlined]="outlined()" [rounded]="rounded()" [severity]="severity()">Dynamic Button</button> `
+})
+class TestDynamicButtonDirectiveComponent {
+    outlined = signal(false);
+    rounded = signal(false);
+    severity = signal<any>(undefined);
+}
 
 // Loading Button Test
 @Component({
@@ -1388,7 +1399,7 @@ describe('ButtonDirective', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [TestButtonDirectiveComponent, TestButtonWithIconLabelDirectiveComponent],
+            declarations: [TestButtonDirectiveComponent, TestButtonWithIconLabelDirectiveComponent, TestDynamicButtonDirectiveComponent],
             imports: [Button, ButtonDirective, ButtonIcon, ButtonLabel],
             providers: [provideZonelessChangeDetection()]
         }).compileComponents();
@@ -1442,6 +1453,30 @@ describe('ButtonDirective', () => {
             expect(buttonDirective.raised()).toBe(true);
             // CSS class application may vary in test environment
             expect(buttonDirective.raised()).toBe(true);
+        });
+
+        it('should update classes when variant properties change dynamically', async () => {
+            const dynamicFixture = TestBed.createComponent(TestDynamicButtonDirectiveComponent);
+            const dynamicComponent = dynamicFixture.componentInstance;
+            const dynamicElement: HTMLButtonElement = dynamicFixture.debugElement.query(By.css('button')).nativeElement;
+            dynamicFixture.detectChanges();
+            await dynamicFixture.whenStable();
+
+            expect(dynamicElement.classList.contains('p-button-outlined')).toBe(false);
+
+            dynamicComponent.outlined.set(true);
+            await dynamicFixture.whenStable();
+
+            expect(dynamicElement.classList.contains('p-button-outlined')).toBe(true);
+
+            dynamicComponent.outlined.set(false);
+            dynamicComponent.rounded.set(true);
+            dynamicComponent.severity.set('danger');
+            await dynamicFixture.whenStable();
+
+            expect(dynamicElement.classList.contains('p-button-outlined')).toBe(false);
+            expect(dynamicElement.classList.contains('p-button-rounded')).toBe(true);
+            expect(dynamicElement.classList.contains('p-button-danger')).toBe(true);
         });
     });
 

--- a/packages/primeng/src/button/button.ts
+++ b/packages/primeng/src/button/button.ts
@@ -193,6 +193,13 @@ export class ButtonDirective extends BaseComponent {
         effect(() => {
             this.loading();
             this.severity();
+            this.text();
+            this.plain();
+            this.raised();
+            this.size();
+            this.outlined();
+            this.rounded();
+            this.hasFluid();
             if (this.initialized) {
                 this.setStyleClass();
             }
@@ -255,6 +262,8 @@ export class ButtonDirective extends BaseComponent {
     }
 
     private _internalClasses: string[] = Object.values(INTERNAL_BUTTON_CLASSES);
+
+    private _variantClasses: string[] = ['p-button-text', 'p-button-plain', 'p-button-raised', 'p-button-outlined', 'p-button-rounded', 'p-button-fluid', 'p-button-sm', 'p-button-lg', 'p-button-small', 'p-button-large'];
 
     pcFluid: Fluid | null = inject(Fluid, { optional: true, host: true, skipSelf: true });
 
@@ -344,7 +353,7 @@ export class ButtonDirective extends BaseComponent {
         const styleClass = this.getStyleClass();
         this.removeExistingSeverityClass();
 
-        this.htmlElement.classList.remove(...this._internalClasses);
+        this.htmlElement.classList.remove(...this._internalClasses, ...this._variantClasses);
         this.htmlElement.classList.add(...styleClass);
     }
 


### PR DESCRIPTION
The pButton directive only reapplied classes for loading/severity changes; toggling outlined/text/plain/raised/rounded/size/fluid after init did nothing, and stale variant classes were never removed. The effect now reads those inputs and setStyleClass drops stale variant classes before reapplying.

Fixes #569