### PR TITLE
docs(showcase): add the v22 migration guide and version switcher entry

### DIFF
--- a/apps/showcase/assets/data/menu.json
+++ b/apps/showcase/assets/data/menu.json
@@ -619,6 +619,10 @@
             "icon": "pi pi-arrow-up",
             "children": [
                 {
+                    "name": "Updating to v22",
+                    "routerLink": "/migration/v22"
+                },
+                {
                     "name": "Updating to v21",
                     "routerLink": "/migration/v21"
                 },

--- a/apps/showcase/assets/data/versions.json
+++ b/apps/showcase/assets/data/versions.json
@@ -1,8 +1,13 @@
 [
     {
+        "version": "v22",
+        "name": "v22",
+        "url": "https://primeng.org"
+    },
+    {
         "version": "v21",
         "name": "v21",
-        "url": "https://primeng.org"
+        "url": "https://v21.primeng.org"
     },
     {
         "version": "v20",

--- a/apps/showcase/doc/migration/v22/breakingdoc.ts
+++ b/apps/showcase/doc/migration/v22/breakingdoc.ts
@@ -1,0 +1,58 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+    selector: 'v22-breaking-doc',
+    standalone: true,
+    imports: [AppDocSectionText, AppCode, RouterModule],
+    template: `
+        <app-docsectiontext>
+            <p>PrimeNG v22 keeps the no-breaking-change policy for incremental updates where possible. The changes below are the exceptions to be aware of when upgrading from v21.</p>
+
+            <h3>Inputs are now read-only signal inputs</h3>
+            <p>
+                As part of the migration to Angular's signal APIs, component and directive inputs are declared with <i>input()</i> and therefore return a read-only <i>InputSignal</i>. Setting an input <b>imperatively</b> from outside the component no
+                longer works — you must bind the value through the template instead. This affects code that injected a PrimeNG component or directive (for example <i>BaseIcon</i>) and assigned to its input property directly.
+            </p>
+            <app-code [code]="importCode" [hideToggleCode]="true" [hideStackBlitz]="true"></app-code>
+            <p>Bind the value from the template instead:</p>
+            <app-code [code]="fixCode" [hideToggleCode]="true" [hideStackBlitz]="true"></app-code>
+            <p>
+                This also affects reading input values: properties like <i>PrimeTemplate.type</i> and <i>PrimeTemplate.name</i> are now signals, so code that queries templates with <i>&#64;ContentChildren(PrimeTemplate)</i> and compares
+                <i>template.type === 'header'</i> must call the signal instead — <i>template.type() === 'header'</i> (or keep using <i>template.getType()</i>, which is unchanged). A plain property access compiles but silently compares against the
+                signal function itself, never matching.
+            </p>
+
+            <h3>Form inputs</h3>
+            <p>
+                The lowercase <i>minlength</i>/<i>maxlength</i> inputs are deprecated in favor of <i>minLength</i>/<i>maxLength</i> (the names bound by the Signal Forms <i>[formField]</i> directive). The <i>pattern</i> input now accepts a string, a
+                <i>RegExp</i> or an array of patterns and is normalized to <i>readonly RegExp[]</i> to match the Angular <i>FormValueControl</i> contract; reading <i>pattern()</i> returns a <i>RegExp</i> array rather than a string.
+            </p>
+            <p>
+                Components that previously declared their own <i>readonly</i> input with a <i>false</i> default (Knob, Rating, InputOtp, Editor) now inherit it from <i>BaseEditableHolder</i>, whose default is <i>undefined</i>. Behavior is unchanged
+                for bindings and truthiness checks, but code comparing strictly against <i>false</i> (<i>readonly() === false</i>) must be updated.
+            </p>
+
+            <p>Other than these cases, v22 should be a drop-in replacement on Angular 22. If you face any issues during the upgrade, please report an issue at GitHub.</p>
+        </app-docsectiontext>
+    `
+})
+export class BreakingDoc {
+    importCode = {
+        typescript: `// No longer works in v22 — inputs are read-only InputSignals
+export class IconDirective implements OnInit {
+    private readonly baseIcon = inject(BaseIcon);
+
+    ngOnInit(): void {
+        this.baseIcon.spin = true;        // ❌ cannot assign to an InputSignal
+        this.baseIcon.spin.set(true);     // ❌ set() only exists on model(), not input()
+    }
+}`
+    };
+
+    fixCode = {
+        html: `<svg data-p-icon="spinner" [spin]="isSpinning" />`
+    };
+}

--- a/apps/showcase/doc/migration/v22/deprecationsdoc.ts
+++ b/apps/showcase/doc/migration/v22/deprecationsdoc.ts
@@ -1,0 +1,17 @@
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'v22-deprecations-doc',
+    standalone: true,
+    imports: [AppDocSectionText],
+    template: `
+        <app-docsectiontext>
+            <p>The following APIs are deprecated in v22 and remain functional for backward compatibility. They are scheduled for removal in a future major version.</p>
+            <ul class="leading-loose list-disc ml-6">
+                <li>The lowercase <i>minlength</i> and <i>maxlength</i> inputs on form components are deprecated in favor of <i>minLength</i> and <i>maxLength</i>.</li>
+            </ul>
+        </app-docsectiontext>
+    `
+})
+export class DeprecationsDoc {}

--- a/apps/showcase/doc/migration/v22/whatsnewdoc.ts
+++ b/apps/showcase/doc/migration/v22/whatsnewdoc.ts
@@ -1,0 +1,31 @@
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+    selector: 'v22-whatsnew-doc',
+    standalone: true,
+    imports: [AppDocSectionText, RouterModule],
+    template: `
+        <app-docsectiontext>
+            <p>PrimeNG v22 targets Angular 22 and focuses on first-class support for Angular's new Signal Forms while continuing the migration to modern signal-based APIs.</p>
+            <ul class="leading-loose list-disc ml-6">
+                <li>
+                    <b>Signal Forms support.</b> Form components integrate with the new <i>[formField]</i> directive from <i>&#64;angular/forms/signals</i>, while remaining fully compatible with template-driven (<i>ngModel</i>) and reactive
+                    (<i>formControl</i>) forms through the same <i>ControlValueAccessor</i>. The three form paradigms can be used interchangeably.
+                </li>
+                <li>
+                    Form components automatically bind the field state exposed by the <i>[formField]</i> directive: <i>readonly</i>, <i>touched</i>, <i>errors</i>, <i>required</i>, <i>invalid</i>, <i>minLength</i>, <i>maxLength</i> and
+                    <i>pattern</i>.
+                </li>
+                <li>
+                    The <i>pattern</i> input now accepts a string, a <i>RegExp</i> or an array of patterns and is normalized to <i>readonly RegExp[]</i>, matching the Angular <i>FormValueControl</i> contract. New <i>minLength</i>/<i>maxLength</i>
+                    inputs replace the lowercase <i>minlength</i>/<i>maxlength</i>.
+                </li>
+                <li>DatePicker honors the Signal Forms <i>min</i>/<i>max</i> constraints as its selectable date range.</li>
+                <li>Continued migration to signal-based APIs (<i>input()</i>, <i>output()</i>, <i>viewChild()</i>, <i>model()</i>), <i>host</i> metadata bindings and built-in control flow (<i>&#64;if</i>/<i>&#64;for</i>).</li>
+            </ul>
+        </app-docsectiontext>
+    `
+})
+export class WhatsNewDoc {}

--- a/apps/showcase/pages/migration/routes.ts
+++ b/apps/showcase/pages/migration/routes.ts
@@ -1,8 +1,13 @@
 import { v19MigrationDemoComponent } from './v19.component';
 import { v20MigrationDemoComponent } from './v20.component';
 import { v21MigrationDemoComponent } from './v21.component';
+import { v22MigrationDemoComponent } from './v22.component';
 
 export default [
+    {
+        path: 'v22',
+        component: v22MigrationDemoComponent
+    },
     {
         path: 'v21',
         component: v21MigrationDemoComponent

--- a/apps/showcase/pages/migration/v22.component.ts
+++ b/apps/showcase/pages/migration/v22.component.ts
@@ -1,0 +1,30 @@
+import { AppDoc } from '@/components/doc/app.doc';
+import { BreakingDoc } from '@/doc/migration/v22/breakingdoc';
+import { DeprecationsDoc } from '@/doc/migration/v22/deprecationsdoc';
+import { WhatsNewDoc } from '@/doc/migration/v22/whatsnewdoc';
+import { Component } from '@angular/core';
+
+@Component({
+    imports: [AppDoc],
+    standalone: true,
+    template: `<app-doc docTitle="Migration - PrimeNG v22" header="Migration to v22" description="Migration guide to PrimeNG v22." [docs]="docs" docType="page"></app-doc>`
+})
+export class v22MigrationDemoComponent {
+    docs = [
+        {
+            id: 'whatsnew',
+            label: "What's New",
+            component: WhatsNewDoc
+        },
+        {
+            id: 'breakingchanges',
+            label: 'Breaking Changes',
+            component: BreakingDoc
+        },
+        {
+            id: 'deprecations',
+            label: 'Deprecations',
+            component: DeprecationsDoc
+        }
+    ];
+}


### PR DESCRIPTION
## Change

Docs only — no library code is touched:

- New **Updating to v22** page under `/migration/v22` with What's New, Deprecations and Breaking Changes sections, registered in `pages/migration/routes.ts` and in the docs menu (`menu.json`).
- `versions.json`: add the **v22** entry to the version switcher; previous versions point at their `v21.primeng.org`-style subdomains.

The What's New section describes the v22 themes (Signal Forms integration, continued signal-API migration); the corresponding code changes are proposed in separate focused PRs.