### PR TITLE
style: format the 38 files that make format:check fail on master

### DIFF
--- a/apps/showcase/doc/configuration/dynamic-doc.ts
+++ b/apps/showcase/doc/configuration/dynamic-doc.ts
@@ -10,7 +10,9 @@ import { AppCode } from '@/components/doc/app.code';
     imports: [AppDocSectionText, AppCode],
     template: `
         <app-docsectiontext>
-            <p>Inject the <i>{{ PROJECT_NAME }}</i> to your application to update the initial configuration at runtime.</p>
+            <p>
+                Inject the <i>{{ PROJECT_NAME }}</i> to your application to update the initial configuration at runtime.
+            </p>
         </app-docsectiontext>
         <app-code [code]="code" [hideToggleCode]="true"></app-code>
     `

--- a/apps/showcase/doc/configuration/zindex-doc.ts
+++ b/apps/showcase/doc/configuration/zindex-doc.ts
@@ -12,8 +12,8 @@ import { AppCode } from '@/components/doc/app.code';
         <app-docsectiontext>
             <p>
                 ZIndexes are managed automatically to make sure layering of overlay components work seamlessly when combining multiple components. Still there may be cases where you'd like to configure the configure default values such as a custom
-                layout where header section is fixed. In a case like this, dropdown needs to be displayed below the application header but a modal dialog should be displayed above. {{ PROJECT_NAME }} configuration offers the <i>zIndex</i> property to customize
-                the default values for components categories. Default values are described below and can be customized when setting up {{ PROJECT_NAME }}.
+                layout where header section is fixed. In a case like this, dropdown needs to be displayed below the application header but a modal dialog should be displayed above. {{ PROJECT_NAME }} configuration offers the <i>zIndex</i> property to
+                customize the default values for components categories. Default values are described below and can be customized when setting up {{ PROJECT_NAME }}.
             </p>
         </app-docsectiontext>
         <app-code [code]="code" [hideToggleCode]="true"></app-code>

--- a/apps/showcase/doc/contribution/communication-doc.ts
+++ b/apps/showcase/doc/contribution/communication-doc.ts
@@ -9,8 +9,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
     template: `
         <app-docsectiontext>
             <p>
-                Join the Contributors channel on the <a [href]="DISCORD_URL" target="_blank" rel="noopener noreferrer">PrimeLand Discord</a> server to connect with {{ PROJECT_NAME }} staff and fellow contributors. In this channel, you
-                can discuss the areas you want to contribute to and receive feedback. This channel is open to everyone who'd like to contribute.
+                Join the Contributors channel on the <a [href]="DISCORD_URL" target="_blank" rel="noopener noreferrer">PrimeLand Discord</a> server to connect with {{ PROJECT_NAME }} staff and fellow contributors. In this channel, you can discuss the
+                areas you want to contribute to and receive feedback. This channel is open to everyone who'd like to contribute.
             </p>
         </app-docsectiontext>
     `

--- a/apps/showcase/doc/contribution/introduction-doc.ts
+++ b/apps/showcase/doc/contribution/introduction-doc.ts
@@ -11,8 +11,8 @@ import { Component } from '@angular/core';
     template: `
         <app-docsectiontext>
             <p>
-                {{ PROJECT_NAME }} is a popular Angular UI library maintained by PrimeTek, a company renowned for its comprehensive set of UI components for various frameworks. PrimeTek is dedicated to providing high-quality, versatile, and accessible UI
-                components that help developers build better applications faster.
+                {{ PROJECT_NAME }} is a popular Angular UI library maintained by PrimeTek, a company renowned for its comprehensive set of UI components for various frameworks. PrimeTek is dedicated to providing high-quality, versatile, and
+                accessible UI components that help developers build better applications faster.
             </p>
             <h3>Development Setup</h3>
             <p>To begin with, clone the {{ PROJECT_NAME }} repository from GitHub:</p>

--- a/apps/showcase/doc/contribution/keypoints-doc.ts
+++ b/apps/showcase/doc/contribution/keypoints-doc.ts
@@ -9,8 +9,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
     template: `
         <app-docsectiontext>
             <p>
-                {{ PROJECT_NAME }} has several add-ons such as UI Kit, Premium Templates, and Blocks that rely on design tokens and styling. Any core structural changes, such as adding new props, events, or updating design tokens, should be communicated with
-                the core team to ensure consistency and compatibility.
+                {{ PROJECT_NAME }} has several add-ons such as UI Kit, Premium Templates, and Blocks that rely on design tokens and styling. Any core structural changes, such as adding new props, events, or updating design tokens, should be
+                communicated with the core team to ensure consistency and compatibility.
             </p>
         </app-docsectiontext>
     `

--- a/apps/showcase/doc/guides/accessibility/waiaria-doc.ts
+++ b/apps/showcase/doc/guides/accessibility/waiaria-doc.ts
@@ -13,8 +13,8 @@ import { CheckboxModule } from 'primeng/checkbox';
         <app-docsectiontext>
             <p>
                 ARIA refers to "Accessible Rich Internet Applications" is a suite to fill the gap where semantic HTML is inadequate. These cases are mainly related to rich UI components/widgets. Although browser support for rich UI components such as
-                a datepicker or colorpicker has been improved over the past years many web developers still utilize UI components derived from standard HTML elements created by them or by other projects like {{ PROJECT_NAME }}. These types of components must
-                provide keyboard and screen reader support, the latter case is where the WAI-ARIA is utilized.
+                a datepicker or colorpicker has been improved over the past years many web developers still utilize UI components derived from standard HTML elements created by them or by other projects like {{ PROJECT_NAME }}. These types of
+                components must provide keyboard and screen reader support, the latter case is where the WAI-ARIA is utilized.
             </p>
             <p>
                 ARIA consists of roles, properties and attributes. <b>Roles</b> define what the element is mainly used for e.g. <i>checkbox</i>, <i>dialog</i>, <i>tablist</i> whereas <b>States</b> and <b>Properties</b> define the metadata of the

--- a/apps/showcase/doc/guides/animations/introduction-doc.ts
+++ b/apps/showcase/doc/guides/animations/introduction-doc.ts
@@ -9,8 +9,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
     template: `
         <app-docsectiontext>
             <p>
-                Various {{ PROJECT_NAME }} Components utilize native CSS animations to provide an enhanced user experience. The default animations are based on the best practices recommended by the usability experts. In case you need to customize the default
-                animations, this documentation covers the entire set of built-in animations.
+                Various {{ PROJECT_NAME }} Components utilize native CSS animations to provide an enhanced user experience. The default animations are based on the best practices recommended by the usability experts. In case you need to customize the
+                default animations, this documentation covers the entire set of built-in animations.
             </p>
             <p>
                 Animations are defined using a combination of style classes and keyframes. The ⁠<i>.&#123;classname&#125;-enter-active</i> and ⁠<i>.&#123;classname&#125;-leave-active</i> classes specify the animation name, duration, and easing

--- a/apps/showcase/doc/guides/csslayer/reset-doc.ts
+++ b/apps/showcase/doc/guides/csslayer/reset-doc.ts
@@ -10,9 +10,10 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
     template: `
         <app-docsectiontext>
             <p>
-                Ease of customization may present an issue if you have global styles on HTML elements like inputs and buttons that are also utilized by {{ PROJECT_NAME }} because global styles with a broader scope e.g. <i>button &#123; &#125;</i> and no layer
-                always override the {{ PROJECT_NAME }} components leading to unexpected results. A common use case for global styles applying to standard HTML elements is CSS reset utilities to remove the default styling of the browsers. In this case, best
-                practice is wrapping your CSS in a layer like <i>reset</i> and make sure <i>primeNG</i> comes after your layer since layers defined after has higher precedence. This way, your Reset CSS does not get in the way of {{ PROJECT_NAME }} components.
+                Ease of customization may present an issue if you have global styles on HTML elements like inputs and buttons that are also utilized by {{ PROJECT_NAME }} because global styles with a broader scope e.g. <i>button &#123; &#125;</i> and
+                no layer always override the {{ PROJECT_NAME }} components leading to unexpected results. A common use case for global styles applying to standard HTML elements is CSS reset utilities to remove the default styling of the browsers. In
+                this case, best practice is wrapping your CSS in a layer like <i>reset</i> and make sure <i>primeNG</i> comes after your layer since layers defined after has higher precedence. This way, your Reset CSS does not get in the way of
+                {{ PROJECT_NAME }} components.
             </p>
             <app-code [hideToggleCode]="true" [hideCodeSandbox]="true" [hideStackBlitz]="true"></app-code>
         </app-docsectiontext>

--- a/apps/showcase/doc/guides/csslayer/specificity-doc.ts
+++ b/apps/showcase/doc/guides/csslayer/specificity-doc.ts
@@ -13,13 +13,13 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
         <app-docsectiontext>
             <p>
                 The <i>&#64;layer</i> is a standard CSS feature to define cascade layers for a customizable order of precedence. If you need to become more familiar with layers, visit the documentation at
-                <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@layer">MDN</a> to begin with. {{ PROJECT_NAME }} wraps the built-in style classes under the <i>primeng</i> cascade layer to make the library styles easy to override. CSS in your app
-                without a layer has the highest CSS specificity, so you'll be able to override styles regardless of the location or how strong a class is written.
+                <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@layer">MDN</a> to begin with. {{ PROJECT_NAME }} wraps the built-in style classes under the <i>primeng</i> cascade layer to make the library styles easy to override. CSS in
+                your app without a layer has the highest CSS specificity, so you'll be able to override styles regardless of the location or how strong a class is written.
             </p>
             <p>
                 For example, let's assume you need to remove the rounded borders of the InputSwitch component defined by the theme in use. In order to achieve this, <i>.p-inputswitch .p-inputswitch-slider</i> selector needs to be overriden. Without
-                the layers, we'd have to write a stronger css or use <i>!important</i> however, with layers, this does not present an issue as your CSS can always override {{ PROJECT_NAME }} with a more straightforward class name such as <i>my-inputswitch</i>.
-                Another advantage of this approach is that it does not force you to figure out the built-in class names of the components.
+                the layers, we'd have to write a stronger css or use <i>!important</i> however, with layers, this does not present an issue as your CSS can always override {{ PROJECT_NAME }} with a more straightforward class name such as
+                <i>my-inputswitch</i>. Another advantage of this approach is that it does not force you to figure out the built-in class names of the components.
             </p>
             <div class="card flex justify-center">
                 <p-inputSwitch [(ngModel)]="checked" styleClass="my-inputswitch" />

--- a/apps/showcase/doc/guides/passthrough/pcprefix-doc.ts
+++ b/apps/showcase/doc/guides/passthrough/pcprefix-doc.ts
@@ -12,8 +12,8 @@ import { PanelModule } from 'primeng/panel';
     template: `
         <app-docsectiontext>
             <p>
-                A UI component may also use other UI components, in this case section names are prefixed with <i>pc</i> (Prime Component) to denote the {{ PROJECT_NAME }} component begin used. This distinguishes components from standard DOM elements and
-                indicating the necessity for a nested structure. For example, the <i>badge</i> section is identified as <i>pcBadge</i> because the button component incorporates the badge component internally.
+                A UI component may also use other UI components, in this case section names are prefixed with <i>pc</i> (Prime Component) to denote the {{ PROJECT_NAME }} component begin used. This distinguishes components from standard DOM elements
+                and indicating the necessity for a nested structure. For example, the <i>badge</i> section is identified as <i>pcBadge</i> because the button component incorporates the badge component internally.
             </p>
         </app-docsectiontext>
         <div class="card flex justify-center">

--- a/apps/showcase/doc/guides/rtl/configuration-doc.ts
+++ b/apps/showcase/doc/guides/rtl/configuration-doc.ts
@@ -11,8 +11,8 @@ import { Component } from '@angular/core';
     template: `
         <app-docsectiontext>
             <p>
-                The {{ PROJECT_NAME }} components natively support Right-to-Left (RTL) text direction through a modern CSS implementation utilizing FlexBox and classes like <i>*-inline-start</i> and <i>*-block-end</i>. Consequently, no JavaScript configuration
-                is necessary; setting the document's text direction to RTL is sufficient to enable this feature.
+                The {{ PROJECT_NAME }} components natively support Right-to-Left (RTL) text direction through a modern CSS implementation utilizing FlexBox and classes like <i>*-inline-start</i> and <i>*-block-end</i>. Consequently, no JavaScript
+                configuration is necessary; setting the document's text direction to RTL is sufficient to enable this feature.
             </p>
             <p>The RTL setting can either be set using the <i>dir</i> attribute or with the <i>direction</i> style property.</p>
         </app-docsectiontext>

--- a/apps/showcase/doc/llms/llmstxt-doc.ts
+++ b/apps/showcase/doc/llms/llmstxt-doc.ts
@@ -10,8 +10,8 @@ import { ButtonModule } from 'primeng/button';
     template: `
         <app-docsectiontext>
             <p>
-                The <a href="https://llmstxt.org/" target="_blank" rel="noopener noreferrer">llms.txt</a> file is an industry standard that helps AI models better understand and navigate the {{ PROJECT_NAME }} documentation. It lists key pages in a structured
-                format, making it easier for LLMs to retrieve relevant information.
+                The <a href="https://llmstxt.org/" target="_blank" rel="noopener noreferrer">llms.txt</a> file is an industry standard that helps AI models better understand and navigate the {{ PROJECT_NAME }} documentation. It lists key pages in a
+                structured format, making it easier for LLMs to retrieve relevant information.
             </p>
             <a href="/llms/llms.txt" target="_blank">
                 <p-button label="Open llms.txt" />

--- a/apps/showcase/doc/migration/v19/breakingchangesdoc.ts
+++ b/apps/showcase/doc/migration/v19/breakingchangesdoc.ts
@@ -11,8 +11,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
         <app-docsectiontext>
             <h4>Configuration</h4>
             <p>
-                The <i>PrimeNGConfig</i> has been replaced by <i>{{ PROJECT_NAME }}</i> and the initial configuration is now done via the <i>providePrimeNG</i> provider during startup. See the <a href="/installation" class="">installation</a> section for an
-                example.
+                The <i>PrimeNGConfig</i> has been replaced by <i>{{ PROJECT_NAME }}</i> and the initial configuration is now done via the <i>providePrimeNG</i> provider during startup. See the <a href="/installation" class="">installation</a> section
+                for an example.
             </p>
 
             <h4>SASS Themes</h4>

--- a/apps/showcase/doc/migration/v19/migrationoverviewdoc.ts
+++ b/apps/showcase/doc/migration/v19/migrationoverviewdoc.ts
@@ -10,20 +10,21 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
     template: `
         <app-docsectiontext>
             <p>
-                At PrimeTek, we have been developing UI component libraries since 2008. The web continues to undergo technological advancements, and as a result, we have to modernize and update our libraries to stay relevant. {{ PROJECT_NAME }} v18 is the
-                next-generation version that fully embraces modern Web APIs and removes technical debt like the legacy-styled mode. Every component has been reviewed and enhanced.
+                At PrimeTek, we have been developing UI component libraries since 2008. The web continues to undergo technological advancements, and as a result, we have to modernize and update our libraries to stay relevant. {{ PROJECT_NAME }} v18
+                is the next-generation version that fully embraces modern Web APIs and removes technical debt like the legacy-styled mode. Every component has been reviewed and enhanced.
             </p>
             <p>
-                The most notable feature is the new <a routerLink="/theming">styled mode</a> implementation. Previous iterations use SASS at an external repo called <i>{{ PROJECT_NAME }}-sass-theme</i> which requires compilation of a <i>theme.css</i>a file.
-                This file had to be included in the application and need to be swapped at runtime for basic tasks like dark mode or primary color changes. In v18, styled mode is now part of the core, SASS is not used at all, and a new design token
-                based architecture that fully utilizes CSS variables has been created. The new API is modern and superior to the legacy styled mode.
+                The most notable feature is the new <a routerLink="/theming">styled mode</a> implementation. Previous iterations use SASS at an external repo called <i>{{ PROJECT_NAME }}-sass-theme</i> which requires compilation of a
+                <i>theme.css</i>a file. This file had to be included in the application and need to be swapped at runtime for basic tasks like dark mode or primary color changes. In v18, styled mode is now part of the core, SASS is not used at all,
+                and a new design token based architecture that fully utilizes CSS variables has been created. The new API is modern and superior to the legacy styled mode.
             </p>
             <p>
                 Names of some of the components have been changed to more common alternatives for example, <i>Popover</i> replaced <i>OverlayPanel</i> and <i>InputSwitch</i> is now called <i>ToggleSwitch</i>. Each component has been reviewed for a
                 consistent naming between CSS class names and sections. An example would be the <i>option</i> element of a Select component that uses <i>p-select-option</i> for the class name.
             </p>
             <p>
-                Components have been utilized more within other components, for instance Dialog close button is not actually a {{ PROJECT_NAME }} button so that <i>closeButtonProps</i> can be used to enable the features of button like outlined, raised and more.
+                Components have been utilized more within other components, for instance Dialog close button is not actually a {{ PROJECT_NAME }} button so that <i>closeButtonProps</i> can be used to enable the features of button like outlined,
+                raised and more.
             </p>
         </app-docsectiontext>
     `

--- a/apps/showcase/doc/migration/v20/backwardcompatibledoc.ts
+++ b/apps/showcase/doc/migration/v20/backwardcompatibledoc.ts
@@ -26,8 +26,8 @@ import { Component } from '@angular/core';
             <h4>PrimeUIX Themes</h4>
             <p>
                 PrimeUIX is a shared package between all Prime libraries, this shared approach allows PrimeTek teams to share theming and the Design team who is responsible for the Figma UI Kit to work on a single design file, which is the single
-                source of truth. Prior to v20, {{ PROJECT_NAME }} has its own fork in default styles and for the design tokens <i>{{ '@' }}primeng/themes</i> package is required. With v20, {{ PROJECT_NAME }} receives the styles from <i>{{ '@' }}primeuix/styles</i> under
-                the hood and the design tokens as theme presets are loaded from <i>{{ '@' }}primeuix/themes</i>.
+                source of truth. Prior to v20, {{ PROJECT_NAME }} has its own fork in default styles and for the design tokens <i>{{ '@' }}primeng/themes</i> package is required. With v20, {{ PROJECT_NAME }} receives the styles from
+                <i>{{ '@' }}primeuix/styles</i> under the hood and the design tokens as theme presets are loaded from <i>{{ '@' }}primeuix/themes</i>.
             </p>
             <p>
                 The components need to be adjusted to fit in the PrimeUIX theming by using the <i>host</i> element where applicable, as a result for the components that use host element (&lt;p-* /&gt;) as their main container, the

--- a/apps/showcase/doc/migration/v20/overviewdoc.ts
+++ b/apps/showcase/doc/migration/v20/overviewdoc.ts
@@ -9,9 +9,9 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
     template: `
         <app-docsectiontext>
             <p>
-                {{ PROJECT_NAME }} v20 is an evolution rather than a revolution compared to v18/v19 that introduced the brand new theming architecture. V20 focuses on <b>form enhancements</b> along with the <b>primeuix migration</b> for shared theming between
-                all Prime projects including PrimeVue, PrimeReact and the upcoming projects such as PrimeUI web components. As of v20, {{ PROJECT_NAME }} has switched {{ PROJECT_NAME }} to semantic versioning, and as a result changes are iterative, with a smooth migration
-                strategy and no breaking changes. In the future versions, same approach will be put in action and migrations will be trivial with no breaking changes.
+                {{ PROJECT_NAME }} v20 is an evolution rather than a revolution compared to v18/v19 that introduced the brand new theming architecture. V20 focuses on <b>form enhancements</b> along with the <b>primeuix migration</b> for shared
+                theming between all Prime projects including PrimeVue, PrimeReact and the upcoming projects such as PrimeUI web components. As of v20, {{ PROJECT_NAME }} has switched {{ PROJECT_NAME }} to semantic versioning, and as a result changes
+                are iterative, with a smooth migration strategy and no breaking changes. In the future versions, same approach will be put in action and migrations will be trivial with no breaking changes.
             </p>
         </app-docsectiontext>
     `

--- a/apps/showcase/doc/migration/v21/breakingdoc.ts
+++ b/apps/showcase/doc/migration/v21/breakingdoc.ts
@@ -10,9 +10,9 @@ import { RouterModule } from '@angular/router';
     template: `
         <app-docsectiontext>
             <p>
-                Beginning with {{ PROJECT_NAME }} v20, PrimeTek adopted a no-breaking-change policy for incremental major version updates. {{ PROJECT_NAME }} v21 maintains this policy with one exception: due to the deprecation of Angular's animations package in Angular
-                v20.2, we have migrated to native CSS-based animations. Consequently, the <i>showTransitionOptions</i> and <i>hideTransitionOptions</i> properties that belong to the animations api are deprecated in v21 and no longer functional. v21
-                will not cause an error as the properties still exist, however your customizations will be ignored. If you currently use these properties for animation customization, please refer to the new
+                Beginning with {{ PROJECT_NAME }} v20, PrimeTek adopted a no-breaking-change policy for incremental major version updates. {{ PROJECT_NAME }} v21 maintains this policy with one exception: due to the deprecation of Angular's animations
+                package in Angular v20.2, we have migrated to native CSS-based animations. Consequently, the <i>showTransitionOptions</i> and <i>hideTransitionOptions</i> properties that belong to the animations api are deprecated in v21 and no
+                longer functional. v21 will not cause an error as the properties still exist, however your customizations will be ignored. If you currently use these properties for animation customization, please refer to the new
                 <a routerLink="/guides/animations" class="text-primary font-medium hover:underline">animations documentation</a> for the updated approach.
             </p>
             <p>Other than this case, v21 should be a drop-in replacement. If you face with any issues during upgrade, please report an issue using at GitHub.</p>

--- a/apps/showcase/doc/tailwind/colorpalette-doc.ts
+++ b/apps/showcase/doc/tailwind/colorpalette-doc.ts
@@ -8,7 +8,9 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
     standalone: true,
     imports: [NgClass, NgStyle, AppDocSectionText],
     template: `
-        <app-docsectiontext> <p>{{ PROJECT_NAME }} color palette as utility classes.</p></app-docsectiontext>
+        <app-docsectiontext>
+            <p>{{ PROJECT_NAME }} color palette as utility classes.</p></app-docsectiontext
+        >
         <div class="card">
             <div class="flex flex-col gap-12">
                 <ul class="p-0 m-0 list-none flex sm:flex-col gap-4 flex-wrap sm:flex-nowrap">

--- a/apps/showcase/doc/tailwind/darkmode-doc.ts
+++ b/apps/showcase/doc/tailwind/darkmode-doc.ts
@@ -10,8 +10,8 @@ import { Component } from '@angular/core';
     template: `
         <app-docsectiontext>
             <p>
-                In styled mode, {{ PROJECT_NAME }} uses the <i>system</i> as the default <i>darkModeSelector</i> in theme configuration. If you have a dark mode switch in your application, ensure that <i>darkModeSelector</i> is aligned with the Tailwind dark
-                variant for seamless integration. Note that, this particular configuration isn't required if you're utilizing the default system color scheme.
+                In styled mode, {{ PROJECT_NAME }} uses the <i>system</i> as the default <i>darkModeSelector</i> in theme configuration. If you have a dark mode switch in your application, ensure that <i>darkModeSelector</i> is aligned with the
+                Tailwind dark variant for seamless integration. Note that, this particular configuration isn't required if you're utilizing the default system color scheme.
             </p>
             <p>Suppose that, the darkModeSelector is set as <i>my-app-dark</i> in {{ PROJECT_NAME }}.</p>
             <app-code [code]="code1" [importCode]="true" [hideToggleCode]="true" [hideStackBlitz]="true" />

--- a/apps/showcase/doc/tailwind/overview-doc.ts
+++ b/apps/showcase/doc/tailwind/overview-doc.ts
@@ -14,8 +14,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
                 that take this approach to build components specifically for Tailwind.
             </p>
             <p>
-                Tailwind is an outstanding CSS library, however it lacks a true comprehensive UI suite when combined with Angular, this is where {{ PROJECT_NAME }} comes in by providing a wide range of highly accessible and feature rich UI component library.
-                The core of {{ PROJECT_NAME }} does not depend on Tailwind CSS.
+                Tailwind is an outstanding CSS library, however it lacks a true comprehensive UI suite when combined with Angular, this is where {{ PROJECT_NAME }} comes in by providing a wide range of highly accessible and feature rich UI component
+                library. The core of {{ PROJECT_NAME }} does not depend on Tailwind CSS.
             </p>
         </app-docsectiontext>
     `

--- a/apps/showcase/doc/tailwind/plugin-doc.ts
+++ b/apps/showcase/doc/tailwind/plugin-doc.ts
@@ -24,8 +24,8 @@ import { Component } from '@angular/core';
             <p>In the CSS file that contains the tailwindcss import, add the <i>tailwindcss-primeui</i> import as well.</p>
             <app-code [code]="code2" [importCode]="true" [hideToggleCode]="true" [hideStackBlitz]="true" />
             <p class="mt-4">
-                For a comprehensive starter guide, review the <a href="{{ GITHUB_REPO_URL }}-examples/tree/main/primeng-quickstart-tailwind" target="_blank" rel="noopener noreferrer">primeng-quickstart-tailwind</a> repository which
-                demonstrates the integration.
+                For a comprehensive starter guide, review the <a href="{{ GITHUB_REPO_URL }}-examples/tree/main/primeng-quickstart-tailwind" target="_blank" rel="noopener noreferrer">primeng-quickstart-tailwind</a> repository which demonstrates the
+                integration.
             </p>
             <h3>Tailwind v3</h3>
             <p>Use the plugins option in your Tailwind config file to configure the plugin.</p>

--- a/apps/showcase/doc/theming/styled/architecture-doc.ts
+++ b/apps/showcase/doc/theming/styled/architecture-doc.ts
@@ -9,9 +9,9 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
     template: `
         <app-docsectiontext>
             <p>
-                {{ PROJECT_NAME }} is a design agnostic library so unlike some other UI libraries it does not enforce a certain styling such as material design. Styling is decoupled from the components using the themes instead. A theme consists of two parts;
-                <i>base</i> and <i>preset</i>. The base is the style rules with CSS variables as placeholders whereas the preset is a set of design tokens to feed a base by mapping the tokens to CSS variables. A base may be configured with different
-                presets, currently Aura, Material, Lara and Nora are the available built-in options.
+                {{ PROJECT_NAME }} is a design agnostic library so unlike some other UI libraries it does not enforce a certain styling such as material design. Styling is decoupled from the components using the themes instead. A theme consists of
+                two parts; <i>base</i> and <i>preset</i>. The base is the style rules with CSS variables as placeholders whereas the preset is a set of design tokens to feed a base by mapping the tokens to CSS variables. A base may be configured with
+                different presets, currently Aura, Material, Lara and Nora are the available built-in options.
             </p>
             <img alt="Architecture" src="https://primefaces.org/cdn/primevue/images/primevue-v4-styled-architecture.png" class="w-full mb-4" />
             <p>The core of the styled mode architecture is based on a concept named <i>design token</i>, a preset defines the token configuration in 3 tiers; <i>primitive</i>, <i>semantic</i> and <i>component</i>.</p>
@@ -33,8 +33,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <h3>Best Practices</h3>
             <p class="mb-0">
                 Use primitive tokens when defining the core color palette and semantic tokens to specify the common design elements such as focus ring, primary colors and surfaces. Components tokens should only be used when customizing a specific
-                component. By defining your own design tokens as a custom preset, you'll be able to define your own style without touching CSS. Overriding the {{ PROJECT_NAME }} components using style classes is not a best practice and should be the last
-                resort, design tokens are the suggested approach.
+                component. By defining your own design tokens as a custom preset, you'll be able to define your own style without touching CSS. Overriding the {{ PROJECT_NAME }} components using style classes is not a best practice and should be the
+                last resort, design tokens are the suggested approach.
             </p>
         </app-docsectiontext>
     `

--- a/apps/showcase/doc/theming/styled/presets-doc.ts
+++ b/apps/showcase/doc/theming/styled/presets-doc.ts
@@ -10,8 +10,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
         <app-docsectiontext>
             <p>
                 Aura, Material, Lara and Nora are the available built-in options, created to demonstrate the power of the design-agnostic theming. Aura is PrimeTek's own vision, Material follows Google Material Design v2, Lara is based on Bootstrap
-                and Nora is inspired by enterprise applications. Visit the <a href="{{ GITHUB_REPO_URL }}/tree/master/packages/themes/src/presets" target="_blank" rel="noopener noreferrer">source code</a> to learn more about the
-                structure of presets. You may use them out of the box with modifications or utilize them as reference in case you need to build your own presets from scratch.
+                and Nora is inspired by enterprise applications. Visit the <a href="{{ GITHUB_REPO_URL }}/tree/master/packages/themes/src/presets" target="_blank" rel="noopener noreferrer">source code</a> to learn more about the structure of presets.
+                You may use them out of the box with modifications or utilize them as reference in case you need to build your own presets from scratch.
             </p>
         </app-docsectiontext>
     `

--- a/apps/showcase/doc/theming/styled/reset-doc.ts
+++ b/apps/showcase/doc/theming/styled/reset-doc.ts
@@ -10,8 +10,8 @@ import { Component } from '@angular/core';
     template: `
         <app-docsectiontext>
             <p>
-                In case {{ PROJECT_NAME }} components have visual issues in your application, a Reset CSS may be the culprit. CSS layers would be an efficient solution that involves enabling the {{ PROJECT_NAME }} layer, wrapping the Reset CSS in another layer and
-                defining the layer order. This way, your Reset CSS does not get in the way of {{ PROJECT_NAME }} components.
+                In case {{ PROJECT_NAME }} components have visual issues in your application, a Reset CSS may be the culprit. CSS layers would be an efficient solution that involves enabling the {{ PROJECT_NAME }} layer, wrapping the Reset CSS in
+                another layer and defining the layer order. This way, your Reset CSS does not get in the way of {{ PROJECT_NAME }} components.
             </p>
         </app-docsectiontext>
         <app-code [code]="code" [hideToggleCode]="true"></app-code>

--- a/apps/showcase/doc/theming/styled/scale-doc.ts
+++ b/apps/showcase/doc/theming/styled/scale-doc.ts
@@ -10,8 +10,8 @@ import { Component } from '@angular/core';
     template: `
         <app-docsectiontext>
             <p>
-                {{ PROJECT_NAME }} UI component use <i>rem</i> units, 1rem equals to the font size of the <i>html</i> element which is <i>16px</i> by default. Use the root font-size to adjust the size of the components globally. This website uses <i>14px</i> as
-                the base so it may differ from your application if your base font size is different.
+                {{ PROJECT_NAME }} UI component use <i>rem</i> units, 1rem equals to the font size of the <i>html</i> element which is <i>16px</i> by default. Use the root font-size to adjust the size of the components globally. This website uses
+                <i>14px</i> as the base so it may differ from your application if your base font size is different.
             </p>
         </app-docsectiontext>
         <app-code [code]="code" [hideToggleCode]="true"></app-code>

--- a/apps/showcase/doc/theming/styled/specificity-doc.ts
+++ b/apps/showcase/doc/theming/styled/specificity-doc.ts
@@ -13,8 +13,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
                 <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/@layer" class="doc-link">MDN</a> to begin with.
             </p>
             <p>
-                The <i>cssLayer</i> is disabled by default, when it is enabled at theme configuration, {{ PROJECT_NAME }} wraps the built-in style classes under the <i>primeng</i> cascade layer to make the library styles easy to override. CSS in your app
-                without a layer has the highest CSS specificity, so you'll be able to override styles regardless of the location or how strong a class is written.
+                The <i>cssLayer</i> is disabled by default, when it is enabled at theme configuration, {{ PROJECT_NAME }} wraps the built-in style classes under the <i>primeng</i> cascade layer to make the library styles easy to override. CSS in your
+                app without a layer has the highest CSS specificity, so you'll be able to override styles regardless of the location or how strong a class is written.
             </p>
         </app-docsectiontext>
     `

--- a/apps/showcase/doc/theming/unstyled/voltui-doc.ts
+++ b/apps/showcase/doc/theming/unstyled/voltui-doc.ts
@@ -14,7 +14,8 @@ import { Component } from '@angular/core';
                 with an added layer of theming through Tailwind CSS v4. This approach, along with the templating features, offers complete control over the theming and presentation.
             </p>
             <p>
-                Volt will also be available for PrimeReact. In the future, PrimeTek may bring Volt to Angular via {{ PROJECT_NAME }} if there is significant community demand. Currently, Volt-Vue can serve as a reference when styling your unstyled {{ PROJECT_NAME }}
+                Volt will also be available for PrimeReact. In the future, PrimeTek may bring Volt to Angular via {{ PROJECT_NAME }} if there is significant community demand. Currently, Volt-Vue can serve as a reference when styling your unstyled
+                {{ PROJECT_NAME }}
                 components with Tailwind CSS.
             </p>
         </app-docsectiontext>

--- a/apps/showcase/doc/tooltip/custom-doc.ts
+++ b/apps/showcase/doc/tooltip/custom-doc.ts
@@ -49,7 +49,9 @@ import { TooltipModule } from 'primeng/tooltip';
                             <path d="M18.8321 8.27235L22.2245 7.94938L19.9629 5.68861H17.7013L18.8321 8.27235Z" fill="var(--ground-background)" />
                             <path d="M11.4013 8.27235L8.00893 7.94938L10.2705 5.68861H12.5321L11.4013 8.27235Z" fill="var(--ground-background)" />
                         </svg>
-                        <span> <b>{{ PROJECT_NAME }}</b> rocks! </span>
+                        <span>
+                            <b>{{ PROJECT_NAME }}</b> rocks!
+                        </span>
                     </div>
                 </ng-template>
             </div>

--- a/apps/showcase/doc/uikit/common/support-doc.ts
+++ b/apps/showcase/doc/uikit/common/support-doc.ts
@@ -8,9 +8,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
     imports: [AppDocSectionText],
     template: `<app-docsectiontext>
         <p>
-            The community gathers on <a href="{{ GITHUB_DISCUSSIONS_URL }}/categories/figma-ui-kit" target="_blank" rel="noopener noreferrer">GitHub Discussions</a> and
-            <a [href]="DISCORD_URL" target="_blank" rel="noopener noreferrer">Discord</a> to ask questions, share ideas, and discuss the technology. For direct inquiries or suggestions, feel free to contact us at
-            <a href="mailto:contact@primetek.com.tr">contact&#64;primetek.com.tr</a>.
+            The community gathers on <a href="{{ GITHUB_DISCUSSIONS_URL }}/categories/figma-ui-kit" target="_blank" rel="noopener noreferrer">GitHub Discussions</a> and <a [href]="DISCORD_URL" target="_blank" rel="noopener noreferrer">Discord</a> to
+            ask questions, share ideas, and discuss the technology. For direct inquiries or suggestions, feel free to contact us at <a href="mailto:contact@primetek.com.tr">contact&#64;primetek.com.tr</a>.
         </p>
     </app-docsectiontext>`
 })

--- a/apps/showcase/pages/designer/index.ts
+++ b/apps/showcase/pages/designer/index.ts
@@ -342,8 +342,7 @@ import { RippleModule } from 'primeng/ripple';
                     <div class="leading-normal mb-2 font-bold">How can I get support?</div>
                     <p class="mt-0 mb-11 p-0 leading-normal">
                         PrimeTek offers assistance with account management and licensing issues, with the expectation that users have the necessary technical knowledge to use our products, as we do not offer technical support or consulting. Users can
-                        seek assistance in our community via our public <a [href]="DISCORD_URL" class="doc-link">Discord</a> and
-                        <a href="{{ GITHUB_DISCUSSIONS_URL }}/categories/theme-designer" class="doc-link">Forum</a>.
+                        seek assistance in our community via our public <a [href]="DISCORD_URL" class="doc-link">Discord</a> and <a href="{{ GITHUB_DISCUSSIONS_URL }}/categories/theme-designer" class="doc-link">Forum</a>.
                     </p>
                 </div>
                 <div class="col-span-12 lg:col-span-4 px-2 lg:px-7">
@@ -423,8 +422,8 @@ import { RippleModule } from 'primeng/ripple';
                 <li>
                     <div class="font-bold mb-4">10. Contact Information</div>
                     <p>
-                        For any questions regarding these Terms and Conditions, please contact us through our official channels as listed on our website. By using the {{ PROJECT_NAME }} Theme Designer, you acknowledge that you have read and agree to these Terms
-                        and Conditions.
+                        For any questions regarding these Terms and Conditions, please contact us through our official channels as listed on our website. By using the {{ PROJECT_NAME }} Theme Designer, you acknowledge that you have read and agree to
+                        these Terms and Conditions.
                     </p>
                 </li>
             </ol>

--- a/apps/showcase/pages/guides/animations/animationsdemo.ts
+++ b/apps/showcase/pages/guides/animations/animationsdemo.ts
@@ -15,7 +15,9 @@ import { AppDoc } from '@/components/doc/app.doc';
     template: `<app-doc
         docTitle="Animations - {{ PROJECT_NAME }}"
         header="Animations"
-        description="Various {{ PROJECT_NAME }} Components utilize native CSS animations to provide an enhanced user experience. The default animations are based on the best practices recommended by the usability experts. In case you need to customize the default animations, this documentation covers the entire set of built-in animations."
+        description="Various {{
+            PROJECT_NAME
+        }} Components utilize native CSS animations to provide an enhanced user experience. The default animations are based on the best practices recommended by the usability experts. In case you need to customize the default animations, this documentation covers the entire set of built-in animations."
         [docs]="docs"
         docType="page"
     ></app-doc>`

--- a/apps/showcase/pages/landing/footersection.component.ts
+++ b/apps/showcase/pages/landing/footersection.component.ts
@@ -18,11 +18,7 @@ import { RouterModule } from '@angular/router';
                                 <a [routerLink]="['installation']" class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300"> Get Started </a>
                             </li>
                             <li class="mb-4">
-                                <a
-                                    href="{{ GITHUB_REPO_URL }}-examples"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300"
+                                <a href="{{ GITHUB_REPO_URL }}-examples" target="_blank" rel="noopener noreferrer" class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300"
                                     >Examples</a
                                 >
                             </li>
@@ -32,13 +28,7 @@ import { RouterModule } from '@angular/router';
                         <ul class="list-none p-0 m-0">
                             <li class="text-sm font-bold mb-7">Support</li>
                             <li class="mb-4">
-                                <a
-                                    [href]="GITHUB_DISCUSSIONS_URL"
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300"
-                                    >Forum</a
-                                >
+                                <a [href]="GITHUB_DISCUSSIONS_URL" target="_blank" rel="noopener noreferrer" class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300">Forum</a>
                             </li>
                             <li class="mb-4">
                                 <a [href]="DISCORD_URL" target="_blank" rel="noopener noreferrer" class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300">Discord</a>
@@ -72,9 +62,7 @@ import { RouterModule } from '@angular/router';
                                 <a href="https://primeui.store" target="_blank" rel="noopener noreferrer" class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300">Store</a>
                             </li>
                             <li class="mb-4">
-                                <a [href]="GITHUB_REPO_URL" target="_blank" rel="noopener noreferrer" class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300"
-                                    >Source Code</a
-                                >
+                                <a [href]="GITHUB_REPO_URL" target="_blank" rel="noopener noreferrer" class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300">Source Code</a>
                             </li>
                             <li class="mb-4">
                                 <a href="https://twitter.com/prime_ng" target="_blank" rel="noopener noreferrer" class="text-sm text-surface-500 dark:text-surface-400 font-medium hover:text-primary rounded-sm transition-all duration-300">Twitter</a>

--- a/apps/showcase/pages/lts/index.ts
+++ b/apps/showcase/pages/lts/index.ts
@@ -18,17 +18,17 @@ import { TagModule } from 'primeng/tag';
                     <i class="pi pi-github absolute text-surface-200 dark:text-surface-600" style="bottom: -50px; right: -50px; font-size: 200px; transform: rotateX(45deg) rotateY(0deg) rotateZ(-45deg)"></i>
                     <div class="text-xl text-surface-900 dark:text-surface-0 font-semibold mb-4 relative">Community Versions</div>
                     <p class="m-0 leading-normal relative text-surface-800 dark:text-surface-50">
-                        Angular is a fast paced technology with a new major version every 6 months. {{ PROJECT_NAME }} release cycle is aligned with Angular and every 6 months a new major {{ PROJECT_NAME }} version is released as open source that is compatible with the
-                        latest Angular core. The maintenance releases of the latest {{ PROJECT_NAME }} version are provided as free and open source for the following 6 months until the new major Angular version is ready.
+                        Angular is a fast paced technology with a new major version every 6 months. {{ PROJECT_NAME }} release cycle is aligned with Angular and every 6 months a new major {{ PROJECT_NAME }} version is released as open source that is
+                        compatible with the latest Angular core. The maintenance releases of the latest {{ PROJECT_NAME }} version are provided as free and open source for the following 6 months until the new major Angular version is ready.
                     </p>
                 </div>
                 <div class="card m-0 xl:w-9/12 text-white bg-cover" style="background-image: url('https://primefaces.org/cdn/primeng/images/lts/card-lts.jpg')">
                     <div class="text-xl font-semibold mb-4">LTS Versions</div>
                     <p class="m-0 leading-normal">
-                        Majority of the existing applications prefer to remain at a previous version due to stability requirements instead of upgrading to the latest version immediately. {{ PROJECT_NAME }} LTS is a support service to provide a license for the
-                        finest compatible version suited to you. LTS covers the prior two versions from the latest release, this means up to 18 months of almost bi-weekly releases to bring the latest defect fixes and security updates to your project.
-                        As an example, when {{ PROJECT_NAME }} moves to Angular 20, v19 and v18 will move to LTS support whereas STS (short term support) versions of {{ PROJECT_NAME }} 20 will be open source under MIT license for at least 6 months until Angular/{{ PROJECT_NAME }} 21
-                        is released.
+                        Majority of the existing applications prefer to remain at a previous version due to stability requirements instead of upgrading to the latest version immediately. {{ PROJECT_NAME }} LTS is a support service to provide a
+                        license for the finest compatible version suited to you. LTS covers the prior two versions from the latest release, this means up to 18 months of almost bi-weekly releases to bring the latest defect fixes and security updates
+                        to your project. As an example, when {{ PROJECT_NAME }} moves to Angular 20, v19 and v18 will move to LTS support whereas STS (short term support) versions of {{ PROJECT_NAME }} 20 will be open source under MIT license for at
+                        least 6 months until Angular/{{ PROJECT_NAME }} 21 is released.
                     </p>
                 </div>
             </div>
@@ -165,7 +165,8 @@ import { TagModule } from 'primeng/tag';
                             <span class="text-surface-900 dark:text-surface-0 font-semibold text-lg">Enhancements</span>
                         </div>
                         <p class="m-0 leading-normal mb-4 text-secondary text-surface-800 dark:text-surface-50">
-                            We are dedicated to continuously improving {{ PROJECT_NAME }} to meet the evolving needs of our users. As part of our long-term support, we will provide regular updates and enhancements to add new features and functionality.
+                            We are dedicated to continuously improving {{ PROJECT_NAME }} to meet the evolving needs of our users. As part of our long-term support, we will provide regular updates and enhancements to add new features and
+                            functionality.
                         </p>
                     </div>
                 </div>
@@ -315,8 +316,8 @@ import { TagModule } from 'primeng/tag';
 
                         <div class="text-surface-900 dark:text-surface-0 leading-normal mb-2 font-medium">What is the difference between LTS and PRO?</div>
                         <p class="mt-0 p-0 leading-normal text-surface-800 dark:text-surface-50">
-                            {{ PROJECT_NAME }} PRO is a premium support service delivered via an exclusive JIRA instance where support engineers of PrimeTek provide assistance within 1 business day to the raised tickets. LTS on the other hand provides a license
-                            to utilize the long term support versions.
+                            {{ PROJECT_NAME }} PRO is a premium support service delivered via an exclusive JIRA instance where support engineers of PrimeTek provide assistance within 1 business day to the raised tickets. LTS on the other hand
+                            provides a license to utilize the long term support versions.
                         </p>
                     </div>
                 </div>

--- a/apps/showcase/pages/roadmap/index.ts
+++ b/apps/showcase/pages/roadmap/index.ts
@@ -11,9 +11,9 @@ import { Meta, Title } from '@angular/platform-browser';
             <div class="doc-intro">
                 <h1>Roadmap</h1>
                 <p>
-                    At <a href="https://www.primetek.com.tr/" target="_blank" rel="noopener noreferrer" class="text-primary font-medium hover:underline">PrimeTek</a>, we are passionate about improving {{ PROJECT_NAME }} and would like to share our ideas for
-                    2026 (Year 10) with the community. These are planned to be implemented in parallel to the regular maintenance work of the library involving review of issue tickets, PRs, LTS updates and {{ PROJECT_NAME }} PRO support. Based on semantic
-                    versioning guidelines, {{ PROJECT_NAME }} updates will be backward compatible with a clear migration path when necessary.
+                    At <a href="https://www.primetek.com.tr/" target="_blank" rel="noopener noreferrer" class="text-primary font-medium hover:underline">PrimeTek</a>, we are passionate about improving {{ PROJECT_NAME }} and would like to share our
+                    ideas for 2026 (Year 10) with the community. These are planned to be implemented in parallel to the regular maintenance work of the library involving review of issue tickets, PRs, LTS updates and {{ PROJECT_NAME }} PRO support.
+                    Based on semantic versioning guidelines, {{ PROJECT_NAME }} updates will be backward compatible with a clear migration path when necessary.
                 </p>
             </div>
 

--- a/apps/showcase/pages/support/index.ts
+++ b/apps/showcase/pages/support/index.ts
@@ -14,16 +14,15 @@ import { Component } from '@angular/core';
                     <p class="m-0 leading-normal relative">
                         <a [href]="GITHUB_DISCUSSIONS_URL" class="doc-link" target="_blank" rel="noopener noreferrer">Forum</a>
                         and
-                        <a [href]="DISCORD_URL" class="doc-link" target="_blank" rel="noopener noreferrer">Discord</a> are where the community users gather to seek support, post topics and discuss the technology. GitHub issue is the
-                        channel for the community users to create tickets however PrimeTek does not guarantee a response time although they are monitored and maintained by our staff. If you need to secure a response, you may consider PRO support
-                        instead.
+                        <a [href]="DISCORD_URL" class="doc-link" target="_blank" rel="noopener noreferrer">Discord</a> are where the community users gather to seek support, post topics and discuss the technology. GitHub issue is the channel for the
+                        community users to create tickets however PrimeTek does not guarantee a response time although they are monitored and maintained by our staff. If you need to secure a response, you may consider PRO support instead.
                     </p>
                 </div>
                 <div class="card m-0! flex-1 bg-primary! text-primary-contrast! font-medium">
                     <div class="text-xl font-semibold mb-3">Professional Support</div>
                     <p class="m-0 leading-normal">
-                        With PRO support, it's easy to support, tune, and add features to {{ PROJECT_NAME }} as an in-house library. With the exclusive services of a PRO account, you no longer need to post questions in the community forum and the community
-                        issue tracker at GitHub. Service is delivered via a private issue tracker based on a one-business-day response time.
+                        With PRO support, it's easy to support, tune, and add features to {{ PROJECT_NAME }} as an in-house library. With the exclusive services of a PRO account, you no longer need to post questions in the community forum and the
+                        community issue tracker at GitHub. Service is delivered via a private issue tracker based on a one-business-day response time.
                     </p>
                 </div>
             </div>
@@ -116,7 +115,8 @@ import { Component } from '@angular/core';
                         <li>
                             <div class="font-semibold mb-1">6. Delivery</div>
                             <span class="leading-normal"
-                                >If the issue requires an update in the library, it gets published to npm by as part of the public {{ PROJECT_NAME }} package. A patch update on an older version can also be requested if you are not using the latest version.
+                                >If the issue requires an update in the library, it gets published to npm by as part of the public {{ PROJECT_NAME }} package. A patch update on an older version can also be requested if you are not using the latest
+                                version.
                             </span>
                         </li>
                     </ul>

--- a/apps/showcase/pages/uikit/index.ts
+++ b/apps/showcase/pages/uikit/index.ts
@@ -369,8 +369,7 @@ import { TooltipModule } from 'primeng/tooltip';
                     <div class="leading-normal mb-2 font-bold">How can I get support?</div>
                     <p class="mt-0 mb-12 p-0 leading-normal">
                         PrimeTek offers assistance with account management and licensing issues, with the expectation that users have the necessary technical knowledge to use our products, as we do not offer technical support or consulting. Users can
-                        seek assistance in our community via our public <a [href]="DISCORD_URL" class="doc-link">Discord</a> and
-                        <a href="{{ GITHUB_DISCUSSIONS_URL }}/categories/figma-ui-kit" class="doc-link">Forum</a>.
+                        seek assistance in our community via our public <a [href]="DISCORD_URL" class="doc-link">Discord</a> and <a href="{{ GITHUB_DISCUSSIONS_URL }}/categories/figma-ui-kit" class="doc-link">Forum</a>.
                     </p>
                 </div>
                 <div class="col-span-12 lg:col-span-4 px-2 lg:px-8">

--- a/apps/showcase/utils/constants.ts
+++ b/apps/showcase/utils/constants.ts
@@ -1,5 +1,5 @@
-export const PROJECT_NAME = "Open Prime";
-export const DISCORD_URL = "https://discord.gg/angular";
-export const GITHUB_REPO_URL = "https://github.com/openng-foundation/open-prime";
+export const PROJECT_NAME = 'Open Prime';
+export const DISCORD_URL = 'https://discord.gg/angular';
+export const GITHUB_REPO_URL = 'https://github.com/openng-foundation/open-prime';
 export const GITHUB_DISCUSSIONS_URL = `${GITHUB_REPO_URL}/discussions`;
-export const LINKEDIN_URL = "https://www.linkedin.com/company/openng-foundation";
+export const LINKEDIN_URL = 'https://www.linkedin.com/company/openng-foundation';

--- a/packages/primeng/schematics/utils/ast-utils.ts
+++ b/packages/primeng/schematics/utils/ast-utils.ts
@@ -7,17 +7,17 @@ export function addImportToModule(tree: Tree, filePath: string, importStatement:
         throw new SchematicsException(`File ${filePath} does not exist.`);
     }
     const sourceText = fileContent.toString('utf-8');
-    
+
     // Simple check to avoid duplicates
     if (sourceText.includes(importStatement)) {
         return;
     }
 
     const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
-    
+
     // Find the last import declaration
     let lastImportEnd = 0;
-    ts.forEachChild(sourceFile, node => {
+    ts.forEachChild(sourceFile, (node) => {
         if (ts.isImportDeclaration(node)) {
             lastImportEnd = node.getEnd();
         }


### PR DESCRIPTION
## Problem

`pnpm run format:check` fails on a pristine `master` checkout — 38 files don't match the repo's prettier configuration. Since the **Code Format** job runs on every PR, CI is currently red for all contributions regardless of their content.

## Change

`pnpm run format` output only (prettier with the repo's own config): 38 files, +111/−114 lines, no functional changes.

After this lands, the Code Format job can go green again for everyone.