### PR TITLE
fix(workspace): add missing @angular-devkit catalog entries so pnpm install works on a clean clone

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,12 @@ catalogs:
     '@angular-devkit/build-angular':
       specifier: ^22.0.0
       version: 22.0.4
+    '@angular-devkit/core':
+      specifier: ^22.0.0
+      version: 22.0.4
+    '@angular-devkit/schematics':
+      specifier: ^22.0.0
+      version: 22.0.4
     '@angular-eslint/eslint-plugin':
       specifier: ^22.0.0
       version: 22.0.0
@@ -357,6 +363,12 @@ importers:
         specifier: ^6.0.0 || ^7.8.1
         version: 7.8.2
     devDependencies:
+      '@angular-devkit/core':
+        specifier: catalog:angular22
+        version: 22.0.4(chokidar@5.0.0)
+      '@angular-devkit/schematics':
+        specifier: catalog:angular22
+        version: 22.0.4(chokidar@5.0.0)
       karma:
         specifier: ~6.4.4
         version: 6.4.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,8 @@ catalog:
 catalogs:
     angular22:
         "@angular-devkit/build-angular": ^22.0.0
+        "@angular-devkit/core": ^22.0.0
+        "@angular-devkit/schematics": ^22.0.0
         "@angular/cdk": ^22.0.0
         "@angular/cli": ^22.0.0
         "@angular/common": ^22.0.0


### PR DESCRIPTION
## Problem

`pnpm install` fails on a clean clone of `master`:

- `pnpm install --frozen-lockfile` (the CI default) fails with `ERR_PNPM_OUTDATED_LOCKFILE`, because `packages/primeng/package.json` lists `@angular-devkit/core` and `@angular-devkit/schematics` (added in 994d415 "feat: add ng add support", used by `schematics/ng-add`) but the lockfile was never regenerated.
- `pnpm install --no-frozen-lockfile` fails with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC: No catalog entry '@angular-devkit/core' was found for catalog 'angular22'`, because the `angular22` catalog in `pnpm-workspace.yaml` never defined those two entries.

## Fix

Add `@angular-devkit/core` and `@angular-devkit/schematics` to the `angular22` catalog and regenerate the lockfile (12 added lines, done with the repo's pinned `pnpm@9.6.0`).

Verified: `pnpm install --frozen-lockfile` now succeeds on a clean checkout.