### PR TITLE
refactor: migrate remaining components to signal APIs, inject() and host metadata

### DIFF
--- a/packages/primeng/src/accordion/accordion-header.ts
+++ b/packages/primeng/src/accordion/accordion-header.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, contentChild, HostListener, inject, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, contentChild, inject, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { findSingle, focus, getAttribute } from '@primeuix/utils';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind, BindModule } from 'primeng/bind';
@@ -53,7 +53,10 @@ import { AccordionStyle } from './style/accordionstyle';
         '[attr.data-p-active]': 'active()',
         '[attr.data-p-disabled]': 'disabled()',
         '[style.user-select]': '"none"',
-        '[attr.data-p]': 'dataP()'
+        '[attr.data-p]': 'dataP()',
+        '(click)': 'onClick($event)',
+        '(focus)': 'onFocus()',
+        '(keydown)': 'onKeydown($event)'
     },
     hostDirectives: [Ripple, Bind],
     providers: [AccordionStyle, { provide: ACCORDION_HEADER_INSTANCE, useExisting: AccordionHeader }, { provide: PARENT_INSTANCE, useExisting: AccordionHeader }]
@@ -96,7 +99,7 @@ export class AccordionHeader extends BaseComponent<AccordionHeaderPassThrough> {
 
     toggleIconContext = computed<AccordionToggleIconTemplateContext>(() => ({ active: this.active() }));
 
-    @HostListener('click', ['$event']) onClick(event?: MouseEvent | KeyboardEvent) {
+    onClick(event?: MouseEvent | KeyboardEvent) {
         if (this.disabled()) {
             return;
         }
@@ -115,13 +118,13 @@ export class AccordionHeader extends BaseComponent<AccordionHeaderPassThrough> {
         }
     }
 
-    @HostListener('focus') onFocus() {
+    onFocus() {
         if (!this.disabled() && this.pcAccordion.selectOnFocus()) {
             this.changeActiveValue();
         }
     }
 
-    @HostListener('keydown', ['$event']) onKeydown(event: KeyboardEvent) {
+    onKeydown(event: KeyboardEvent) {
         switch (event.code) {
             case 'ArrowDown':
                 this.arrowDownKey(event);

--- a/packages/primeng/src/accordion/accordion.ts
+++ b/packages/primeng/src/accordion/accordion.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, HostListener, inject, input, model, NgModule, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, model, NgModule, output, signal } from '@angular/core';
 import { MotionOptions } from '@primeuix/motion';
 import { findSingle, focus, getAttribute, uuid } from '@primeuix/utils';
 import { BlockableUI, SharedModule } from 'primeng/api';
@@ -22,7 +22,8 @@ import { AccordionStyle } from './style/accordionstyle';
     imports: [SharedModule, BindModule],
     template: ` <ng-content />`,
     host: {
-        '[class]': "cx('root')"
+        '[class]': "cx('root')",
+        '(keydown)': 'onKeydown($event)'
     },
     hostDirectives: [Bind],
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -97,7 +98,6 @@ export class Accordion extends BaseComponent<AccordionPassThrough> implements Bl
 
     _componentStyle = inject(AccordionStyle);
 
-    @HostListener('keydown', ['$event'])
     onKeydown(event: KeyboardEvent) {
         switch (event.code) {
             case 'ArrowDown':

--- a/packages/primeng/src/api/shared.ts
+++ b/packages/primeng/src/api/shared.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Directive, Input, NgModule, TemplateRef } from '@angular/core';
+import { Component, Directive, inject, input, NgModule, TemplateRef } from '@angular/core';
 
 /**
  * @deprecated Use ng-template #header instead.
@@ -29,14 +29,14 @@ export class Footer {}
     standalone: true
 })
 export class PrimeTemplate {
-    @Input() type: string | undefined;
+    type = input<string | undefined>();
 
-    @Input('pTemplate') name: string | undefined;
+    name = input<string | undefined>(undefined, { alias: 'pTemplate' });
 
-    constructor(public template: TemplateRef<any>) {}
+    template = inject<TemplateRef<any>>(TemplateRef);
 
     getType(): string {
-        return this.name!;
+        return this.name()!;
     }
 }
 

--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -8,7 +8,6 @@ import {
     effect,
     ElementRef,
     forwardRef,
-    HostListener,
     inject,
     InjectionToken,
     input,
@@ -350,7 +349,8 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR = {
     host: {
         '[class]': "cx('root')",
         '[style]': "sx('root')",
-        '[attr.data-p]': 'containerDataP'
+        '[attr.data-p]': 'containerDataP',
+        '(click)': 'onHostClick($event)'
     },
     hostDirectives: [Bind]
 })
@@ -810,7 +810,6 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
      */
     dropdownIconTemplate = contentChild<TemplateRef<void>>('dropdownicon', { descendants: false });
 
-    @HostListener('click', ['$event'])
     onHostClick(event: MouseEvent) {
         this.onContainerClick(event);
     }

--- a/packages/primeng/src/avatargroup/avatargroup.ts
+++ b/packages/primeng/src/avatargroup/avatargroup.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, HostBinding, inject, InjectionToken, Input, NgModule, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, input, NgModule, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
@@ -22,7 +22,8 @@ const AVATARGROUP_INSTANCE = new InjectionToken<AvatarGroup>('AVATARGROUP_INSTAN
     encapsulation: ViewEncapsulation.None,
     providers: [AvatarGroupStyle, { provide: AVATARGROUP_INSTANCE, useExisting: AvatarGroup }, { provide: PARENT_INSTANCE, useExisting: AvatarGroup }],
     host: {
-        '[class]': "cx('root')"
+        '[class]': "cx('root')",
+        '[style]': 'style()'
     },
     hostDirectives: [Bind]
 })
@@ -41,11 +42,7 @@ export class AvatarGroup extends BaseComponent<AvatarGroupPassThrough> {
      * Inline style of the component.
      * @group Props
      */
-    @Input() style: CSSProperties;
-
-    @HostBinding('style') get hostStyle() {
-        return this.style;
-    }
+    style = input<CSSProperties>();
 
     _componentStyle = inject(AvatarGroupStyle);
 }

--- a/packages/primeng/src/cascadeselect/cascadeselect.ts
+++ b/packages/primeng/src/cascadeselect/cascadeselect.ts
@@ -8,7 +8,6 @@ import {
     effect,
     ElementRef,
     forwardRef,
-    HostListener,
     inject,
     input,
     NgModule,
@@ -196,7 +195,8 @@ export const CASCADESELECT_VALUE_ACCESSOR: Provider = {
     encapsulation: ViewEncapsulation.None,
     host: {
         '[class]': "cx('root')",
-        '[style]': "sx('root')"
+        '[style]': "sx('root')",
+        '(mousedown)': 'onHostClick($event)'
     },
     hostDirectives: [Bind]
 })
@@ -574,7 +574,6 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
         return this.fluid() ?? !!this.pcFluid;
     }
 
-    @HostListener('mousedown', ['$event'])
     onHostClick(event: MouseEvent) {
         this.onContainerClick(event);
     }

--- a/packages/primeng/src/confirmpopup/confirmpopup.ts
+++ b/packages/primeng/src/confirmpopup/confirmpopup.ts
@@ -1,8 +1,7 @@
-import { DOCUMENT, NgTemplateOutlet } from '@angular/common';
+import { NgTemplateOutlet } from '@angular/common';
 import {
     booleanAttribute,
     ChangeDetectionStrategy,
-    ChangeDetectorRef,
     Component,
     computed,
     contentChild,
@@ -10,13 +9,11 @@ import {
     ElementRef,
     EventEmitter,
     HostListener,
-    Inject,
     inject,
     InjectionToken,
     input,
     NgModule,
     numberAttribute,
-    Renderer2,
     signal,
     TemplateRef,
     untracked,
@@ -263,14 +260,11 @@ export class ConfirmPopup extends BaseComponent<ConfirmPopupPassThrough> {
 
     _componentStyle = inject(ConfirmPopupStyle);
 
-    constructor(
-        public el: ElementRef,
-        private confirmationService: ConfirmationService,
-        public renderer: Renderer2,
-        public cd: ChangeDetectorRef,
-        public overlayService: OverlayService,
-        @Inject(DOCUMENT) public document: Document
-    ) {
+    private confirmationService = inject(ConfirmationService);
+
+    overlayService = inject(OverlayService);
+
+    constructor() {
         super();
         this.window = this.document.defaultView as Window;
         this.subscription = this.confirmationService.requireConfirmation$.subscribe((confirmation) => {

--- a/packages/primeng/src/confirmpopup/confirmpopup.ts
+++ b/packages/primeng/src/confirmpopup/confirmpopup.ts
@@ -8,7 +8,6 @@ import {
     effect,
     ElementRef,
     EventEmitter,
-    HostListener,
     inject,
     InjectionToken,
     input,
@@ -48,6 +47,9 @@ const CONFIRMPOPUP_INSTANCE = new InjectionToken<ConfirmPopup>('CONFIRMPOPUP_INS
     imports: [NgTemplateOutlet, SharedModule, ButtonModule, FocusTrap, Bind, MotionModule],
     providers: [ConfirmPopupStyle, { provide: CONFIRMPOPUP_INSTANCE, useExisting: ConfirmPopup }, { provide: PARENT_INSTANCE, useExisting: ConfirmPopup }],
     hostDirectives: [Bind],
+    host: {
+        '(document:keydown.Escape)': 'onEscapeKeydown($event)'
+    },
     template: `
         @if (render()) {
             <div
@@ -321,7 +323,6 @@ export class ConfirmPopup extends BaseComponent<ConfirmPopupPassThrough> {
         return undefined;
     }
 
-    @HostListener('document:keydown.Escape', ['$event'])
     onEscapeKeydown(event: KeyboardEvent) {
         const confirmation = this.confirmation();
         if (confirmation && confirmation.closeOnEscape !== false) {

--- a/packages/primeng/src/dragdrop/dragdrop.ts
+++ b/packages/primeng/src/dragdrop/dragdrop.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, booleanAttribute, Directive, ElementRef, EventEmitter, HostListener, inject, Input, NgModule, OnDestroy, Output, Renderer2 } from '@angular/core';
+import { AfterViewInit, booleanAttribute, Directive, effect, ElementRef, inject, input, NgModule, OnDestroy, output, Renderer2 } from '@angular/core';
 import { addClass, removeClass } from '@primeuix/utils';
 import { DomHandler } from 'primeng/dom';
 import { VoidListener } from 'primeng/ts-helpers';
@@ -9,38 +9,47 @@ import { VoidListener } from 'primeng/ts-helpers';
  */
 @Directive({
     selector: '[pDraggable]',
-    standalone: true
+    standalone: true,
+    host: {
+        '(dragstart)': 'dragStart($event)',
+        '(dragend)': 'dragEnd($event)'
+    }
 })
 export class Draggable implements AfterViewInit, OnDestroy {
-    @Input('pDraggable') scope: string | undefined;
+    scope = input<string | undefined>(undefined, { alias: 'pDraggable' });
     /**
      * Defines the cursor style.
      * @group Props
      */
-    @Input() dragEffect: 'none' | 'copy' | 'copyLink' | 'copyMove' | 'link' | 'linkMove' | 'move' | 'all' | 'uninitialized' | undefined;
+    dragEffect = input<'none' | 'copy' | 'copyLink' | 'copyMove' | 'link' | 'linkMove' | 'move' | 'all' | 'uninitialized' | undefined>();
     /**
      * Selector to define the drag handle, by default anywhere on the target element is a drag handle to start dragging.
      * @group Props
      */
-    @Input() dragHandle: string | undefined;
+    dragHandle = input<string | undefined>();
+    /**
+     * Whether the element is draggable, useful for conditional cases.
+     * @group Props
+     */
+    pDraggableDisabled = input(false, { transform: booleanAttribute });
     /**
      * Callback to invoke when drag begins.
      * @param {DragEvent} event - Drag event.
      * @group Emits
      */
-    @Output() onDragStart: EventEmitter<DragEvent> = new EventEmitter();
+    onDragStart = output<DragEvent>();
     /**
      * Callback to invoke when drag ends.
      * @param {DragEvent} event - Drag event.
      * @group Emits
      */
-    @Output() onDragEnd: EventEmitter<DragEvent> = new EventEmitter();
+    onDragEnd = output<DragEvent>();
     /**
      * Callback to invoke on dragging.
      * @param {DragEvent} event - Drag event.
      * @group Emits
      */
-    @Output() onDrag: EventEmitter<DragEvent> = new EventEmitter();
+    onDrag = output<DragEvent>();
 
     handle: any;
 
@@ -50,28 +59,23 @@ export class Draggable implements AfterViewInit, OnDestroy {
 
     mouseUpListener: VoidListener;
 
-    _pDraggableDisabled: boolean = false;
-
     el = inject(ElementRef);
 
     private renderer = inject(Renderer2);
 
-    @Input() get pDraggableDisabled(): boolean {
-        return this._pDraggableDisabled;
-    }
-    set pDraggableDisabled(_pDraggableDisabled: boolean) {
-        this._pDraggableDisabled = _pDraggableDisabled;
-
-        if (this._pDraggableDisabled) {
-            this.unbindMouseListeners();
-        } else {
-            this.el.nativeElement.draggable = true;
-            this.bindMouseListeners();
-        }
+    constructor() {
+        effect(() => {
+            if (this.pDraggableDisabled()) {
+                this.unbindMouseListeners();
+            } else {
+                this.el.nativeElement.draggable = true;
+                this.bindMouseListeners();
+            }
+        });
     }
 
     ngAfterViewInit() {
-        if (!this.pDraggableDisabled) {
+        if (!this.pDraggableDisabled()) {
             this.el.nativeElement.draggable = true;
             this.bindMouseListeners();
         }
@@ -110,13 +114,13 @@ export class Draggable implements AfterViewInit, OnDestroy {
         this.onDrag.emit(event);
     }
 
-    @HostListener('dragstart', ['$event'])
     dragStart(event: DragEvent) {
-        if (this.allowDrag() && !this.pDraggableDisabled) {
-            if (this.dragEffect) {
-                (event.dataTransfer as DataTransfer).effectAllowed = this.dragEffect;
+        if (this.allowDrag() && !this.pDraggableDisabled()) {
+            const dragEffect = this.dragEffect();
+            if (dragEffect) {
+                (event.dataTransfer as DataTransfer).effectAllowed = dragEffect;
             }
-            (event.dataTransfer as DataTransfer).setData('text', this.scope!);
+            (event.dataTransfer as DataTransfer).setData('text', this.scope()!);
 
             this.onDragStart.emit(event);
 
@@ -126,7 +130,6 @@ export class Draggable implements AfterViewInit, OnDestroy {
         }
     }
 
-    @HostListener('dragend', ['$event'])
     dragEnd(event: DragEvent) {
         this.onDragEnd.emit(event);
         this.unbindDragListener();
@@ -141,7 +144,8 @@ export class Draggable implements AfterViewInit, OnDestroy {
     }
 
     allowDrag(): boolean {
-        if (this.dragHandle && this.handle) return DomHandler.matches(this.handle, this.dragHandle);
+        const dragHandle = this.dragHandle();
+        if (dragHandle && this.handle) return DomHandler.matches(this.handle, dragHandle);
         else return true;
     }
 
@@ -156,48 +160,40 @@ export class Draggable implements AfterViewInit, OnDestroy {
  */
 @Directive({
     selector: '[pDroppable]',
-    standalone: true
+    standalone: true,
+    host: {
+        '(drop)': 'drop($event)',
+        '(dragenter)': 'dragEnter($event)',
+        '(dragleave)': 'dragLeave($event)'
+    }
 })
 export class Droppable implements AfterViewInit, OnDestroy {
-    @Input('pDroppable') scope: string | string[] | undefined;
+    scope = input<string | string[] | undefined>(undefined, { alias: 'pDroppable' });
     /**
      * Whether the element is droppable, useful for conditional cases.
      * @group Props
      */
-    _pDroppableDisabled: boolean = false;
-
-    @Input() get pDroppableDisabled(): boolean {
-        return this._pDroppableDisabled;
-    }
-    set pDroppableDisabled(_pDroppableDisabled: boolean) {
-        this._pDroppableDisabled = _pDroppableDisabled;
-
-        if (this._pDroppableDisabled) {
-            this.unbindDragOverListener();
-        } else {
-            this.bindDragOverListener();
-        }
-    }
+    pDroppableDisabled = input(false, { transform: booleanAttribute });
     /**
      * Defines the cursor style, valid values are none, copy, move, link, copyMove, copyLink, linkMove and all.
      * @group Props
      */
-    @Input() dropEffect: 'none' | 'copy' | 'link' | 'move' | undefined;
+    dropEffect = input<'none' | 'copy' | 'link' | 'move' | undefined>();
     /**
      * Callback to invoke when a draggable enters drop area.
      * @group Emits
      */
-    @Output() onDragEnter: EventEmitter<DragEvent> = new EventEmitter();
+    onDragEnter = output<DragEvent>();
     /**
      * Callback to invoke when a draggable leave drop area.
      * @group Emits
      */
-    @Output() onDragLeave: EventEmitter<DragEvent> = new EventEmitter();
+    onDragLeave = output<DragEvent>();
     /**
      * Callback to invoke when a draggable is dropped onto drop area.
      * @group Emits
      */
-    @Output() onDrop: EventEmitter<DragEvent> = new EventEmitter();
+    onDrop = output<DragEvent>();
 
     el = inject(ElementRef);
 
@@ -205,8 +201,18 @@ export class Droppable implements AfterViewInit, OnDestroy {
 
     dragOverListener: VoidListener;
 
+    constructor() {
+        effect(() => {
+            if (this.pDroppableDisabled()) {
+                this.unbindDragOverListener();
+            } else {
+                this.bindDragOverListener();
+            }
+        });
+    }
+
     ngAfterViewInit() {
-        if (!this.pDroppableDisabled) {
+        if (!this.pDroppableDisabled()) {
             this.bindDragOverListener();
         }
     }
@@ -228,7 +234,6 @@ export class Droppable implements AfterViewInit, OnDestroy {
         event.preventDefault();
     }
 
-    @HostListener('drop', ['$event'])
     drop(event: DragEvent) {
         if (this.allowDrop(event)) {
             removeClass(this.el.nativeElement, 'p-draggable-enter');
@@ -237,19 +242,18 @@ export class Droppable implements AfterViewInit, OnDestroy {
         }
     }
 
-    @HostListener('dragenter', ['$event'])
     dragEnter(event: DragEvent) {
         event.preventDefault();
 
-        if (this.dropEffect) {
-            (event.dataTransfer as DataTransfer).dropEffect = this.dropEffect;
+        const dropEffect = this.dropEffect();
+        if (dropEffect) {
+            (event.dataTransfer as DataTransfer).dropEffect = dropEffect;
         }
 
         addClass(this.el.nativeElement, 'p-draggable-enter');
         this.onDragEnter.emit(event);
     }
 
-    @HostListener('dragleave', ['$event'])
     dragLeave(event: DragEvent) {
         event.preventDefault();
 
@@ -261,11 +265,12 @@ export class Droppable implements AfterViewInit, OnDestroy {
 
     allowDrop(event: DragEvent): boolean {
         let dragScope = (event.dataTransfer as DataTransfer).getData('text');
-        if (typeof this.scope == 'string' && dragScope == this.scope) {
+        const scope = this.scope();
+        if (typeof scope == 'string' && dragScope == scope) {
             return true;
-        } else if (Array.isArray(this.scope)) {
-            for (let j = 0; j < this.scope.length; j++) {
-                if (dragScope == this.scope[j]) {
+        } else if (Array.isArray(scope)) {
+            for (let j = 0; j < scope.length; j++) {
+                if (dragScope == scope[j]) {
                     return true;
                 }
             }

--- a/packages/primeng/src/dynamicdialog/dialogservice.ts
+++ b/packages/primeng/src/dynamicdialog/dialogservice.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { ApplicationRef, ComponentRef, EmbeddedViewRef, Inject, Injectable, Injector, Type, createComponent } from '@angular/core';
+import { ApplicationRef, ComponentRef, EmbeddedViewRef, Injectable, Injector, Type, createComponent, inject } from '@angular/core';
 import { appendChild } from '@primeuix/utils';
 import { DynamicDialog } from './dynamicdialog';
 import { DynamicDialogConfig } from './dynamicdialog-config';
@@ -14,11 +14,11 @@ import { DynamicDialogRef } from './dynamicdialog-ref';
 export class DialogService {
     dialogComponentRefMap: Map<DynamicDialogRef<any>, ComponentRef<DynamicDialog>> = new Map();
 
-    constructor(
-        private appRef: ApplicationRef,
-        private injector: Injector,
-        @Inject(DOCUMENT) private document: Document
-    ) {}
+    private appRef = inject(ApplicationRef);
+
+    private injector = inject(Injector);
+
+    private document = inject(DOCUMENT);
     /**
      * Displays the dialog using the dynamic dialog object options.
      * @param {*} componentType - Dynamic component for content template.

--- a/packages/primeng/src/dynamicdialog/dynamicdialogcontent.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialogcontent.ts
@@ -1,9 +1,9 @@
-import { Directive, ViewContainerRef } from '@angular/core';
+import { Directive, inject, ViewContainerRef } from '@angular/core';
 
 @Directive({
     selector: '[pDynamicDialogContent]',
     standalone: true
 })
 export class DynamicDialogContent {
-    constructor(public viewContainerRef: ViewContainerRef) {}
+    viewContainerRef = inject(ViewContainerRef);
 }

--- a/packages/primeng/src/galleria/galleria-content.ts
+++ b/packages/primeng/src/galleria/galleria-content.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, ElementRef, HostListener, inject, input, linkedSignal, model, numberAttribute, output, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, linkedSignal, model, numberAttribute, output, viewChild } from '@angular/core';
 import { uuid } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
 import { Bind, BindModule } from 'primeng/bind';
@@ -80,7 +80,8 @@ import { GalleriaStyle } from './style/galleriastyle';
         '[attr.id]': 'id()',
         '[attr.role]': '"region"',
         '[style]': 'hostStyle()',
-        '[class]': "cx('root')"
+        '[class]': "cx('root')",
+        '(document:fullscreenchange)': 'handleFullscreenChange()'
     },
     hostDirectives: [Bind]
 })
@@ -135,7 +136,6 @@ export class GalleriaContent extends BaseComponent<GalleriaPassThrough> {
     });
 
     // For custom fullscreen
-    @HostListener('document:fullscreenchange')
     handleFullscreenChange() {
         if (document?.fullscreenElement === this.el.nativeElement?.children[0]) {
             this.fullScreen.set(true);

--- a/packages/primeng/src/icons/baseicon/baseicon.ts
+++ b/packages/primeng/src/icons/baseicon/baseicon.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, Input, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
 import { cn } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
 import { BaseIconStyle } from './style/baseiconstyle';
@@ -19,13 +19,13 @@ import { BaseIconStyle } from './style/baseiconstyle';
     }
 })
 export class BaseIcon extends BaseComponent {
-    @Input({ transform: booleanAttribute }) spin: boolean = false;
+    spin = input(false, { transform: booleanAttribute });
 
     _componentStyle = inject(BaseIconStyle);
 
     getClassNames() {
         return cn('p-icon', {
-            'p-icon-spin': this.spin
+            'p-icon-spin': this.spin()
         });
     }
 }

--- a/packages/primeng/src/image/image.ts
+++ b/packages/primeng/src/image/image.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChild, ElementRef, HostListener, inject, InjectionToken, input, NgModule, output, signal, TemplateRef, viewChild, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChild, ElementRef, inject, InjectionToken, input, NgModule, output, signal, TemplateRef, viewChild, ViewEncapsulation } from '@angular/core';
 import { SafeUrl } from '@angular/platform-browser';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
 import { appendChild, focus } from '@primeuix/utils';
@@ -131,7 +131,8 @@ const IMAGE_INSTANCE = new InjectionToken<Image>('IMAGE_INSTANCE');
     encapsulation: ViewEncapsulation.None,
     providers: [ImageStyle, { provide: IMAGE_INSTANCE, useExisting: Image }, { provide: PARENT_INSTANCE, useExisting: Image }],
     host: {
-        '[class]': "cx('root')"
+        '[class]': "cx('root')",
+        '(document:keydown.escape)': 'onKeydownHandler()'
     },
     hostDirectives: [Bind]
 })
@@ -540,7 +541,7 @@ export class Image extends BaseComponent<ImagePassThrough> {
         return this.aria?.close;
     }
 
-    @HostListener('document:keydown.escape') onKeydownHandler() {
+    onKeydownHandler() {
         if (this.previewVisible) {
             this.closePreview();
         }

--- a/packages/primeng/src/listbox/listbox.ts
+++ b/packages/primeng/src/listbox/listbox.ts
@@ -6,7 +6,6 @@ import {
     contentChild,
     effect,
     ElementRef,
-    HostListener,
     InjectionToken,
     NgModule,
     output,
@@ -353,7 +352,8 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
     host: {
         '[attr.id]': '$id()',
         '[class]': "cx('root')",
-        '[attr.data-p]': 'containerDataP'
+        '[attr.data-p]': 'containerDataP',
+        '(focusout)': 'onHostFocusOut($event)'
     },
     hostDirectives: [Bind]
 })
@@ -997,7 +997,6 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
         return t?.aria ? t.aria[this.allSelected() ? 'selectAll' : 'unselectAll'] : undefined;
     });
 
-    @HostListener('focusout', ['$event'])
     onHostFocusOut(event: FocusEvent) {
         this.onFocusout(event);
     }

--- a/packages/primeng/src/password/password.ts
+++ b/packages/primeng/src/password/password.ts
@@ -9,7 +9,6 @@ import {
     effect,
     ElementRef,
     forwardRef,
-    HostListener,
     inject,
     InjectionToken,
     input,
@@ -61,7 +60,11 @@ type Meter = {
     selector: '[pPassword]',
     standalone: true,
     host: {
-        '[class]': "cx('rootDirective')"
+        '[class]': "cx('rootDirective')",
+        '(input)': 'onInput($event)',
+        '(focus)': 'onFocus()',
+        '(blur)': 'onBlur()',
+        '(keyup)': 'onKeyup($event)'
     },
     providers: [PasswordStyle, { provide: PASSWORD_DIRECTIVE_INSTANCE, useExisting: PasswordDirective }, { provide: PARENT_INSTANCE, useExisting: PasswordDirective }],
     hostDirectives: [Bind]
@@ -182,7 +185,6 @@ export class PasswordDirective extends BaseEditableHolder {
         });
     }
 
-    @HostListener('input', ['$event'])
     onInput(e: Event) {
         this.writeModelValue(this.el.nativeElement.value);
     }
@@ -246,19 +248,16 @@ export class PasswordDirective extends BaseEditableHolder {
         }
     }
 
-    @HostListener('focus')
     onFocus() {
         this.showOverlay();
     }
 
-    @HostListener('blur')
     onBlur() {
         this.hideOverlay();
     }
 
     labelSignal = signal('');
 
-    @HostListener('keyup', ['$event'])
     onKeyup(e: Event) {
         if (this.feedback()) {
             let value = (e.target as HTMLInputElement).value,

--- a/packages/primeng/src/popover/popover.ts
+++ b/packages/primeng/src/popover/popover.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChild, ElementRef, HostListener, inject, InjectionToken, input, NgModule, numberAttribute, output, signal, TemplateRef, ViewEncapsulation, ViewRef } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChild, ElementRef, inject, InjectionToken, input, NgModule, numberAttribute, output, signal, TemplateRef, ViewEncapsulation, ViewRef } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
 import { $dt } from '@primeuix/styled';
 import { absolutePosition, addClass, appendChild, findSingle, getOffset, isIOS, isTouchDevice } from '@primeuix/utils';
@@ -27,6 +27,9 @@ const POPOVER_INSTANCE = new InjectionToken<Popover>('POPOVER_INSTANCE');
     imports: [NgTemplateOutlet, SharedModule, Bind, MotionModule],
     providers: [PopoverStyle, { provide: POPOVER_INSTANCE, useExisting: Popover }, { provide: PARENT_INSTANCE, useExisting: Popover }],
     hostDirectives: [Bind],
+    host: {
+        '(document:keydown.escape)': 'onEscapeKeydown($event)'
+    },
     template: `
         @if (render()) {
             <div
@@ -381,7 +384,6 @@ export class Popover extends BaseComponent<PopoverPassThrough> {
         event.preventDefault();
     }
 
-    @HostListener('document:keydown.escape', ['$event'])
     onEscapeKeydown(_event: KeyboardEvent) {
         this.hide();
     }

--- a/packages/primeng/src/slider/slider.ts
+++ b/packages/primeng/src/slider/slider.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, forwardRef, HostListener, inject, InjectionToken, input, NgModule, numberAttribute, output, Provider, signal, viewChild, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, forwardRef, inject, InjectionToken, input, NgModule, numberAttribute, output, Provider, signal, viewChild, ViewEncapsulation } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { addClass, getWindowScrollLeft, getWindowScrollTop, isRTL, removeClass } from '@primeuix/utils';
 import { SharedModule } from 'primeng/api';
@@ -106,7 +106,8 @@ export const SLIDER_VALUE_ACCESSOR: Provider = {
         '[attr.data-pc-section]': "'root'",
         '[class]': "cx('root')",
         '[attr.data-p]': 'dataP()',
-        '[attr.data-p-sliding]': 'false'
+        '[attr.data-p-sliding]': 'false',
+        '(click)': 'onHostClick($event)'
     },
     hostDirectives: [Bind]
 })
@@ -228,7 +229,6 @@ export class Slider extends BaseEditableHolder<SliderPassThrough> {
 
     public starty: Nullable<number>;
 
-    @HostListener('click', ['$event'])
     onHostClick(event: MouseEvent) {
         this.onBarClick(event);
     }

--- a/packages/primeng/src/steps/steps.ts
+++ b/packages/primeng/src/steps/steps.ts
@@ -1,11 +1,9 @@
-import { CommonModule } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, inject, Input, NgModule, numberAttribute, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, inject, input, NgModule, numberAttribute, output, viewChild, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { find, findSingle } from '@primeuix/utils';
 import { MenuItem, SharedModule } from 'primeng/api';
 import { BaseComponent } from 'primeng/basecomponent';
 import { TooltipModule } from 'primeng/tooltip';
-import { Nullable } from 'primeng/ts-helpers';
 import { Subscription } from 'rxjs';
 import { StepsStyle } from './style/stepsstyle';
 
@@ -16,67 +14,74 @@ import { StepsStyle } from './style/stepsstyle';
 @Component({
     selector: 'p-steps',
     standalone: true,
-    imports: [CommonModule, RouterModule, TooltipModule, SharedModule],
+    imports: [RouterModule, TooltipModule, SharedModule],
     template: `
-        <nav [class]="cn(cx('root'), styleClass)" [ngStyle]="style" [attr.data-pc-name]="'steps'">
+        <nav [class]="cn(cx('root'), styleClass())" [style]="style()" [attr.data-pc-name]="'steps'">
             <ul #list [attr.data-pc-section]="'menu'" [class]="cx('list')">
-                @for (item of model; track item.label; let i = $index) {
-                    <li
-                        *ngIf="item.visible !== false"
-                        [class]="cx('item', { item, index: i })"
-                        #menuitem
-                        [ngStyle]="item.style"
-                        [attr.aria-current]="isActive(item, i) ? 'step' : undefined"
-                        [attr.id]="item.id"
-                        pTooltip
-                        [tooltipOptions]="item.tooltipOptions"
-                        [pTooltipUnstyled]="unstyled()"
-                        [attr.data-pc-section]="'menuitem'"
-                    >
-                        <a
-                            role="link"
-                            *ngIf="isClickableRouterLink(item); else elseBlock"
-                            [routerLink]="item.routerLink"
-                            [queryParams]="item.queryParams"
-                            [routerLinkActiveOptions]="item.routerLinkActiveOptions || { exact: false }"
-                            [class]="cx('itemLink')"
-                            (click)="onItemClick($event, item, i)"
-                            (keydown)="onItemKeydown($event, item, i)"
-                            [target]="item.target"
-                            [attr.tabindex]="getItemTabIndex(item, i)"
-                            [attr.aria-expanded]="i === activeIndex"
-                            [attr.aria-disabled]="item.disabled || (readonly && i !== activeIndex)"
-                            [fragment]="item.fragment"
-                            [queryParamsHandling]="item.queryParamsHandling"
-                            [preserveFragment]="item.preserveFragment"
-                            [skipLocationChange]="item.skipLocationChange"
-                            [replaceUrl]="item.replaceUrl"
-                            [state]="item.state"
-                            [attr.ariaCurrentWhenActive]="exact ? 'step' : undefined"
+                @for (item of model(); track item.label; let i = $index) {
+                    @if (item.visible !== false) {
+                        <li
+                            [class]="cx('item', { item, index: i })"
+                            #menuitem
+                            [style]="item.style"
+                            [attr.aria-current]="isActive(item, i) ? 'step' : undefined"
+                            [attr.id]="item.id"
+                            pTooltip
+                            [tooltipOptions]="item.tooltipOptions"
+                            [pTooltipUnstyled]="unstyled()"
+                            [attr.data-pc-section]="'menuitem'"
                         >
-                            <span [class]="cx('itemNumber')">{{ i + 1 }}</span>
-                            <span [class]="cx('itemLabel')" *ngIf="item.escape !== false; else htmlLabel">{{ item.label }}</span>
-                            <ng-template #htmlLabel><span [class]="cx('itemLabel')" [innerHTML]="item.label"></span></ng-template>
-                        </a>
-                        <ng-template #elseBlock>
-                            <a
-                                role="link"
-                                [attr.href]="item.url"
-                                [class]="cx('itemLink')"
-                                (click)="onItemClick($event, item, i)"
-                                (keydown)="onItemKeydown($event, item, i)"
-                                [target]="item.target"
-                                [attr.tabindex]="getItemTabIndex(item, i)"
-                                [attr.aria-expanded]="i === activeIndex"
-                                [attr.aria-disabled]="item.disabled || (readonly && i !== activeIndex)"
-                                [attr.ariaCurrentWhenActive]="exact && (!item.disabled || readonly) ? 'step' : undefined"
-                            >
-                                <span [class]="cx('itemNumber')">{{ i + 1 }}</span>
-                                <span [class]="cx('itemLabel')" *ngIf="item.escape !== false; else htmlRouteLabel">{{ item.label }}</span>
-                                <ng-template #htmlRouteLabel><span [class]="cx('itemLabel')" [innerHTML]="item.label"></span></ng-template>
-                            </a>
-                        </ng-template>
-                    </li>
+                            @if (isClickableRouterLink(item)) {
+                                <a
+                                    role="link"
+                                    [routerLink]="item.routerLink"
+                                    [queryParams]="item.queryParams"
+                                    [routerLinkActiveOptions]="item.routerLinkActiveOptions || { exact: false }"
+                                    [class]="cx('itemLink')"
+                                    (click)="onItemClick($event, item, i)"
+                                    (keydown)="onItemKeydown($event, item, i)"
+                                    [target]="item.target"
+                                    [attr.tabindex]="getItemTabIndex(item, i)"
+                                    [attr.aria-expanded]="i === activeIndex()"
+                                    [attr.aria-disabled]="item.disabled || (readonly() && i !== activeIndex())"
+                                    [fragment]="item.fragment"
+                                    [queryParamsHandling]="item.queryParamsHandling"
+                                    [preserveFragment]="item.preserveFragment"
+                                    [skipLocationChange]="item.skipLocationChange"
+                                    [replaceUrl]="item.replaceUrl"
+                                    [state]="item.state"
+                                    [attr.ariaCurrentWhenActive]="exact() ? 'step' : undefined"
+                                >
+                                    <span [class]="cx('itemNumber')">{{ i + 1 }}</span>
+                                    @if (item.escape !== false) {
+                                        <span [class]="cx('itemLabel')">{{ item.label }}</span>
+                                    } @else {
+                                        <span [class]="cx('itemLabel')" [innerHTML]="item.label"></span>
+                                    }
+                                </a>
+                            } @else {
+                                <a
+                                    role="link"
+                                    [attr.href]="item.url"
+                                    [class]="cx('itemLink')"
+                                    (click)="onItemClick($event, item, i)"
+                                    (keydown)="onItemKeydown($event, item, i)"
+                                    [target]="item.target"
+                                    [attr.tabindex]="getItemTabIndex(item, i)"
+                                    [attr.aria-expanded]="i === activeIndex()"
+                                    [attr.aria-disabled]="item.disabled || (readonly() && i !== activeIndex())"
+                                    [attr.ariaCurrentWhenActive]="exact() && (!item.disabled || readonly()) ? 'step' : undefined"
+                                >
+                                    <span [class]="cx('itemNumber')">{{ i + 1 }}</span>
+                                    @if (item.escape !== false) {
+                                        <span [class]="cx('itemLabel')">{{ item.label }}</span>
+                                    } @else {
+                                        <span [class]="cx('itemLabel')" [innerHTML]="item.label"></span>
+                                    }
+                                </a>
+                            }
+                        </li>
+                    }
                 }
             </ul>
         </nav>
@@ -91,40 +96,40 @@ export class Steps extends BaseComponent {
      * Index of the active item.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) activeIndex: number = 0;
+    activeIndex = input(0, { transform: numberAttribute });
     /**
      * An array of menu items.
      * @group Props
      */
-    @Input() model: MenuItem[] | undefined;
+    model = input<MenuItem[] | undefined>();
     /**
      * Whether the items are clickable or not.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) readonly: boolean = true;
+    readonly = input(true, { transform: booleanAttribute });
     /**
      * Inline style of the component.
      * @group Props
      */
-    @Input() style: { [klass: string]: any } | null | undefined;
+    style = input<{ [klass: string]: any } | null | undefined>();
     /**
      * Style class of the component.
      * @group Props
      */
-    @Input() styleClass: string | undefined;
+    styleClass = input<string | undefined>();
     /**
      * Whether to apply 'router-link-active-exact' class if route exactly matches the item path.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) exact: boolean = true;
+    exact = input(true, { transform: booleanAttribute });
     /**
      * Callback to invoke when the new step is selected.
      * @param {number} number - current index.
      * @group Emits
      */
-    @Output() activeIndexChange: EventEmitter<number> = new EventEmitter<number>();
+    activeIndexChange = output<number>();
 
-    @ViewChild('list', { static: false }) listViewChild: Nullable<ElementRef>;
+    listViewChild = viewChild<ElementRef>('list');
 
     router = inject(Router);
 
@@ -139,7 +144,7 @@ export class Steps extends BaseComponent {
     }
 
     onItemClick(event: Event, item: MenuItem, i: number) {
-        if (this.readonly || item.disabled) {
+        if (this.readonly() || item.disabled) {
             event.preventDefault();
             return;
         }
@@ -186,10 +191,10 @@ export class Steps extends BaseComponent {
             }
 
             case 'Tab':
-                if (i !== (this.activeIndex ?? -1)) {
-                    const siblings = <any>find(this.listViewChild?.nativeElement, '[data-pc-section="menuitem"]');
+                if (i !== (this.activeIndex() ?? -1)) {
+                    const siblings = <any>find(this.listViewChild()?.nativeElement, '[data-pc-section="menuitem"]');
                     siblings[i].children[0].tabIndex = '-1';
-                    siblings[this.activeIndex ?? 0].children[0].tabIndex = '0';
+                    siblings[this.activeIndex() ?? 0].children[0].tabIndex = '0';
                 }
                 break;
 
@@ -242,13 +247,13 @@ export class Steps extends BaseComponent {
     }
 
     findFirstItem() {
-        const firstSibling = findSingle(this.listViewChild?.nativeElement, '[data-pc-section="menuitem"]');
+        const firstSibling = findSingle(this.listViewChild()?.nativeElement, '[data-pc-section="menuitem"]');
 
         return firstSibling ? firstSibling.children[0] : null;
     }
 
     findLastItem() {
-        const siblings = find(this.listViewChild?.nativeElement, '[data-pc-section="menuitem"]');
+        const siblings = find(this.listViewChild()?.nativeElement, '[data-pc-section="menuitem"]');
 
         return siblings ? siblings[siblings.length - 1].children[0] : null;
     }
@@ -260,11 +265,11 @@ export class Steps extends BaseComponent {
     }
 
     isClickableRouterLink(item: MenuItem) {
-        return item.routerLink && !this.readonly && !item.disabled;
+        return item.routerLink && !this.readonly() && !item.disabled;
     }
 
     isItemDisabled(item: MenuItem, index: number): boolean {
-        return item.disabled || (this.readonly && !this.isActive(item, index));
+        return item.disabled || (this.readonly() && !this.isActive(item, index));
     }
 
     isActive(item: MenuItem, index: number) {
@@ -274,7 +279,7 @@ export class Steps extends BaseComponent {
             return this.router.isActive(this.router.createUrlTree(routerLink, { relativeTo: this.route }).toString(), false);
         }
 
-        return index === this.activeIndex;
+        return index === this.activeIndex();
     }
 
     getItemTabIndex(item: MenuItem, index: number): string {
@@ -282,7 +287,7 @@ export class Steps extends BaseComponent {
             return '-1';
         }
 
-        if (!item.disabled && this.activeIndex === index) {
+        if (!item.disabled && this.activeIndex() === index) {
             return item.tabindex || '0';
         }
 

--- a/packages/primeng/src/steps/style/stepsstyle.ts
+++ b/packages/primeng/src/steps/style/stepsstyle.ts
@@ -3,7 +3,7 @@ import { style } from '@primeuix/styles/steps';
 import { BaseStyle } from 'primeng/base';
 
 const classes = {
-    root: ({ instance }) => ['p-steps p-component', { 'p-readonly': instance.readonly }],
+    root: ({ instance }) => ['p-steps p-component', { 'p-readonly': instance.readonly() }],
     list: 'p-steps-list',
     item: ({ instance, item, index }) => [
         'p-steps-item',

--- a/packages/primeng/src/styleclass/styleclass.ts
+++ b/packages/primeng/src/styleclass/styleclass.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, ElementRef, HostListener, inject, input, NgModule, OnDestroy, Renderer2 } from '@angular/core';
+import { booleanAttribute, Directive, ElementRef, inject, input, NgModule, OnDestroy, Renderer2 } from '@angular/core';
 import { addClass, getTargetElement, hasClass, isElement, removeClass } from '@primeuix/utils';
 import { VoidListener } from 'primeng/ts-helpers';
 
@@ -8,7 +8,10 @@ import { VoidListener } from 'primeng/ts-helpers';
  */
 @Directive({
     selector: '[pStyleClass]',
-    standalone: true
+    standalone: true,
+    host: {
+        '(click)': 'clickListener()'
+    }
 })
 export class StyleClass implements OnDestroy {
     el = inject(ElementRef);
@@ -111,7 +114,6 @@ export class StyleClass implements OnDestroy {
 
     _resizeTarget: any;
 
-    @HostListener('click')
     clickListener() {
         this.target ||= getTargetElement(this.selector(), this.el.nativeElement) as HTMLElement;
 

--- a/packages/primeng/src/table/cancel-editable-row.ts
+++ b/packages/primeng/src/table/cancel-editable-row.ts
@@ -1,4 +1,4 @@
-import { Directive, HostListener, inject } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { BaseComponent } from 'primeng/basecomponent';
 import { EditableRow } from './editable-row';
 import { TableStyle } from './style/tablestyle';
@@ -9,7 +9,8 @@ import type { Table } from './table';
     selector: '[pCancelEditableRow]',
     standalone: true,
     host: {
-        '[class]': "cx('rowEditorCancel')"
+        '[class]': "cx('rowEditorCancel')",
+        '(click)': 'onClick($event)'
     },
     providers: [TableStyle]
 })
@@ -20,7 +21,6 @@ export class CancelEditableRow extends BaseComponent {
 
     _componentStyle = inject(TableStyle);
 
-    @HostListener('click', ['$event'])
     onClick(event: Event) {
         this.dataTable.cancelRowEdit(this.editableRow.data());
         event.preventDefault();

--- a/packages/primeng/src/table/context-menu-row.ts
+++ b/packages/primeng/src/table/context-menu-row.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, HostListener, inject, input } from '@angular/core';
+import { booleanAttribute, Directive, inject, input } from '@angular/core';
 import { BaseComponent } from 'primeng/basecomponent';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TableStyle } from './style/tablestyle';
@@ -10,7 +10,8 @@ import type { Table } from './table';
     standalone: true,
     host: {
         '[class]': 'cx("contextMenuRowSelected")',
-        '[attr.tabindex]': 'isEnabled() ? 0 : undefined'
+        '[attr.tabindex]': 'isEnabled() ? 0 : undefined',
+        '(contextmenu)': 'onContextMenu($event)'
     },
     providers: [TableStyle]
 })
@@ -38,7 +39,6 @@ export class ContextMenuRow extends BaseComponent {
         }
     }
 
-    @HostListener('contextmenu', ['$event'])
     onContextMenu(event: Event) {
         if (this.isEnabled()) {
             this.dataTable.handleRowRightClick({

--- a/packages/primeng/src/table/editable-column.ts
+++ b/packages/primeng/src/table/editable-column.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, effect, HostListener, inject, input, untracked } from '@angular/core';
+import { booleanAttribute, Directive, effect, inject, input, untracked } from '@angular/core';
 import { findSingle, setAttribute } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
 import { DomHandler } from 'primeng/dom';
@@ -9,7 +9,17 @@ import type { Table } from './table';
     selector: '[pEditableColumn]',
     standalone: true,
     host: {
-        '[attr.data-p-editable-column]': 'true'
+        '[attr.data-p-editable-column]': 'true',
+        '(click)': 'onClick($event)',
+        '(keydown.enter)': 'onEnterKeyDown($event)',
+        '(keydown.tab)': 'onTabKeyDown($event)',
+        '(keydown.escape)': 'onEscapeKeyDown($event)',
+        '(keydown.shift.tab)': 'onShiftKeyDown($event)',
+        '(keydown.meta.tab)': 'onShiftKeyDown($event)',
+        '(keydown.arrowdown)': 'onArrowDown($event)',
+        '(keydown.arrowup)': 'onArrowUp($event)',
+        '(keydown.arrowleft)': 'onArrowLeft($event)',
+        '(keydown.arrowright)': 'onArrowRight($event)'
     }
 })
 export class EditableColumn extends BaseComponent {
@@ -48,7 +58,6 @@ export class EditableColumn extends BaseComponent {
         }
     }
 
-    @HostListener('click', ['$event'])
     onClick(event: MouseEvent) {
         if (this.isEnabled()) {
             this.dataTable.selfClick = true;
@@ -128,7 +137,6 @@ export class EditableColumn extends BaseComponent {
         }
     }
 
-    @HostListener('keydown.enter', ['$event'])
     onEnterKeyDown(event: KeyboardEvent) {
         if (this.isEnabled() && !event.shiftKey) {
             if (this.dataTable.isEditingCellValid()) {
@@ -139,7 +147,6 @@ export class EditableColumn extends BaseComponent {
         }
     }
 
-    @HostListener('keydown.tab', ['$event'])
     onTabKeyDown(event: KeyboardEvent) {
         if (this.isEnabled()) {
             if (this.dataTable.isEditingCellValid()) {
@@ -147,10 +154,11 @@ export class EditableColumn extends BaseComponent {
             }
 
             event.preventDefault();
+            // A plain Tab also advances to the next editable cell (previously handled by a second keydown.tab listener).
+            this.moveToNextCell(event);
         }
     }
 
-    @HostListener('keydown.escape', ['$event'])
     onEscapeKeyDown(event: KeyboardEvent) {
         if (this.isEnabled()) {
             if (this.dataTable.isEditingCellValid()) {
@@ -161,9 +169,6 @@ export class EditableColumn extends BaseComponent {
         }
     }
 
-    @HostListener('keydown.tab', ['$event'])
-    @HostListener('keydown.shift.tab', ['$event'])
-    @HostListener('keydown.meta.tab', ['$event'])
     onShiftKeyDown(event: KeyboardEvent) {
         if (this.isEnabled()) {
             if (event.shiftKey) this.moveToPreviousCell(event);
@@ -172,7 +177,6 @@ export class EditableColumn extends BaseComponent {
             }
         }
     }
-    @HostListener('keydown.arrowdown', ['$event'])
     onArrowDown(event: KeyboardEvent) {
         if (this.isEnabled()) {
             let currentCell = this.findCell(event.target);
@@ -194,7 +198,6 @@ export class EditableColumn extends BaseComponent {
         }
     }
 
-    @HostListener('keydown.arrowup', ['$event'])
     onArrowUp(event: KeyboardEvent) {
         if (this.isEnabled()) {
             let currentCell = this.findCell(event.target);
@@ -216,14 +219,12 @@ export class EditableColumn extends BaseComponent {
         }
     }
 
-    @HostListener('keydown.arrowleft', ['$event'])
     onArrowLeft(event: KeyboardEvent) {
         if (this.isEnabled()) {
             this.moveToPreviousCell(event);
         }
     }
 
-    @HostListener('keydown.arrowright', ['$event'])
     onArrowRight(event: KeyboardEvent) {
         if (this.isEnabled()) {
             this.moveToNextCell(event);

--- a/packages/primeng/src/table/init-editable-row.ts
+++ b/packages/primeng/src/table/init-editable-row.ts
@@ -1,4 +1,4 @@
-import { Directive, HostListener, inject } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { BaseComponent } from 'primeng/basecomponent';
 import { EditableRow } from './editable-row';
 import { TABLE_INSTANCE } from './table-service';
@@ -8,7 +8,8 @@ import type { Table } from './table';
     selector: '[pInitEditableRow]',
     standalone: true,
     host: {
-        class: 'p-datatable-row-editor-init'
+        class: 'p-datatable-row-editor-init',
+        '(click)': 'onClick($event)'
     }
 })
 export class InitEditableRow extends BaseComponent {
@@ -16,7 +17,6 @@ export class InitEditableRow extends BaseComponent {
 
     public editableRow = inject(EditableRow);
 
-    @HostListener('click', ['$event'])
     onClick(event: Event) {
         this.dataTable.initRowEdit(this.editableRow.data());
         event.preventDefault();

--- a/packages/primeng/src/table/reorderable-column.ts
+++ b/packages/primeng/src/table/reorderable-column.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { booleanAttribute, Directive, HostListener, inject, input } from '@angular/core';
+import { booleanAttribute, Directive, inject, input } from '@angular/core';
 import { findSingle } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
 import { VoidListener } from 'primeng/ts-helpers';
@@ -11,7 +11,8 @@ import type { Table } from './table';
     selector: '[pReorderableColumn]',
     standalone: true,
     host: {
-        '[class]': "cx('reorderableColumn')"
+        '[class]': "cx('reorderableColumn')",
+        '(drop)': 'onDrop($event)'
     },
     providers: [TableStyle]
 })
@@ -100,7 +101,6 @@ export class ReorderableColumn extends BaseComponent {
         this.dataTable.onColumnDragLeave(event);
     }
 
-    @HostListener('drop', ['$event'])
     onDrop(event: any) {
         if (this.isEnabled()) {
             this.dataTable.onColumnDrop(event, this.el.nativeElement);

--- a/packages/primeng/src/table/reorderable-row-handle.ts
+++ b/packages/primeng/src/table/reorderable-row-handle.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { BaseComponent } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
 import { TableStyle } from './style/tablestyle';
@@ -22,12 +22,4 @@ export class ReorderableRowHandle extends BaseComponent {
     }
 
     _componentStyle = inject(TableStyle);
-
-    constructor(public el: ElementRef) {
-        super();
-    }
-
-    onAfterViewInit() {
-        // DomHandler.addClass(this.el.nativeElement, 'p-datatable-reorderable-row-handle');
-    }
 }

--- a/packages/primeng/src/table/reorderable-row.ts
+++ b/packages/primeng/src/table/reorderable-row.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, HostListener, inject, input } from '@angular/core';
+import { booleanAttribute, Directive, inject, input } from '@angular/core';
 import { BaseComponent } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
 import { VoidListener } from 'primeng/ts-helpers';
@@ -8,7 +8,10 @@ import type { Table } from './table';
 @Directive({
     selector: '[pReorderableRow]',
     standalone: true,
-    hostDirectives: [Bind]
+    hostDirectives: [Bind],
+    host: {
+        '(drop)': 'onDrop($event)'
+    }
 })
 export class ReorderableRow extends BaseComponent {
     hostName = 'Table';
@@ -123,7 +126,6 @@ export class ReorderableRow extends BaseComponent {
         return this.pReorderableRowDisabled() !== true;
     }
 
-    @HostListener('drop', ['$event'])
     onDrop(event: DragEvent) {
         if (this.isEnabled() && this.dataTable.rowDragging) {
             this.dataTable.onRowDrop(event, this.el.nativeElement);

--- a/packages/primeng/src/table/row-toggler.ts
+++ b/packages/primeng/src/table/row-toggler.ts
@@ -1,11 +1,14 @@
-import { booleanAttribute, Directive, HostListener, inject, input } from '@angular/core';
+import { booleanAttribute, Directive, inject, input } from '@angular/core';
 import { BaseComponent } from 'primeng/basecomponent';
 import { TABLE_INSTANCE } from './table-service';
 import type { Table } from './table';
 
 @Directive({
     selector: '[pRowToggler]',
-    standalone: true
+    standalone: true,
+    host: {
+        '(click)': 'onClick($event)'
+    }
 })
 export class RowToggler extends BaseComponent {
     data = input<any>(undefined, { alias: 'pRowToggler' });
@@ -14,7 +17,6 @@ export class RowToggler extends BaseComponent {
 
     public dataTable = inject<Table>(TABLE_INSTANCE);
 
-    @HostListener('click', ['$event'])
     onClick(event: Event) {
         if (this.isEnabled()) {
             this.dataTable.toggleRow(this.data(), event);

--- a/packages/primeng/src/table/save-editable-row.ts
+++ b/packages/primeng/src/table/save-editable-row.ts
@@ -1,4 +1,4 @@
-import { Directive, HostListener, inject } from '@angular/core';
+import { Directive, inject } from '@angular/core';
 import { BaseComponent } from 'primeng/basecomponent';
 import { TableStyle } from './style/tablestyle';
 import { EditableRow } from './editable-row';
@@ -10,7 +10,8 @@ import type { Table } from './table';
     standalone: true,
     providers: [TableStyle],
     host: {
-        '[class]': 'cx("pcRowEditorSave")'
+        '[class]': 'cx("pcRowEditorSave")',
+        '(click)': 'onClick($event)'
     }
 })
 export class SaveEditableRow extends BaseComponent {
@@ -22,7 +23,6 @@ export class SaveEditableRow extends BaseComponent {
 
     public editableRow = inject(EditableRow);
 
-    @HostListener('click', ['$event'])
     onClick(event: Event) {
         this.dataTable.saveRowEdit(this.editableRow.data(), this.editableRow.el.nativeElement);
         event.preventDefault();

--- a/packages/primeng/src/table/selectable-row-dbl-click.ts
+++ b/packages/primeng/src/table/selectable-row-dbl-click.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, HostListener, inject, input } from '@angular/core';
+import { booleanAttribute, Directive, inject, input } from '@angular/core';
 import { BaseComponent } from 'primeng/basecomponent';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TableStyle } from './style/tablestyle';
@@ -9,7 +9,8 @@ import type { Table } from './table';
     selector: '[pSelectableRowDblClick]',
     standalone: true,
     host: {
-        '[class]': 'cx("selectableRow")'
+        '[class]': 'cx("selectableRow")',
+        '(dblclick)': 'onClick($event)'
     },
     providers: [TableStyle]
 })
@@ -43,7 +44,6 @@ export class SelectableRowDblClick extends BaseComponent {
         }
     }
 
-    @HostListener('dblclick', ['$event'])
     onClick(event: Event) {
         if (this.isEnabled()) {
             this.dataTable.handleRowClick({

--- a/packages/primeng/src/table/selectable-row.ts
+++ b/packages/primeng/src/table/selectable-row.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, HostListener, inject, input } from '@angular/core';
+import { booleanAttribute, Directive, inject, input } from '@angular/core';
 import { find } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
 import { DomHandler } from 'primeng/dom';
@@ -14,7 +14,10 @@ import type { Table } from './table';
     host: {
         '[class]': "cx('selectableRow')",
         '[tabindex]': 'setRowTabIndex()',
-        '[attr.data-p-selectable-row]': 'true'
+        '[attr.data-p-selectable-row]': 'true',
+        '(click)': 'onClick($event)',
+        '(touchend)': 'onTouchEnd($event)',
+        '(keydown)': 'onKeyDown($event)'
     },
     providers: [TableStyle]
 })
@@ -54,7 +57,6 @@ export class SelectableRow extends BaseComponent {
         }
     }
 
-    @HostListener('click', ['$event'])
     onClick(event: Event) {
         if (this.isEnabled()) {
             this.dataTable.handleRowClick({
@@ -65,14 +67,12 @@ export class SelectableRow extends BaseComponent {
         }
     }
 
-    @HostListener('touchend', ['$event'])
     onTouchEnd(event: Event) {
         if (this.isEnabled()) {
             this.dataTable.handleRowTouchEnd(event);
         }
     }
 
-    @HostListener('keydown', ['$event'])
     onKeyDown(event: KeyboardEvent) {
         switch (event.code) {
             case 'ArrowDown':

--- a/packages/primeng/src/table/sortable-column.ts
+++ b/packages/primeng/src/table/sortable-column.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, computed, Directive, HostListener, inject, input, signal } from '@angular/core';
+import { booleanAttribute, computed, Directive, inject, input, signal } from '@angular/core';
 import { getAttribute } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
 import { DomHandler } from 'primeng/dom';
@@ -14,7 +14,10 @@ import type { Table } from './table';
         '[class]': "cx('sortableColumn')",
         '[tabindex]': '$tabindex()',
         role: 'columnheader',
-        '[attr.aria-sort]': 'ariaSort()'
+        '[attr.aria-sort]': 'ariaSort()',
+        '(click)': 'onClick($event)',
+        '(keydown.space)': 'onEnterKey($event)',
+        '(keydown.enter)': 'onEnterKey($event)'
     },
     providers: [TableStyle]
 })
@@ -73,7 +76,6 @@ export class SortableColumn extends BaseComponent {
         this.sortOrder.set(sortOrder);
     }
 
-    @HostListener('click', ['$event'])
     onClick(event: MouseEvent) {
         if (this.isEnabled() && !this.isFilterElement(<HTMLElement>event.target)) {
             this.updateSortState();
@@ -86,8 +88,6 @@ export class SortableColumn extends BaseComponent {
         }
     }
 
-    @HostListener('keydown.space', ['$event'])
-    @HostListener('keydown.enter', ['$event'])
     onEnterKey(event: MouseEvent) {
         this.onClick(event);
 

--- a/packages/primeng/src/tabs/tab.ts
+++ b/packages/primeng/src/tabs/tab.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, forwardRef, HostListener, inject, InjectionToken, input, model, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, forwardRef, inject, InjectionToken, input, model, ViewEncapsulation } from '@angular/core';
 import { equals, focus, getAttribute } from '@primeuix/utils';
 import { SharedModule } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
@@ -32,7 +32,10 @@ const TAB_INSTANCE = new InjectionToken<Tab>('TAB_INSTANCE');
         '[attr.aria-disabled]': 'disabled()',
         '[attr.data-p-disabled]': 'disabled()',
         '[attr.data-p-active]': 'active()',
-        '[attr.tabindex]': 'tabindex()'
+        '[attr.tabindex]': 'tabindex()',
+        '(focus)': 'onFocus($event)',
+        '(click)': 'onClick($event)',
+        '(keydown)': 'onKeyDown($event)'
     },
     hostDirectives: [Ripple, Bind],
     providers: [TabStyle, { provide: TAB_INSTANCE, useExisting: Tab }, { provide: PARENT_INSTANCE, useExisting: Tab }]
@@ -81,19 +84,19 @@ export class Tab extends BaseComponent<TabPassThrough> {
 
     mutationObserver: MutationObserver | undefined;
 
-    @HostListener('focus', ['$event']) onFocus(event: FocusEvent) {
+    onFocus(event: FocusEvent) {
         if (!this.disabled()) {
             this.pcTabs.selectOnFocus() && this.changeActiveValue();
         }
     }
 
-    @HostListener('click', ['$event']) onClick(event: MouseEvent) {
+    onClick(event: MouseEvent) {
         if (!this.disabled()) {
             this.changeActiveValue();
         }
     }
 
-    @HostListener('keydown', ['$event']) onKeyDown(event: KeyboardEvent) {
+    onKeyDown(event: KeyboardEvent) {
         switch (event.code) {
             case 'ArrowRight':
                 this.onArrowRightKey(event);

--- a/packages/primeng/src/terminal/terminal.ts
+++ b/packages/primeng/src/terminal/terminal.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, effect, ElementRef, HostListener, inject, InjectionToken, input, NgModule, viewChild, ViewEncapsulation } from '@angular/core';
+import { AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, Component, DestroyRef, effect, ElementRef, inject, InjectionToken, input, NgModule, viewChild, ViewEncapsulation } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { SharedModule } from 'primeng/api';
@@ -40,7 +40,8 @@ const TERMINAL_INSTANCE = new InjectionToken<Terminal>('TERMINAL_INSTANCE');
     encapsulation: ViewEncapsulation.None,
     providers: [TerminalStyle, { provide: TERMINAL_INSTANCE, useExisting: Terminal }, { provide: PARENT_INSTANCE, useExisting: Terminal }],
     host: {
-        '[class]': "cx('root')"
+        '[class]': "cx('root')",
+        '(click)': 'onHostClick()'
     },
     hostDirectives: [Bind]
 })
@@ -85,7 +86,6 @@ export class Terminal extends BaseComponent<TerminalPassThrough> implements Afte
 
     inputRef = viewChild.required<ElementRef<HTMLInputElement>>('in');
 
-    @HostListener('click')
     onHostClick() {
         this.focus(this.inputRef()?.nativeElement);
     }

--- a/packages/primeng/src/textarea/textarea.ts
+++ b/packages/primeng/src/textarea/textarea.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, computed, DestroyRef, Directive, effect, HostListener, inject, InjectionToken, input, NgModule, output } from '@angular/core';
+import { booleanAttribute, computed, DestroyRef, Directive, effect, inject, InjectionToken, input, NgModule, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl } from '@angular/forms';
 import { PARENT_INSTANCE } from 'primeng/basecomponent';
@@ -19,7 +19,8 @@ const TEXTAREA_INSTANCE = new InjectionToken<Textarea>('TEXTAREA_INSTANCE');
     selector: '[pTextarea], [pInputTextarea]',
     standalone: true,
     host: {
-        '[class]': "cx('root')"
+        '[class]': "cx('root')",
+        '(input)': 'onInput($event)'
     },
     providers: [TextareaStyle, { provide: TEXTAREA_INSTANCE, useExisting: Textarea }, { provide: PARENT_INSTANCE, useExisting: Textarea }],
     hostDirectives: [Bind]
@@ -127,7 +128,6 @@ export class Textarea extends BaseModelHolder<TextareaPassThrough> {
         this.writeModelValue(this.ngControl?.value ?? this.el.nativeElement.value);
     }
 
-    @HostListener('input', ['$event'])
     onInput(e: Event) {
         this.writeModelValue((e.target as HTMLTextAreaElement)?.value);
         this.updateState();

--- a/packages/primeng/src/togglebutton/togglebutton.ts
+++ b/packages/primeng/src/togglebutton/togglebutton.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChild, forwardRef, HostListener, inject, InjectionToken, input, NgModule, numberAttribute, output, Provider, signal, TemplateRef } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChild, forwardRef, inject, InjectionToken, input, NgModule, numberAttribute, output, Provider, signal, TemplateRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { SharedModule } from 'primeng/api';
 import { PARENT_INSTANCE } from 'primeng/basecomponent';
@@ -36,7 +36,9 @@ export const TOGGLEBUTTON_VALUE_ACCESSOR: Provider = {
         '[attr.data-pc-name]': "'togglebutton'",
         '[attr.data-p-checked]': 'active()',
         '[attr.data-p-disabled]': '$disabled()',
-        '[attr.data-p]': 'dataP()'
+        '[attr.data-p]': 'dataP()',
+        '(keydown)': 'onKeyDown($event)',
+        '(click)': 'toggle($event)'
     },
     template: `<span [class]="cx('content')" [pBind]="ptm('content')" [attr.data-p]="dataP()">
         <ng-container *ngTemplateOutlet="contentTemplate(); context: getTemplateContext()"></ng-container>
@@ -184,7 +186,6 @@ export class ToggleButton extends BaseEditableHolder<ToggleButtonPassThrough> {
         this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
     }
 
-    @HostListener('keydown', ['$event'])
     onKeyDown(event: KeyboardEvent) {
         switch (event.code) {
             case 'Enter':
@@ -198,7 +199,6 @@ export class ToggleButton extends BaseEditableHolder<ToggleButtonPassThrough> {
         }
     }
 
-    @HostListener('click', ['$event'])
     toggle(event: Event) {
         if (!this.$disabled() && !(this.allowEmpty() === false && this.checked())) {
             this.checked.set(!this.checked());

--- a/packages/primeng/src/toggleswitch/toggleswitch.ts
+++ b/packages/primeng/src/toggleswitch/toggleswitch.ts
@@ -7,7 +7,6 @@ import {
     contentChild,
     ElementRef,
     forwardRef,
-    HostListener,
     inject,
     InjectionToken,
     input,
@@ -81,7 +80,8 @@ export const TOGGLESWITCH_VALUE_ACCESSOR: Provider = {
         '[style]': "sx('root')",
         '[attr.data-p-checked]': '$checked()',
         '[attr.data-p-disabled]': '$disabled()',
-        '[attr.data-p]': 'dataP()'
+        '[attr.data-p]': 'dataP()',
+        '(click)': 'onHostClick($event)'
     },
     hostDirectives: [Bind]
 })
@@ -176,7 +176,6 @@ export class ToggleSwitch extends BaseEditableHolder<ToggleSwitchPassThrough> {
         this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
     }
 
-    @HostListener('click', ['$event'])
     onHostClick(event: MouseEvent) {
         this.onClick(event);
     }

--- a/packages/primeng/src/treetable/context-menu-row.ts
+++ b/packages/primeng/src/treetable/context-menu-row.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, HostListener, inject, input, signal } from '@angular/core';
+import { booleanAttribute, Directive, inject, input, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BaseComponent } from 'primeng/basecomponent';
 import { TreeTableStyle } from './style/treetablestyle';
@@ -10,7 +10,8 @@ import type { TreeTable } from './treetable';
     standalone: true,
     host: {
         '[class]': 'cx("contextMenuRow")',
-        '[tabindex]': 'hostTabindex'
+        '[tabindex]': 'hostTabindex',
+        '(contextmenu)': 'onContextMenu($event)'
     },
     providers: [TreeTableStyle]
 })
@@ -32,7 +33,6 @@ export class TTContextMenuRow extends BaseComponent {
         });
     }
 
-    @HostListener('contextmenu', ['$event'])
     onContextMenu(event: Event) {
         if (this.isEnabled()) {
             this.tt.handleRowRightClick({

--- a/packages/primeng/src/treetable/editable-column.ts
+++ b/packages/primeng/src/treetable/editable-column.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, HostListener, inject, input } from '@angular/core';
+import { booleanAttribute, Directive, inject, input } from '@angular/core';
 import { addClass, findSingle, invokeElementMethod, removeClass } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
 import { TREETABLE_INSTANCE } from './treetable-service';
@@ -6,7 +6,11 @@ import type { TreeTable } from './treetable';
 
 @Directive({
     selector: '[ttEditableColumn]',
-    standalone: true
+    standalone: true,
+    host: {
+        '(click)': 'onClick($event)',
+        '(keydown)': 'onKeyDown($event)'
+    }
 })
 export class TTEditableColumn extends BaseComponent {
     data = input<any>(undefined, { alias: 'ttEditableColumn' });
@@ -24,7 +28,6 @@ export class TTEditableColumn extends BaseComponent {
         }
     }
 
-    @HostListener('click', ['$event'])
     onClick(event: MouseEvent) {
         if (this.isEnabled()) {
             this.tt.editingCellClick = true;
@@ -64,7 +67,6 @@ export class TTEditableColumn extends BaseComponent {
         this.tt.unbindDocumentEditListener();
     }
 
-    @HostListener('keydown', ['$event'])
     onKeyDown(event: KeyboardEvent) {
         if (this.isEnabled()) {
             //enter

--- a/packages/primeng/src/treetable/reorderable-column.ts
+++ b/packages/primeng/src/treetable/reorderable-column.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { booleanAttribute, Directive, HostListener, inject, input } from '@angular/core';
+import { booleanAttribute, Directive, inject, input } from '@angular/core';
 import { findSingle } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
 import { VoidListener } from 'primeng/ts-helpers';
@@ -8,7 +8,10 @@ import type { TreeTable } from './treetable';
 
 @Directive({
     selector: '[ttReorderableColumn]',
-    standalone: true
+    standalone: true,
+    host: {
+        '(drop)': 'onDrop($event)'
+    }
 })
 export class TTReorderableColumn extends BaseComponent {
     hostName = 'TreeTable';
@@ -88,7 +91,6 @@ export class TTReorderableColumn extends BaseComponent {
         this.tt.onColumnDragLeave(event);
     }
 
-    @HostListener('drop', ['$event'])
     onDrop(event: DragEvent) {
         if (this.isEnabled()) {
             this.tt.onColumnDrop(event, this.el.nativeElement);

--- a/packages/primeng/src/treetable/selectable-row-dbl-click.ts
+++ b/packages/primeng/src/treetable/selectable-row-dbl-click.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, HostListener, inject, input, signal } from '@angular/core';
+import { booleanAttribute, Directive, inject, input, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BaseComponent } from 'primeng/basecomponent';
 import { TreeTableStyle } from './style/treetablestyle';
@@ -9,7 +9,8 @@ import type { TreeTable } from './treetable';
     selector: '[ttSelectableRowDblClick]',
     standalone: true,
     host: {
-        '[class]': 'cx("row")'
+        '[class]': 'cx("row")',
+        '(dblclick)': 'onClick($event)'
     },
     providers: [TreeTableStyle]
 })
@@ -37,7 +38,6 @@ export class TTSelectableRowDblClick extends BaseComponent {
         }
     }
 
-    @HostListener('dblclick', ['$event'])
     onClick(event: Event) {
         if (this.isEnabled()) {
             this.tt.handleRowClick({

--- a/packages/primeng/src/treetable/selectable-row.ts
+++ b/packages/primeng/src/treetable/selectable-row.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, HostListener, inject, input, signal } from '@angular/core';
+import { booleanAttribute, Directive, inject, input, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BaseComponent } from 'primeng/basecomponent';
 import { TreeTableStyle } from './style/treetablestyle';
@@ -10,7 +10,10 @@ import type { TreeTable } from './treetable';
     standalone: true,
     host: {
         '[class]': 'cx("row")',
-        '[attr.aria-selected]': 'selected()'
+        '[attr.aria-selected]': 'selected()',
+        '(click)': 'onClick($event)',
+        '(keydown)': 'onKeyDown($event)',
+        '(touchend)': 'onTouchEnd($event)'
     },
     providers: [TreeTableStyle]
 })
@@ -38,7 +41,6 @@ export class TTSelectableRow extends BaseComponent {
         }
     }
 
-    @HostListener('click', ['$event'])
     onClick(event: Event) {
         if (this.isEnabled()) {
             this.tt.handleRowClick({
@@ -48,7 +50,6 @@ export class TTSelectableRow extends BaseComponent {
         }
     }
 
-    @HostListener('keydown', ['$event'])
     onKeyDown(event: KeyboardEvent) {
         switch (event.code) {
             case 'Enter':
@@ -61,7 +62,6 @@ export class TTSelectableRow extends BaseComponent {
         }
     }
 
-    @HostListener('touchend', ['$event'])
     onTouchEnd(event: Event) {
         if (this.isEnabled()) {
             this.tt.handleRowTouchEnd(event);

--- a/packages/primeng/src/treetable/sortable-column.ts
+++ b/packages/primeng/src/treetable/sortable-column.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, HostListener, inject, input, signal } from '@angular/core';
+import { booleanAttribute, Directive, inject, input, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { clearSelection } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
@@ -14,7 +14,9 @@ import type { TreeTable } from './treetable';
         '[class]': 'cx("sortableColumn")',
         '[tabindex]': 'hostTabindex',
         role: 'columnheader',
-        '[attr.aria-sort]': 'ariaSorted'
+        '[attr.aria-sort]': 'ariaSorted',
+        '(click)': 'onClick($event)',
+        '(keydown.enter)': 'onEnterKey($event)'
     },
     providers: [TreeTableStyle],
     hostDirectives: [Bind]
@@ -65,7 +67,6 @@ export class TTSortableColumn extends BaseComponent {
         this.sorted.set(this.tt.isSorted(<string>this.field()) as boolean);
     }
 
-    @HostListener('click', ['$event'])
     onClick(event: MouseEvent) {
         if (this.isEnabled()) {
             this.updateSortState();
@@ -78,7 +79,6 @@ export class TTSortableColumn extends BaseComponent {
         }
     }
 
-    @HostListener('keydown.enter', ['$event'])
     onEnterKey(event: MouseEvent) {
         this.onClick(event);
     }

--- a/packages/primeng/src/treetable/treetable-row.ts
+++ b/packages/primeng/src/treetable/treetable-row.ts
@@ -1,4 +1,4 @@
-import { Directive, HostListener, inject, input } from '@angular/core';
+import { Directive, inject, input } from '@angular/core';
 import { find, findSingle, focus, getAttribute, getIndex, isNotEmpty } from '@primeuix/utils';
 import { BaseComponent } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
@@ -14,7 +14,8 @@ import type { TreeTable } from './treetable';
         '[tabindex]': "'0'",
         '[attr.aria-expanded]': 'expanded',
         '[attr.aria-level]': 'level',
-        role: 'row'
+        role: 'row',
+        '(keydown)': 'onKeyDown($event)'
     },
     providers: [TreeTableStyle],
     hostDirectives: [Bind]
@@ -46,7 +47,6 @@ export class TTRow extends BaseComponent {
 
     _componentStyle = inject(TreeTableStyle);
 
-    @HostListener('keydown', ['$event'])
     onKeyDown(event: KeyboardEvent) {
         switch (event.code) {
             case 'ArrowDown':


### PR DESCRIPTION
## Change

Single topic — internal modernization of component implementations to the current Angular style, with no behavior or public API changes. Seven focused commits, reviewable one by one:

1. `refactor(steps)`: signal inputs/outputs and built-in control flow (`@if`/`@for`) — the last component template still using `*ngIf`/`*ngFor`.
2. `refactor(dragdrop)`: `pDraggable`/`pDroppable` to signal APIs.
3. `refactor(avatargroup)`: decorated style input + `@HostBinding` replaced with a signal input.
4. `refactor(icons)`: `BaseIcon.spin` to a signal input.
5. `refactor(api)`: `PrimeTemplate` to signal inputs and `inject()`.
6. `refactor`: constructor DI replaced with `inject()` in the remaining components.
7. `refactor`: `@HostListener` migrated to `host` metadata across components.

Scope: 44 files, all under `packages/primeng/src` — no specs, no dependency or tooling changes.

## Verified

Full library build (`build:lib` incl. schematics) passes on this branch.