### PR TITLE
feat(dynamicdialog): support passing Angular bindings to the dynamically created component

### DIFF
--- a/packages/primeng/src/dynamicdialog/dialogservice.spec.ts
+++ b/packages/primeng/src/dynamicdialog/dialogservice.spec.ts
@@ -1,0 +1,155 @@
+import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { DialogService } from './dialogservice';
+import { DynamicDialogConfig } from './dynamicdialog-config';
+import { DynamicDialogRef } from './dynamicdialog-ref';
+
+@Component({
+    standalone: true,
+    template: `<span class="child-content">{{ label }}</span>`
+})
+class ChildComponent {
+    label = 'child';
+}
+
+@Component({
+    standalone: true,
+    template: `<span class="other-content">other</span>`
+})
+class OtherComponent {}
+
+describe('DialogService', () => {
+    let service: DialogService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [DialogService, provideZonelessChangeDetection()]
+        });
+        service = TestBed.inject(DialogService);
+    });
+
+    afterEach(() => {
+        // Remove any dialog nodes that survived a test.
+        document.querySelectorAll('p-dynamicdialog').forEach((el) => el.remove());
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    describe('open', () => {
+        it('should return a DynamicDialogRef', () => {
+            const ref = service.open(ChildComponent, new DynamicDialogConfig());
+
+            expect(ref).toBeInstanceOf(DynamicDialogRef);
+        });
+
+        it('should register the dialog in the component ref map', () => {
+            const ref = service.open(ChildComponent, new DynamicDialogConfig())!;
+
+            expect(service.dialogComponentRefMap.has(ref)).toBe(true);
+        });
+
+        it('should assign the child component type to the dialog instance', () => {
+            const ref = service.open(ChildComponent, new DynamicDialogConfig())!;
+
+            expect(service.getInstance(ref)!.childComponentType).toBe(ChildComponent);
+        });
+
+        it('should forward inputValues to the dialog instance', () => {
+            const config = new DynamicDialogConfig();
+            config.inputValues = { label: 'hello' };
+
+            const ref = service.open(ChildComponent, config)!;
+
+            expect(service.getInstance(ref)!.inputValues).toEqual({ label: 'hello' });
+        });
+
+        it('should default inputValues and bindings to empty when not provided', () => {
+            const ref = service.open(ChildComponent, new DynamicDialogConfig())!;
+            const instance = service.getInstance(ref)!;
+
+            expect(instance.inputValues).toEqual({});
+            expect(instance.bindings).toEqual([]);
+        });
+
+        it('should append the dialog element to the document body by default', () => {
+            const before = document.querySelectorAll('p-dynamicdialog').length;
+
+            service.open(ChildComponent, new DynamicDialogConfig());
+
+            expect(document.querySelectorAll('p-dynamicdialog').length).toBe(before + 1);
+        });
+    });
+
+    describe('duplicate prevention', () => {
+        it('should return null when opening the same component twice', () => {
+            const first = service.open(ChildComponent, new DynamicDialogConfig());
+            const second = service.open(ChildComponent, new DynamicDialogConfig());
+
+            expect(first).toBeInstanceOf(DynamicDialogRef);
+            expect(second).toBeNull();
+        });
+
+        it('should allow duplicates when config.duplicate is true', () => {
+            const config = new DynamicDialogConfig();
+            config.duplicate = true;
+
+            const first = service.open(ChildComponent, config);
+            const second = service.open(ChildComponent, config);
+
+            expect(first).toBeInstanceOf(DynamicDialogRef);
+            expect(second).toBeInstanceOf(DynamicDialogRef);
+        });
+
+        it('should allow different component types simultaneously', () => {
+            const first = service.open(ChildComponent, new DynamicDialogConfig());
+            const second = service.open(OtherComponent, new DynamicDialogConfig());
+
+            expect(first).toBeInstanceOf(DynamicDialogRef);
+            expect(second).toBeInstanceOf(DynamicDialogRef);
+        });
+    });
+
+    describe('getInstance', () => {
+        it('should return the dialog component instance for a ref', () => {
+            const ref = service.open(ChildComponent, new DynamicDialogConfig())!;
+
+            expect(service.getInstance(ref)).toBe(service.dialogComponentRefMap.get(ref)!.instance);
+        });
+
+        it('should return undefined for an unknown ref', () => {
+            expect(service.getInstance(new DynamicDialogRef())).toBeUndefined();
+        });
+    });
+
+    describe('lifecycle cleanup', () => {
+        it('should close the dialog instance when onClose emits', () => {
+            const ref = service.open(ChildComponent, new DynamicDialogConfig())!;
+            const closeSpy = spyOn(service.getInstance(ref)!, 'close');
+
+            ref.close();
+
+            expect(closeSpy).toHaveBeenCalled();
+        });
+
+        it('should remove the dialog from the ref map when onDestroy emits', () => {
+            const ref = service.open(ChildComponent, new DynamicDialogConfig())!;
+            expect(service.dialogComponentRefMap.has(ref)).toBe(true);
+
+            ref.destroy();
+
+            expect(service.dialogComponentRefMap.has(ref)).toBe(false);
+        });
+
+        it('should remove the dialog element from the DOM when destroyed', () => {
+            const before = document.querySelectorAll('p-dynamicdialog').length;
+            const ref = service.open(ChildComponent, new DynamicDialogConfig())!;
+            expect(document.querySelectorAll('p-dynamicdialog').length).toBe(before + 1);
+
+            ref.destroy();
+
+            expect(document.querySelectorAll('p-dynamicdialog').length).toBe(before);
+        });
+    });
+});

--- a/packages/primeng/src/dynamicdialog/dialogservice.ts
+++ b/packages/primeng/src/dynamicdialog/dialogservice.ts
@@ -37,6 +37,7 @@ export class DialogService {
         if (componentRefInstance) {
             componentRefInstance.instance.childComponentType = componentType as Type<object>;
             componentRefInstance.instance.inputValues = config.inputValues || {};
+            componentRefInstance.instance.bindings = config.bindings || [];
         }
 
         return dialogRef;

--- a/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
@@ -1,4 +1,4 @@
-import { Type } from '@angular/core';
+import { Binding, Type } from '@angular/core';
 import type { MotionOptions } from '@primeuix/motion';
 import type { DialogPassThrough, DialogPosition } from 'primeng/types/dialog';
 
@@ -202,6 +202,11 @@ export class DynamicDialogConfig<DataType = any, InputValuesType extends Record<
      * @group Props
      */
     unstyled?: boolean;
+    /**
+     * An array of Angular Bindings (providers) to pass to the dynamically created component.
+     * @group Props
+     */
+    bindings?: Binding[];
 }
 
 /**

--- a/packages/primeng/src/dynamicdialog/dynamicdialog-ref.spec.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog-ref.spec.ts
@@ -1,0 +1,119 @@
+import { DynamicDialogRef } from './dynamicdialog-ref';
+
+describe('DynamicDialogRef', () => {
+    let ref: DynamicDialogRef;
+
+    beforeEach(() => {
+        ref = new DynamicDialogRef();
+    });
+
+    describe('close', () => {
+        it('should emit the result through onClose', () => {
+            const spy = jasmine.createSpy('onClose');
+            ref.onClose.subscribe(spy);
+
+            ref.close('result-value');
+
+            expect(spy).toHaveBeenCalledWith('result-value');
+        });
+
+        it('should emit undefined when no result is provided', () => {
+            const spy = jasmine.createSpy('onClose');
+            ref.onClose.subscribe(spy);
+
+            ref.close();
+
+            expect(spy).toHaveBeenCalledWith(undefined);
+        });
+
+        it('should complete onClose after the teardown delay', () => {
+            jasmine.clock().install();
+            try {
+                const completeSpy = jasmine.createSpy('complete');
+                ref.onClose.subscribe({ complete: completeSpy });
+
+                ref.close('done');
+                expect(completeSpy).not.toHaveBeenCalled();
+
+                jasmine.clock().tick(1000);
+                expect(completeSpy).toHaveBeenCalledTimes(1);
+            } finally {
+                jasmine.clock().uninstall();
+            }
+        });
+    });
+
+    describe('destroy', () => {
+        it('should emit through onDestroy', () => {
+            const spy = jasmine.createSpy('onDestroy');
+            ref.onDestroy.subscribe(spy);
+
+            ref.destroy();
+
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('drag, resize and maximize callbacks', () => {
+        it('should forward dragStart events', () => {
+            const spy = jasmine.createSpy('onDragStart');
+            const event = new MouseEvent('mousedown');
+            ref.onDragStart.subscribe(spy);
+
+            ref.dragStart(event);
+
+            expect(spy).toHaveBeenCalledWith(event);
+        });
+
+        it('should forward dragEnd events', () => {
+            const spy = jasmine.createSpy('onDragEnd');
+            const event = new MouseEvent('mouseup');
+            ref.onDragEnd.subscribe(spy);
+
+            ref.dragEnd(event);
+
+            expect(spy).toHaveBeenCalledWith(event);
+        });
+
+        it('should forward resizeInit events', () => {
+            const spy = jasmine.createSpy('onResizeInit');
+            const event = new MouseEvent('mousedown');
+            ref.onResizeInit.subscribe(spy);
+
+            ref.resizeInit(event);
+
+            expect(spy).toHaveBeenCalledWith(event);
+        });
+
+        it('should forward resizeEnd events', () => {
+            const spy = jasmine.createSpy('onResizeEnd');
+            const event = new MouseEvent('mouseup');
+            ref.onResizeEnd.subscribe(spy);
+
+            ref.resizeEnd(event);
+
+            expect(spy).toHaveBeenCalledWith(event);
+        });
+
+        it('should forward the maximize value', () => {
+            const spy = jasmine.createSpy('onMaximize');
+            ref.onMaximize.subscribe(spy);
+
+            ref.maximize({ maximized: true });
+
+            expect(spy).toHaveBeenCalledWith({ maximized: true });
+        });
+    });
+
+    describe('onChildComponentLoaded', () => {
+        it('should expose a subject that emits the loaded instance', () => {
+            const spy = jasmine.createSpy('childLoaded');
+            const instance = { some: 'component' };
+            ref.onChildComponentLoaded.subscribe(spy);
+
+            ref.onChildComponentLoaded.next(instance);
+
+            expect(spy).toHaveBeenCalledWith(instance);
+        });
+    });
+});

--- a/packages/primeng/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.ts
@@ -1,5 +1,5 @@
 import { NgComponentOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ComponentRef, inject, InjectionToken, NgModule, signal, Type, viewChild, ViewEncapsulation } from '@angular/core';
+import { Binding, ChangeDetectionStrategy, Component, ComponentRef, inject, InjectionToken, NgModule, signal, Type, viewChild, ViewEncapsulation } from '@angular/core';
 import { uuid } from '@primeuix/utils';
 import { SharedModule, TranslationKeys } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
@@ -136,6 +136,8 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
     childComponentType: Nullable<Type<object>>;
 
     inputValues: NonNullable<DynamicDialogConfig['inputValues']> = {};
+
+    bindings: Binding[] = [];
 
     get draggable(): boolean {
         return this.ddconfig.draggable !== false;
@@ -362,7 +364,7 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
         let viewContainerRef = this.insertionPoint()?.viewContainerRef;
         viewContainerRef?.clear();
 
-        this.componentRef = viewContainerRef?.createComponent(componentType);
+        this.componentRef = viewContainerRef?.createComponent(componentType, {bindings: this.bindings});
 
         if (this.inputValues && this.componentRef) {
             Object.entries(this.inputValues).forEach(([key, value]) => {

--- a/packages/primeng/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.ts
@@ -364,7 +364,7 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
         let viewContainerRef = this.insertionPoint()?.viewContainerRef;
         viewContainerRef?.clear();
 
-        this.componentRef = viewContainerRef?.createComponent(componentType, {bindings: this.bindings});
+        this.componentRef = viewContainerRef?.createComponent(componentType, { bindings: this.bindings });
 
         if (this.inputValues && this.componentRef) {
             Object.entries(this.inputValues).forEach(([key, value]) => {


### PR DESCRIPTION
Allows passing an Angular `Binding[]` (inputs/outputs/providers) to components created via `DialogService` through `DynamicDialogConfig`, using the framework's `createComponent({ bindings })`. Adds coverage for `DialogService` and `DynamicDialogRef`.