### PR TITLE
fix(autocomplete): type selected event values

### DIFF
--- a/packages/optimus-ui/src/autocomplete/autocomplete.spec.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.spec.ts
@@ -827,6 +827,15 @@ describe('AutoComplete', () => {
             }
         });
 
+        it('should type the selected value', () => {
+            const selectEvent: AutoCompleteSelectEvent<(typeof mockCountries)[number]> = {
+                originalEvent: new Event('click'),
+                value: mockCountries[0]
+            };
+
+            expect(selectEvent.value.code).toBe('AF');
+        });
+
         it('should emit onFocus event', async () => {
             const inputElement = testFixture.debugElement.query(By.css('input'));
             inputElement.nativeElement.dispatchEvent(new Event('focus'));

--- a/packages/optimus-ui/src/types/autocomplete/autocomplete.types.ts
+++ b/packages/optimus-ui/src/types/autocomplete/autocomplete.types.ts
@@ -136,10 +136,11 @@ export interface AutoCompleteDropdownClickEvent {
 }
 /**
  * Custom select event.
+ * @template T Type of selected value.
  * @see {@link AutoComplete.onSelect}
  * @group Events
  */
-export interface AutoCompleteSelectEvent {
+export interface AutoCompleteSelectEvent<T = any> {
     /**
      * Browser event.
      */
@@ -147,7 +148,7 @@ export interface AutoCompleteSelectEvent {
     /**
      * Selected value.
      */
-    value: any;
+    value: T;
 }
 /**
  * Custom unselect event.


### PR DESCRIPTION
## What

- make `AutoCompleteSelectEvent` generic over its selected value
- preserve the existing unparameterized behavior with a default `any` type
- add a focused typed regression to the AutoComplete spec

## Verification

- focused AutoComplete tests: 126 passed
- `pnpm run build:optimus-ui`
- `pnpm run build:lib`
- Prettier check for changed files
- `git diff --check`

Closes #926