### PR TITLE
fix(select): accept the lowercase #selecteditem template name

### DIFF
--- a/packages/primeng/src/select/select.spec.ts
+++ b/packages/primeng/src/select/select.spec.ts
@@ -4628,3 +4628,51 @@ describe('Select Multiple Selection', () => {
         });
     });
 });
+
+@Component({
+    standalone: true,
+    imports: [Select, CommonModule, FormsModule, ReactiveFormsModule],
+    template: `
+        <p-select [options]="options" [(ngModel)]="selectedValue" optionLabel="name" optionValue="code">
+            <ng-template #selecteditem let-option>
+                <div class="alias-selected">Chosen: {{ option?.name }}</div>
+            </ng-template>
+        </p-select>
+    `
+})
+class TestSelectSelectedItemAliasComponent {
+    options = [
+        { name: 'Option 1', code: 'o1' },
+        { name: 'Option 2', code: 'o2' }
+    ];
+    selectedValue: any = 'o2';
+}
+
+describe('Select - selecteditem Template Alias', () => {
+    let fixture: ComponentFixture<TestSelectSelectedItemAliasComponent>;
+    let selectInstance: Select;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [CommonModule, FormsModule, Select],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestSelectSelectedItemAliasComponent);
+        selectInstance = fixture.debugElement.query(By.css('p-select')).componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should resolve the lowercase #selecteditem template name', () => {
+        expect(selectInstance.selectedItemTemplate()).toBeTruthy();
+    });
+
+    it('should render the aliased selected item template', async () => {
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const selected = fixture.debugElement.query(By.css('.alias-selected'));
+        expect(selected).toBeTruthy();
+        expect(selected.nativeElement.textContent).toContain('Option 2');
+    });
+});

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -720,11 +720,15 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
      */
     loaderTemplate = contentChild<TemplateRef<SelectLoaderTemplateContext>>('loader', { descendants: false });
 
+    _selectedItemTemplate = contentChild<TemplateRef<SelectSelectedItemTemplateContext>>('selectedItem', { descendants: false });
+
+    _selectedItemTemplateAlias = contentChild<TemplateRef<SelectSelectedItemTemplateContext>>('selecteditem', { descendants: false });
+
     /**
-     * Custom selected item template.
+     * Custom selected item template. Accepts both the `selectedItem` and `selecteditem` template names for consistency with MultiSelect and AutoComplete.
      * @group Templates
      */
-    selectedItemTemplate = contentChild<TemplateRef<SelectSelectedItemTemplateContext>>('selectedItem', { descendants: false });
+    selectedItemTemplate = computed(() => this._selectedItemTemplate() ?? this._selectedItemTemplateAlias());
 
     /**
      * Custom header template.


### PR DESCRIPTION
## Problem

MultiSelect and AutoComplete resolve their selected item template with a lowercase template name, but Select only accepts `#selectedItem` — moving a template between the three components silently stops rendering it.

## Fix

Resolve both `#selectedItem` and `#selecteditem` through a `contentChild` alias and a `computed()` that prefers the camelCase name. No behavior change for existing templates.

Includes regression tests for the lowercase alias (resolution + rendering).