### PR TITLE
fix(inputnumber): maxlength spinning, button disabled styling, and a leadingZero option

### DIFF
--- a/packages/primeng/src/inputnumber/inputnumber.spec.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.spec.ts
@@ -552,6 +552,149 @@ describe('InputNumber', () => {
         });
     });
 
+
+    describe('Spin with maxlength', () => {
+        it('should spin when the plain value fits maxlength even if the formatted value is longer', () => {
+            fixture.componentRef.setInput('locale', 'en-US');
+            fixture.componentRef.setInput('maxlength', 3);
+            fixture.componentRef.setInput('minFractionDigits', 2);
+            fixture.detectChanges();
+
+            component.spin(new Event('mousedown'), 1);
+
+            expect(component.value).toBe(1);
+            expect(component.input().nativeElement.value).toBe('1.00');
+        });
+
+        it('should allow decrementing a value that already exceeds maxlength', () => {
+            fixture.componentRef.setInput('locale', 'en-US');
+            fixture.componentRef.setInput('maxlength', 3);
+            fixture.detectChanges();
+
+            component.input().nativeElement.value = '5,000';
+            component.spin(new Event('mousedown'), -1);
+
+            expect(component.value).toBe(4999);
+        });
+
+        it('should not spin beyond maxlength', () => {
+            fixture.componentRef.setInput('locale', 'en-US');
+            fixture.componentRef.setInput('maxlength', 3);
+            fixture.detectChanges();
+
+            component.input().nativeElement.value = '999';
+            component.spin(new Event('mousedown'), 1);
+
+            expect(component.value).toBeUndefined();
+            expect(component.input().nativeElement.value).toBe('999');
+        });
+    });
+
+    describe('Button Disabled Style', () => {
+        it('should style increment button as disabled when value reaches max', () => {
+            fixture.componentRef.setInput('showButtons', true);
+            fixture.componentRef.setInput('min', 0);
+            fixture.componentRef.setInput('max', 10);
+            component.value = 10;
+            fixture.detectChanges();
+
+            const incrementBtn = fixture.debugElement.query(By.css('.p-inputnumber-increment-button'));
+            const decrementBtn = fixture.debugElement.query(By.css('.p-inputnumber-decrement-button'));
+
+            expect(incrementBtn.nativeElement.classList.contains('p-disabled')).toBe(true);
+            expect(decrementBtn.nativeElement.classList.contains('p-disabled')).toBe(false);
+        });
+
+        it('should style decrement button as disabled when value reaches min', () => {
+            fixture.componentRef.setInput('showButtons', true);
+            fixture.componentRef.setInput('min', 0);
+            fixture.componentRef.setInput('max', 10);
+            component.value = 0;
+            fixture.detectChanges();
+
+            const incrementBtn = fixture.debugElement.query(By.css('.p-inputnumber-increment-button'));
+            const decrementBtn = fixture.debugElement.query(By.css('.p-inputnumber-decrement-button'));
+
+            expect(incrementBtn.nativeElement.classList.contains('p-disabled')).toBe(false);
+            expect(decrementBtn.nativeElement.classList.contains('p-disabled')).toBe(true);
+        });
+
+        it('should not style buttons as disabled when value is between min and max', () => {
+            fixture.componentRef.setInput('showButtons', true);
+            fixture.componentRef.setInput('min', 0);
+            fixture.componentRef.setInput('max', 10);
+            component.value = 5;
+            fixture.detectChanges();
+
+            const incrementBtn = fixture.debugElement.query(By.css('.p-inputnumber-increment-button'));
+            const decrementBtn = fixture.debugElement.query(By.css('.p-inputnumber-decrement-button'));
+
+            expect(incrementBtn.nativeElement.classList.contains('p-disabled')).toBe(false);
+            expect(decrementBtn.nativeElement.classList.contains('p-disabled')).toBe(false);
+        });
+
+        it('should style both buttons as disabled when the component is disabled', () => {
+            fixture.componentRef.setInput('showButtons', true);
+            fixture.componentRef.setInput('disabled', true);
+            fixture.detectChanges();
+
+            const incrementBtn = fixture.debugElement.query(By.css('.p-inputnumber-increment-button'));
+            const decrementBtn = fixture.debugElement.query(By.css('.p-inputnumber-decrement-button'));
+
+            expect(incrementBtn.nativeElement.classList.contains('p-disabled')).toBe(true);
+            expect(decrementBtn.nativeElement.classList.contains('p-disabled')).toBe(true);
+        });
+    });
+
+    describe('Leading Zero', () => {
+        const pressBackspaceAt = (inputEl: HTMLInputElement, position: number) => {
+            inputEl.setSelectionRange(position, position);
+            inputEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'Backspace', cancelable: true }));
+        };
+
+        it('should keep leading zeros while editing when leadingZero is enabled', () => {
+            fixture.componentRef.setInput('locale', 'en-US');
+            fixture.componentRef.setInput('leadingZero', true);
+            fixture.componentRef.setInput('minFractionDigits', 2);
+            fixture.detectChanges();
+
+            const inputEl = component.input().nativeElement;
+            inputEl.value = '305.00';
+            pressBackspaceAt(inputEl, 1);
+
+            expect(inputEl.value).toBe('05.00');
+            expect(component.value).toBe(5);
+        });
+
+        it('should remove leading zeros while editing by default', () => {
+            fixture.componentRef.setInput('locale', 'en-US');
+            fixture.componentRef.setInput('minFractionDigits', 2);
+            fixture.detectChanges();
+
+            const inputEl = component.input().nativeElement;
+            inputEl.value = '305.00';
+            pressBackspaceAt(inputEl, 1);
+
+            expect(inputEl.value).toBe('5.00');
+            expect(component.value).toBe(5);
+        });
+
+        it('should normalize leading zeros when the input loses focus', () => {
+            fixture.componentRef.setInput('locale', 'en-US');
+            fixture.componentRef.setInput('leadingZero', true);
+            fixture.componentRef.setInput('minFractionDigits', 2);
+            fixture.detectChanges();
+
+            const inputEl = component.input().nativeElement;
+            inputEl.value = '305.00';
+            pressBackspaceAt(inputEl, 1);
+            inputEl.dispatchEvent(new FocusEvent('blur'));
+
+            expect(inputEl.value).toBe('5.00');
+            expect(component.value).toBe(5);
+        });
+    });
+
     describe('Clear Functionality', () => {
         let testComponent: TestBasicInputNumberComponent;
         let testFixture: ComponentFixture<TestBasicInputNumberComponent>;

--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -243,6 +243,11 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
      */
     format = input(true, { transform: booleanAttribute });
     /**
+     * When enabled, leading zeros are preserved while editing instead of being removed when the value is reformatted. The value is normalized when the input loses focus.
+     * @group Props
+     */
+    leadingZero = input(false, { transform: booleanAttribute });
+    /**
      * Layout of the buttons, valid values are "stacked" (default), "horizontal" and "vertical".
      * @group Props
      */
@@ -737,8 +742,12 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
         let currentValue = this.parseValue(this.input()?.nativeElement.value) || 0;
         let newValue = this.validateValue((currentValue as number) + step);
         const max = this.maxlength();
-        if (max && max < this.formatValue(newValue).length) {
-            return;
+        if (max && newValue != null) {
+            const newValueStr = this.parseValue(this.formatValue(newValue))?.toString() ?? '';
+            const currentValueStr = currentValue.toString();
+            if (newValueStr.length > max && newValueStr.length > currentValueStr.length) {
+                return;
+            }
         }
 
         this.updateInput(newValue, null, 'spin', null);
@@ -1296,11 +1305,28 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
 
     handleOnInput(event: Event, currentValue: string, newValue: any) {
         if (this.isValueChanged(currentValue, newValue)) {
-            this.input().nativeElement.value = this.formatValue(newValue);
+            if (!(this.leadingZero() && this.parseValue(this.input().nativeElement.value) === newValue)) {
+                this.input().nativeElement.value = this.formatValue(newValue);
+            }
             this.input()?.nativeElement.setAttribute('aria-valuenow', newValue);
             this.updateModel(event, newValue);
             this.onInput.emit({ originalEvent: event, value: newValue, formattedValue: currentValue });
         }
+    }
+
+    hasLeadingZero(valueStr: string): boolean {
+        const zeroChar = new Intl.NumberFormat(this.locale(), { useGrouping: false }).format(0);
+        const integerPart = valueStr
+            .replace(this._suffix as RegExp, '')
+            .replace(this._prefix as RegExp, '')
+            .trim()
+            .replace(/\s/g, '')
+            .replace(this._currency as RegExp, '')
+            .replace(this._minusSign, '')
+            .replace(this._group, '')
+            .split(this._decimal)[0];
+
+        return integerPart.length > 1 && integerPart.startsWith(zeroChar);
     }
 
     isValueChanged(currentValue: string, newValue: string) {
@@ -1341,7 +1367,9 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
         let newValue = this.formatValue(value);
         let currentLength = inputValue.length;
 
-        if (newValue !== valueStr) {
+        if (this.leadingZero() && valueStr != null && this.hasLeadingZero(valueStr) && this.parseValue(valueStr) === value) {
+            newValue = valueStr;
+        } else if (newValue !== valueStr) {
             newValue = this.concatValues(newValue, valueStr as string);
         }
 

--- a/packages/primeng/src/inputnumber/style/inputnumberstyle.ts
+++ b/packages/primeng/src/inputnumber/style/inputnumberstyle.ts
@@ -43,13 +43,13 @@ const classes = {
     incrementButton: ({ instance }) => [
         'p-inputnumber-button p-inputnumber-increment-button',
         {
-            'p-disabled': instance.showButtons() && instance.max() != null && instance.maxlength()
+            'p-disabled': instance.showButtons() && (instance.$disabled() || (instance.max() != null && instance.value != null && instance.value >= instance.max()))
         }
     ],
     decrementButton: ({ instance }) => [
         'p-inputnumber-button p-inputnumber-decrement-button',
         {
-            'p-disabled': instance.showButtons() && instance.min() != null && instance.minlength()
+            'p-disabled': instance.showButtons() && (instance.$disabled() || (instance.min() != null && instance.value != null && instance.value <= instance.min()))
         }
     ],
     clearIcon: 'p-inputnumber-clear-icon'


### PR DESCRIPTION
## Fixes

1. **Spinning vs `maxlength`**: `spin()` compared `maxlength` against the *formatted* value (group separators, fraction digits included), so with `maxlength=3` a value of `1` formatted as `1.00` could not spin at all, and a value already longer than `maxlength` could never be decremented back into range. Compare the parsed value's length instead, and only block the spin when the value would actually grow.
2. **Button disabled styling**: the increment/decrement buttons applied `p-disabled` based on `instance.maxlength()`/`minlength()` — string-length attributes, unrelated to the numeric range. Style them based on the value actually reaching `max`/`min`, and style both as disabled when the whole component is disabled.
3. **New `leadingZero` option**: preserves leading zeros while editing (e.g. ID/account numbers) instead of reformatting them away on every keystroke; the value is normalized when the input loses focus. Default behavior is unchanged.

Includes regression tests for all three (10 new tests in Spin with maxlength / Button Disabled Style / Leading Zero blocks).