### PR TITLE
chore(scripts): fix a ReferenceError in build-helper and remove dead code from build scripts

### DIFF
--- a/apps/showcase/scripts/build-apidoc.mjs
+++ b/apps/showcase/scripts/build-apidoc.mjs
@@ -471,64 +471,6 @@ async function main() {
                             };
 
                             module_types_group.children.forEach((t) => {
-                                const parameters =
-                                    t.signatures && t.signatures[0]?.parameters
-                                        ? t.signatures[0].parameters.map((param) => ({
-                                              name: param.name,
-                                              description: param.comment && param.comment.summary.map((s) => s.text || '').join(' '),
-                                              type: param.type && param.type.name
-                                          }))
-                                        : [];
-
-                                const returnType = t.signatures && t.signatures[0]?.type ? t.signatures[0].type.name : t.type && t.type.declaration && t.type.declaration.signatures && t.type.declaration.signatures[0]?.type.name;
-
-                                const returnDescription =
-                                    t.comment && t.comment.blockTags
-                                        ? t.comment.blockTags
-                                              .filter((tag) => tag.tag === '@returns')
-                                              .map((tag) => tag.content.map((content) => content.text).join(' '))
-                                              .join(' ')
-                                        : '';
-
-                                const typeChildren =
-                                    t.children && t.children.length
-                                        ? t.children.map((child) => {
-                                              const childSignatures = child.type && child.type.declaration && child.type.declaration.signatures;
-                                              const childParameters =
-                                                  childSignatures && childSignatures[0]?.parameters
-                                                      ? childSignatures[0].parameters.map((param) => ({
-                                                            name: param.name,
-                                                            description: param.comment && param.comment.summary.map((s) => s.text || '').join(' '),
-                                                            type: param.type && param.type.name
-                                                        }))
-                                                      : [];
-
-                                              const childReturnType = childSignatures && childSignatures[0]?.type ? childSignatures[0].type.name : undefined;
-
-                                              const childReturnDescription =
-                                                  child.comment && child.comment.blockTags
-                                                      ? child.comment.blockTags
-                                                            .filter((tag) => tag.tag === '@returns')
-                                                            .map((tag) => tag.content.map((content) => content.text).join(' '))
-                                                            .join(' ')
-                                                      : '';
-
-                                              return {
-                                                  name: child.name,
-                                                  description: child.comment && child.comment.summary.map((s) => s.text || '').join(' '),
-                                                  type: childParameters.length || childReturnType ? 'function' : child.type && child.type.name,
-                                                  parameters: childParameters.length ? childParameters : undefined,
-                                                  returns: childReturnType
-                                                      ? {
-                                                            type: childReturnType,
-                                                            description: childReturnDescription
-                                                        }
-                                                      : undefined,
-                                                  deprecated: getDeprecatedText(child)
-                                              };
-                                          })
-                                        : [];
-
                                 types.values.push({
                                     name: t.name,
                                     value: getTypesValue(t),
@@ -684,7 +626,7 @@ async function main() {
 }
 
 function extractParameter(emitter) {
-    let { comment, type } = emitter;
+    let { type } = emitter;
 
     if (type && type.typeArguments) {
         if (type.toString()) {

--- a/apps/showcase/scripts/build-llm-docs.mjs
+++ b/apps/showcase/scripts/build-llm-docs.mjs
@@ -705,16 +705,6 @@ function getTokensFromApi(componentName) {
 }
 
 /**
- * Get all related components from API doc
- */
-function getRelatedComponents(apiDocs, componentName) {
-    const apiDoc = apiDocs[componentName.toLowerCase()];
-    if (!apiDoc || !apiDoc.components) return [];
-
-    return Object.keys(apiDoc.components);
-}
-
-/**
  * Generate API section for markdown (with all sub-components)
  */
 function generateApiSection(apiDocs, componentName, includeRelated = true) {

--- a/apps/showcase/scripts/test-demo-code.mjs
+++ b/apps/showcase/scripts/test-demo-code.mjs
@@ -140,7 +140,6 @@ function testStackBlitzFileGeneration(demos) {
             allPassed &= logTest('theme-switcher added to template', modified.includes('<theme-switcher />'));
 
             // Test: PrimeNG module imports removed
-            const hasNoDirectModuleImport = !modified.includes("from 'primeng/select';") || modified.includes('ImportsModule');
             allPassed &= logTest('PrimeNG direct imports removed', !modified.match(/import\s+\{[^}]*Module[^}]*\}\s+from\s+'primeng\//));
         }
 
@@ -260,7 +259,6 @@ function testStackBlitzProjectStructure(demos) {
     }
 
     const selector = testDemo.selector || 'select-basic-demo';
-    const code = testDemo.code;
 
     log(`\n  Simulating StackBlitz project for: ${selector}`, 'blue');
 

--- a/apps/showcase/scripts/test-stackblitz-e2e.mjs
+++ b/apps/showcase/scripts/test-stackblitz-e2e.mjs
@@ -16,7 +16,6 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -237,7 +236,7 @@ function validatePackageJson(packageJson) {
 }
 
 // Test a single demo
-function testSingleDemo(demo, selector, verbose = true) {
+function testSingleDemo(demo, selector, _verbose = true) {
     const errors = [];
 
     // Generate project

--- a/packages/mcp/scripts/prebuild.mjs
+++ b/packages/mcp/scripts/prebuild.mjs
@@ -3,7 +3,7 @@ import { removeBuild, resolvePath, updatePackageJson } from '../../../scripts/bu
 
 removeBuild(import.meta.url);
 
-const { __dirname, INPUT_DIR } = resolvePath(import.meta.url);
+const { __dirname } = resolvePath(import.meta.url);
 const __root = path.resolve(__dirname, '../');
 const pkg = path.resolve(__root, './package.json');
 

--- a/packages/primeng/scripts/changelog-generator.mjs
+++ b/packages/primeng/scripts/changelog-generator.mjs
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { dirname } from 'path';
-import * as TypeDoc from 'typedoc';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -41,7 +40,7 @@ fs.readFile(tsvFilePath, 'utf8', (err, data) => {
             return;
         }
 
-        let [title, issueUrl, assignees, pullRequestUrl, status, labels, milestone] = columns.map((item) => item.trim());
+        let [title, issueUrl, , , , labels, milestone] = columns.map((item) => item.trim());
 
         if (!milestone) {
             console.warn(`⚠ Milestone (Version) information is missing: "${title}"`);

--- a/packages/themes/scripts/prebuild.mjs
+++ b/packages/themes/scripts/prebuild.mjs
@@ -3,7 +3,7 @@ import { removeBuild, resolvePath, updatePackageJson } from '../../../scripts/bu
 
 removeBuild(import.meta.url);
 
-const { __dirname, INPUT_DIR } = resolvePath(import.meta.url);
+const { __dirname } = resolvePath(import.meta.url);
 const __root = path.resolve(__dirname, '../');
 const pkg = path.resolve(__root, './package.json');
 

--- a/scripts/build-helper.mjs
+++ b/scripts/build-helper.mjs
@@ -63,9 +63,9 @@ export function createPackageJson_For_NG_Packager(localPackageJson, INPUT_PATH, 
         delete pkg?.main;
         delete pkg?.module;
         delete pkg?.types;
-    });
 
-    callback?.(pkg);
+        callback?.(pkg);
+    });
 }
 
 export function clearPackageJson(localPackageJson, callback) {


### PR DESCRIPTION
## Changes

Tooling scripts only:

1. **Real bug in `scripts/build-helper.mjs`**: `createPackageJson_For_NG_Packager` invoked `callback?.(pkg)` *outside* the `clearPackageJson` closure, where `pkg` is undefined — any caller passing a callback got a `ReferenceError`. The callback now runs inside the closure with the actual `pkg`.
2. **Dead code removal** across build scripts, as flagged by linting: unused `INPUT_DIR` destructuring in the themes/mcp prebuild scripts, unused `TypeDoc` import and destructured columns in `changelog-generator.mjs`, an unused parameters mapping in `build-apidoc.mjs`, an unused helper in `build-llm-docs.mjs`, and unused locals in `test-demo-code.mjs` / `test-stackblitz-e2e.mjs`.

No behavior change beyond the bug fix in (1).