### PR TITLE
fix(menubar): trigger item command with enter when a custom item template is used

### DIFF
--- a/packages/primeng/src/menubar/menubar.spec.ts
+++ b/packages/primeng/src/menubar/menubar.spec.ts
@@ -246,6 +246,30 @@ class TestCommandMenubarComponent {
 
 @Component({
     standalone: false,
+    selector: 'test-item-template-command-menubar',
+    template: `
+        <p-menubar [model]="model">
+            <ng-template #item let-item>
+                <span class="custom-template-item">{{ item.label }}</span>
+            </ng-template>
+        </p-menubar>
+    `
+})
+class TestItemTemplateCommandMenubarComponent {
+    commandExecuted: any;
+
+    model: MenuItem[] = [
+        {
+            label: 'Custom Command Item',
+            command: (event) => {
+                this.commandExecuted = event;
+            }
+        }
+    ];
+}
+
+@Component({
+    standalone: false,
     selector: 'test-autohide-menubar',
     template: ` <p-menubar [model]="model" [autoHide]="autoHide" [autoHideDelay]="autoHideDelay"> </p-menubar> `
 })
@@ -283,6 +307,7 @@ describe('Menubar', () => {
                 TestMinimalMenubarComponent,
                 TestDynamicMenubarComponent,
                 TestCommandMenubarComponent,
+                TestItemTemplateCommandMenubarComponent,
                 TestAutoHideMenubarComponent
             ],
             imports: [
@@ -676,6 +701,20 @@ describe('Menubar', () => {
             menubarInstance.onKeyDown(keyEvent);
 
             expect(keyEvent.preventDefault).toHaveBeenCalled();
+        });
+
+        it('should trigger item command with enter key when using custom item template', () => {
+            const templateFixture = TestBed.createComponent(TestItemTemplateCommandMenubarComponent);
+            templateFixture.detectChanges();
+
+            const templateMenubar = templateFixture.debugElement.query(By.directive(Menubar)).componentInstance as Menubar;
+            templateMenubar.focused = true;
+            templateMenubar.focusedItemInfo.set({ index: 0, level: 0, parentKey: '', item: null });
+
+            const keyEvent = new KeyboardEvent('keydown', { code: 'Enter' });
+            templateMenubar.onKeyDown(keyEvent);
+
+            expect(templateFixture.componentInstance.commandExecuted).toBeTruthy();
         });
 
         it('should handle space key', () => {

--- a/packages/primeng/src/menubar/menubar.ts
+++ b/packages/primeng/src/menubar/menubar.ts
@@ -783,7 +783,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
     onEnterKey(event: KeyboardEvent) {
         if (this.focusedItemInfo().index !== -1) {
             const element = findSingle(this.rootmenu()?.el.nativeElement, `li[id="${`${this.focusedItemId}`}"]`) as HTMLElement | null;
-            const anchorElement = element && ((findSingle(element, '[data-pc-section="itemlink"]') || findSingle(element, 'a,button')) as HTMLElement | null);
+            const anchorElement = element && ((findSingle(element, '[data-pc-section="itemlink"]') || findSingle(element, 'a,button') || findSingle(element, '[data-pc-section="itemcontent"]')) as HTMLElement | null);
 
             anchorElement ? anchorElement.click() : element && element.click();
         }


### PR DESCRIPTION
## Problem

When a menubar uses a custom `#item` template, pressing <kbd>Enter</kbd> on a focused item does nothing: `onEnterKey` looks for `[data-pc-section=itemlink]` or an `a`/`button` element to click, and a custom template typically renders neither, so the item's `command` never runs.

## Fix

Fall back to the `[data-pc-section=itemcontent]` element when no link/button is found (one-line change), so the click lands on the item content and the command executes.

Includes a regression test with a custom item template host.