### PR TITLE
fix(multiselect): label with unmatched values, header checkbox deselect, and selectedItemsOnTop

### DIFF
--- a/packages/primeng/src/multiselect/multiselect.spec.ts
+++ b/packages/primeng/src/multiselect/multiselect.spec.ts
@@ -3759,3 +3759,76 @@ describe('MultiSelect Complex Edge Cases', () => {
         });
     });
 });
+
+describe('MultiSelect Selected Items On Top', () => {
+    let fixture: ComponentFixture<MultiSelect>;
+    let multiSelect: MultiSelect;
+
+    const options = [
+        { label: 'Option 1', value: 1 },
+        { label: 'Option 2', value: 2 },
+        { label: 'Option 3', value: 3 },
+        { label: 'Option 4', value: 4 }
+    ];
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [MultiSelectModule, FormsModule],
+            providers: [provideNoopAnimations(), provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(MultiSelect);
+        multiSelect = fixture.componentInstance;
+        fixture.componentRef.setInput('options', options);
+        fixture.componentRef.setInput('optionLabel', 'label');
+        fixture.componentRef.setInput('optionValue', 'value');
+        fixture.detectChanges();
+    });
+
+    it('should keep the original order by default', () => {
+        multiSelect.writeValue([3]);
+        multiSelect.show();
+        fixture.detectChanges();
+
+        expect(multiSelect.visibleOptions().map((option: any) => option.value)).toEqual([1, 2, 3, 4]);
+    });
+
+    it('should display selected options on top when the overlay is opened', () => {
+        fixture.componentRef.setInput('selectedItemsOnTop', true);
+        multiSelect.writeValue([3]);
+        multiSelect.show();
+        fixture.detectChanges();
+
+        expect(multiSelect.visibleOptions().map((option: any) => option.value)).toEqual([3, 1, 2, 4]);
+    });
+
+    it('should keep selected options on top when filtering', () => {
+        fixture.componentRef.setInput('selectedItemsOnTop', true);
+        multiSelect.writeValue([3]);
+        multiSelect.show();
+        fixture.detectChanges();
+
+        multiSelect._filterValue.set('Option');
+        fixture.detectChanges();
+
+        expect(multiSelect.visibleOptions().map((option: any) => option.value)).toEqual([3, 1, 2, 4]);
+    });
+
+    it('should not reorder options while the overlay is open and reorder on next open', () => {
+        fixture.componentRef.setInput('selectedItemsOnTop', true);
+        multiSelect.writeValue([3]);
+        multiSelect.show();
+        fixture.detectChanges();
+
+        multiSelect.onOptionSelect({ originalEvent: new Event('click'), option: options[1] });
+        fixture.detectChanges();
+
+        expect(multiSelect.visibleOptions().map((option: any) => option.value)).toEqual([3, 1, 2, 4]);
+
+        multiSelect.hide();
+        multiSelect.show();
+        fixture.detectChanges();
+
+        expect(multiSelect.visibleOptions().map((option: any) => option.value)).toEqual([2, 3, 1, 4]);
+    });
+});

--- a/packages/primeng/src/multiselect/multiselect.spec.ts
+++ b/packages/primeng/src/multiselect/multiselect.spec.ts
@@ -644,6 +644,24 @@ describe('MultiSelect', () => {
             expect(multiSelect.modelValue()).toBeDefined();
         });
 
+        it('should deselect all options when toggle all is triggered while all options are selected', async () => {
+            const toggleAllEvent = () => ({
+                originalEvent: { preventDefault: () => {}, stopPropagation: () => {} },
+                checked: true
+            });
+
+            multiSelect.onToggleAll(toggleAllEvent());
+            await fixture.whenStable();
+
+            expect(multiSelect.modelValue().length).toBe(5);
+            expect(multiSelect.allSelected()).toBe(true);
+
+            multiSelect.onToggleAll(toggleAllEvent());
+            await fixture.whenStable();
+
+            expect(multiSelect.modelValue().length).toBe(0);
+        });
+
         it('should remove option when chip is clicked', async () => {
             component.display = 'chip';
             component.selectedCities = [component.options[0], component.options[1]];

--- a/packages/primeng/src/multiselect/multiselect.spec.ts
+++ b/packages/primeng/src/multiselect/multiselect.spec.ts
@@ -1189,6 +1189,19 @@ describe('MultiSelect', () => {
             }).not.toThrow();
         });
 
+        it('should not display null label for selected values that do not match any option', async () => {
+            component.optionValue = 'code';
+            component.selectedCities = ['NY', 'INVALID'] as any;
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(multiSelect.label()).toBe('New York');
+
+            const label = fixture.debugElement.query(By.css('.p-multiselect-label'));
+            expect(label.nativeElement.textContent).not.toContain('null');
+        });
+
         it('should not break with circular references', () => {
             const circularOption: any = { name: 'Circular', code: 'C' };
             circularOption.self = circularOption;

--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -527,6 +527,12 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
      */
     resetFilterOnHide = input(false, { transform: booleanAttribute });
     /**
+     * When enabled, the selected options are displayed at the top of the list when the overlay is opened. The order is updated on each open instead of on selection to keep the list stable while interacting with it.
+     * @defaultValue false
+     * @group Props
+     */
+    selectedItemsOnTop = input(false, { transform: booleanAttribute });
+    /**
      * Icon class of the dropdown icon.
      * @group Props
      */
@@ -986,6 +992,8 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     selectedOptions = signal<any>(null);
 
+    pinnedSelectedValues = signal<any[]>([]);
+
     clickInProgress: boolean = false;
 
     emptyMessageLabel = computed(() => {
@@ -1060,10 +1068,29 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
                 return this.flatOptions(filtered);
             }
 
-            return filteredOptions;
+            return this.sortSelectedItemsOnTop(filteredOptions);
         }
-        return options;
+        return group ? options : this.sortSelectedItemsOnTop(options);
     });
+
+    private sortSelectedItemsOnTop(options: any[]) {
+        const pinnedValues = this.pinnedSelectedValues();
+
+        if (!this.selectedItemsOnTop() || !isNotEmpty(pinnedValues)) {
+            return options;
+        }
+
+        const equalityKey = this.equalityKey() || '';
+        const selectedOptions: any[] = [];
+        const restOptions: any[] = [];
+
+        for (const option of options) {
+            const optionValue = this.getOptionValue(option);
+            (pinnedValues.some((value) => equals(value, optionValue, equalityKey)) ? selectedOptions : restOptions).push(option);
+        }
+
+        return [...selectedOptions, ...restOptions];
+    }
 
     label = computed(() => {
         let label;
@@ -1835,6 +1862,10 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
      * @group Method
      */
     public show(isFocus?) {
+        if (this.selectedItemsOnTop()) {
+            this.pinnedSelectedValues.set(this.modelValue() || []);
+        }
+
         this.overlayVisible.set(true);
 
         const focusedOptionIndex = this.focusedOptionIndex() !== -1 ? this.focusedOptionIndex() : this.autoOptionFocus() ? this.findFirstFocusedOptionIndex() : this.findSelectedOptionIndex();

--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -685,7 +685,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
      * Whether all data is selected.
      * @group Props
      */
-    selectAll = input<boolean | null>();
+    selectAll = input<boolean | null>(null);
     /**
      * Indicates whether to focus on options when hovering over them, defaults to optionLabel.
      * @group Props

--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -1075,15 +1075,10 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
             if (isNotEmpty(maxSelectedLabels) && modelValue?.length > (maxSelectedLabels || 0)) {
                 return this.getSelectedItemsLabel();
             } else {
-                label = '';
-
-                for (let i = 0; i < modelValue.length; i++) {
-                    if (i !== 0) {
-                        label += ', ';
-                    }
-
-                    label += this.getLabelByValue(modelValue[i]);
-                }
+                label = modelValue
+                    .map((value) => this.getLabelByValue(value))
+                    .filter((optionLabel) => optionLabel != null)
+                    .join(', ');
             }
         } else {
             label = this.placeholder() || '';


### PR DESCRIPTION
Three focused MultiSelect fixes:

- **#869** — the label rendered the literal string "null" when selected values had no matching option; unmatched values are now filtered out.
- **#936** — the header "select all" checkbox couldn't deselect: `selectAll` lost its `null` default in the signal migration and the strict `!== null` check never matched. Restored the default.
- **#613** — new `selectedItemsOnTop` input: selected options are pinned first when the overlay (re)opens, without reordering under the cursor.

Fixes #869
Fixes #936
Fixes #613