### PR TITLE
feat(autocomplete): render the selected item template in single mode and fix size bindings

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.spec.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.spec.ts
@@ -1070,6 +1070,35 @@ describe('AutoComplete', () => {
                 const autocompleteInstance = templateFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
                 expect(autocompleteInstance.selectedItemTemplate()).toBeTruthy();
             });
+
+            it('should render #selecteditem with item context in single mode', async () => {
+                const autocompleteInstance = templateFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+                autocompleteInstance.writeValue(mockCountries[0]);
+                templateFixture.changeDetectorRef.markForCheck();
+                await templateFixture.whenStable();
+
+                const selectedItemElement = templateFixture.debugElement.query(By.css('.p-autocomplete-selected-item'));
+                expect(selectedItemElement).toBeTruthy();
+                expect(selectedItemElement.query(By.css('.selected-name')).nativeElement.textContent.trim()).toBe('Afghanistan');
+            });
+
+            it('should hide #selecteditem in single mode while the input is focused', async () => {
+                const autocompleteInstance = templateFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+                autocompleteInstance.writeValue(mockCountries[0]);
+                templateFixture.changeDetectorRef.markForCheck();
+                await templateFixture.whenStable();
+
+                const inputElement = templateFixture.debugElement.query(By.css('input'));
+                inputElement.nativeElement.dispatchEvent(new Event('focus'));
+                await templateFixture.whenStable();
+
+                expect(templateFixture.debugElement.query(By.css('.p-autocomplete-selected-item'))).toBeFalsy();
+
+                inputElement.nativeElement.dispatchEvent(new Event('blur'));
+                await templateFixture.whenStable();
+
+                expect(templateFixture.debugElement.query(By.css('.p-autocomplete-selected-item'))).toBeTruthy();
+            });
         });
 
         describe('Group Template (_groupTemplate)', () => {
@@ -2289,6 +2318,56 @@ describe('AutoComplete', () => {
         });
     });
 
+    describe('Size Property', () => {
+        let fixture: ComponentFixture<AutoComplete>;
+        let autocompleteElement: HTMLElement;
+
+        beforeEach(async () => {
+            fixture = TestBed.createComponent(AutoComplete);
+            fixture.componentRef.setInput('suggestions', mockCountries);
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            autocompleteElement = fixture.nativeElement;
+        });
+
+        it('should apply size classes to the root element', async () => {
+            fixture.componentRef.setInput('size', 'small');
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            expect(autocompleteElement.classList.contains('p-autocomplete-sm')).toBe(true);
+            expect(autocompleteElement.classList.contains('p-inputfield-sm')).toBe(true);
+
+            fixture.componentRef.setInput('size', 'large');
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            expect(autocompleteElement.classList.contains('p-autocomplete-lg')).toBe(true);
+            expect(autocompleteElement.classList.contains('p-inputfield-lg')).toBe(true);
+        });
+
+        it('should apply size classes to the root element in multiple mode', async () => {
+            fixture.componentRef.setInput('multiple', true);
+            fixture.componentRef.setInput('size', 'large');
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            expect(autocompleteElement.querySelector('ul[role="listbox"]')).toBeTruthy();
+            expect(autocompleteElement.classList.contains('p-autocomplete-lg')).toBe(true);
+            expect(autocompleteElement.classList.contains('p-inputfield-lg')).toBe(true);
+        });
+
+        it('should not render the size attribute on the multiple input when pSize is set', async () => {
+            fixture.componentRef.setInput('multiple', true);
+            fixture.componentRef.setInput('size', 'large');
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            const inputElement = autocompleteElement.querySelector('input') as HTMLInputElement;
+            expect(inputElement.getAttribute('size')).toBeNull();
+        });
+    });
+
     describe('PassThrough (PT) Tests', () => {
         let fixture: ComponentFixture<AutoComplete>;
         let autocompleteElement: HTMLElement;
@@ -2598,5 +2677,54 @@ describe('AutoComplete', () => {
                 expect(dropdownButton?.getAttribute('data-has-suggestions')).toBe('true');
             });
         });
+    });
+});
+
+@Component({
+    standalone: true,
+    imports: [AutoCompleteModule, FormsModule],
+    template: `
+        <p-autocomplete [(ngModel)]="value" [suggestions]="suggestions()" optionLabel="name" [multiple]="true" (completeMethod)="search()">
+            <ng-template #selectedItem let-item>
+                <span class="alias-selected">{{ item.name }}</span>
+            </ng-template>
+        </p-autocomplete>
+    `
+})
+class TestSelectedItemAliasAutocompleteComponent {
+    value: any[] = [{ name: 'Afghanistan', code: 'AF' }];
+    suggestions = signal<any[]>([]);
+
+    search() {
+        this.suggestions.set([...mockCountries]);
+    }
+}
+
+describe('AutoComplete - selectedItem Template Alias', () => {
+    let fixture: ComponentFixture<TestSelectedItemAliasAutocompleteComponent>;
+    let autocompleteInstance: AutoComplete;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [AutoCompleteModule, FormsModule, TestSelectedItemAliasAutocompleteComponent],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestSelectedItemAliasAutocompleteComponent);
+        autocompleteInstance = fixture.debugElement.query(By.css('p-autocomplete')).componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should resolve the camelCase #selectedItem template name', () => {
+        expect(autocompleteInstance.selectedItemTemplate()).toBeTruthy();
+    });
+
+    it('should render the aliased selected item template', async () => {
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const selected = fixture.debugElement.query(By.css('.alias-selected'));
+        expect(selected).toBeTruthy();
+        expect(selected.nativeElement.textContent).toContain('Afghanistan');
     });
 });

--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -118,6 +118,11 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR = {
                 [fluid]="hasFluid"
                 [pInputTextUnstyled]="unstyled()"
             />
+            @if ($showSelectedItem()) {
+                <span [pBind]="ptm('selectedItem')" [class]="cx('selectedItem')">
+                    <ng-container [ngTemplateOutlet]="selectedItemTemplate()!" [ngTemplateOutletContext]="getSelectedItemContext($selectedOption())"></ng-container>
+                </span>
+            }
         }
         @if ($showClear()) {
             @if (!clearIconTemplate()) {
@@ -187,7 +192,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR = {
                         [attr.name]="name()"
                         [attr.minlength]="minlength()"
                         [attr.maxlength]="maxlength()"
-                        [attr.size]="size()"
+                        [attr.size]="inputSize()"
                         [attr.min]="min()"
                         [attr.max]="max()"
                         [attr.pattern]="pattern()"
@@ -768,11 +773,15 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
      */
     footerTemplate = contentChild<TemplateRef<void>>('footer', { descendants: false });
 
+    _selectedItemTemplate = contentChild<TemplateRef<AutoCompleteSelectedItemTemplateContext>>('selecteditem', { descendants: false });
+
+    _selectedItemTemplateAlias = contentChild<TemplateRef<AutoCompleteSelectedItemTemplateContext>>('selectedItem', { descendants: false });
+
     /**
-     * Custom selected item template.
+     * Custom selected item template. Accepts both the `selecteditem` and `selectedItem` template names for consistency with Select.
      * @group Templates
      */
-    selectedItemTemplate = contentChild<TemplateRef<AutoCompleteSelectedItemTemplateContext>>('selecteditem', { descendants: false });
+    selectedItemTemplate = computed(() => this._selectedItemTemplate() ?? this._selectedItemTemplateAlias());
 
     /**
      * Custom group template.
@@ -857,9 +866,17 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
         return this.group() ? this.flatOptions(this.suggestions()) : this.suggestions() || [];
     });
 
+    $selectedOption = computed(() => {
+        const modelValue = this.modelValue();
+
+        return this.optionValueSelected ? (this.suggestions() || []).find((option: any) => equals(option, modelValue, this.equalityKey())) : modelValue;
+    });
+
+    $showSelectedItem = computed(() => !this.multiple() && this.$filled() && !this.focused() && !!this.selectedItemTemplate());
+
     inputValue = computed(() => {
         const modelValue = this.modelValue();
-        const selectedOption = this.optionValueSelected ? (this.suggestions() || []).find((option: any) => equals(option, modelValue, this.equalityKey())) : modelValue;
+        const selectedOption = this.$selectedOption();
 
         if (isNotEmpty(modelValue)) {
             if (typeof modelValue === 'object' || this.optionValueSelected) {

--- a/packages/primeng/src/autocomplete/style/autocompletestyle.ts
+++ b/packages/primeng/src/autocomplete/style/autocompletestyle.ts
@@ -34,6 +34,60 @@ p-auto-complete.ng-invalid.ng-dirty .p-autocomplete-input::placeholder,
 p-autocomplete.ng-invalid.ng-dirty .p-autocomplete-input::placeholder {
     color: dt('autocomplete.invalid.placeholder.color');
 }
+
+.p-autocomplete-selected-item {
+    position: absolute;
+    inset-block: 1px;
+    inset-inline-start: 1px;
+    inset-inline-end: 1px;
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+    white-space: nowrap;
+    padding-inline: dt('autocomplete.padding.x');
+    border-radius: dt('autocomplete.border.radius');
+    pointer-events: none;
+}
+
+.p-autocomplete:has(.p-autocomplete-selected-item) .p-autocomplete-input {
+    color: transparent;
+}
+
+.p-autocomplete:has(.p-autocomplete-dropdown) .p-autocomplete-selected-item {
+    inset-inline-end: calc(dt('autocomplete.dropdown.width') + 1px);
+}
+
+.p-autocomplete:has(.p-autocomplete-clear-icon) .p-autocomplete-selected-item {
+    padding-inline-end: calc((dt('form.field.padding.x') * 2) + dt('icon.size'));
+}
+
+.p-autocomplete-sm .p-autocomplete-input-multiple {
+    font-size: dt('form.field.sm.font.size');
+    padding-block: calc(dt('form.field.sm.padding.y') / 2);
+    padding-inline: dt('form.field.sm.padding.x');
+}
+
+.p-autocomplete-sm .p-autocomplete-input-chip input {
+    font-size: dt('form.field.sm.font.size');
+}
+
+.p-autocomplete-sm .p-autocomplete-dropdown {
+    width: dt('autocomplete.dropdown.sm.width');
+}
+
+.p-autocomplete-lg .p-autocomplete-input-multiple {
+    font-size: dt('form.field.lg.font.size');
+    padding-block: calc(dt('form.field.lg.padding.y') / 2);
+    padding-inline: dt('form.field.lg.padding.x');
+}
+
+.p-autocomplete-lg .p-autocomplete-input-chip input {
+    font-size: dt('form.field.lg.font.size');
+}
+
+.p-autocomplete-lg .p-autocomplete-dropdown {
+    width: dt('autocomplete.dropdown.lg.width');
+}
 `;
 
 const inlineStyles = {
@@ -50,10 +104,13 @@ const classes = {
             'p-inputwrapper-focus': (instance.focused() && !instance.$disabled()) || instance.autofocus() || instance.overlayVisible(),
             'p-autocomplete-open': instance.overlayVisible(),
             'p-autocomplete-clearable': instance.showClear() && !instance.$disabled(),
-            'p-autocomplete-fluid': instance.hasFluid
+            'p-autocomplete-fluid': instance.hasFluid,
+            'p-autocomplete-sm p-inputfield-sm': instance.size() === 'small',
+            'p-autocomplete-lg p-inputfield-lg': instance.size() === 'large'
         }
     ],
     pcInputText: 'p-autocomplete-input',
+    selectedItem: 'p-autocomplete-selected-item',
     inputMultiple: ({ instance }) => [
         'p-autocomplete-input-multiple',
         {
@@ -115,6 +172,10 @@ export enum AutoCompleteClasses {
      * Class name of the input element
      */
     pcInputText = 'p-autocomplete-input',
+    /**
+     * Class name of the selected item element
+     */
+    selectedItem = 'p-autocomplete-selected-item',
     /**
      * Class name of the input multiple element
      */

--- a/packages/primeng/src/types/autocomplete/autocomplete.types.ts
+++ b/packages/primeng/src/types/autocomplete/autocomplete.types.ts
@@ -28,6 +28,10 @@ export interface AutoCompletePassThroughOptions<I = unknown> {
      */
     pcInputText?: InputTextPassThrough;
     /**
+     * Used to pass attributes to the selected item's DOM element.
+     */
+    selectedItem?: PassThroughOption<HTMLSpanElement, I>;
+    /**
      * Used to pass attributes to the input multiple's DOM element.
      */
     inputMultiple?: PassThroughOption<HTMLUListElement, I>;
@@ -277,7 +281,7 @@ export interface AutoCompleteTemplates<T = any> {
      */
     group(context: AutoCompleteGroupTemplateContext<T>): TemplateRef<AutoCompleteGroupTemplateContext<T>>;
     /**
-     * Custom selected item template, only supported in multiple mode.
+     * Custom selected item template.
      * @param {Object} context - selected item data.
      */
     selecteditem(context: AutoCompleteSelectedItemTemplateContext<T>): TemplateRef<AutoCompleteSelectedItemTemplateContext<T>>;


### PR DESCRIPTION
## Changes

1. **`#selecteditem` in single mode**: the selected item template was only rendered in multiple mode (as chips). Render it in single mode too, as an overlay on the input (hidden while the input is focused, so typing stays visible), with the accompanying styles and a `selectedItem` PT section.
2. **camelCase alias**: accept `#selectedItem` as well as `#selecteditem`, mirroring how Select/MultiSelect name the template, via a `contentChild` alias + `computed()`.
3. **`size` fixes**: the `small`/`large` `size` input did not apply its style classes to the root element (`p-autocomplete-sm/lg`, `p-inputfield-sm/lg` + sm/lg tokens), and in multiple mode it was bound to the native `size` **attribute** of the input (`[attr.size]=\"size()\"` instead of `inputSize()`), producing invalid markup like `size=\"large\"`.

Includes regression tests: single-mode rendering + focus hiding, camelCase alias resolution + rendering, and the three size cases.

Verified: full library build passes on this branch.