### PR TITLE
fix(breadcrumb): hide decorative separators from assistive tech

### DIFF
--- a/packages/optimus-ui/src/breadcrumb/breadcrumb.spec.ts
+++ b/packages/optimus-ui/src/breadcrumb/breadcrumb.spec.ts
@@ -524,6 +524,9 @@ describe('Breadcrumb', () => {
             const separators = fixture.debugElement.queryAll(By.css('[data-pc-section="separator"]'));
             // Should have separators between home-first and first-second
             expect(separators.length).toBeGreaterThan(0);
+            separators.forEach((separator) => {
+                expect(separator.nativeElement.getAttribute('aria-hidden')).toBe('true');
+            });
         });
 
         it('should handle HTML labels with escape=false', async () => {

--- a/packages/optimus-ui/src/breadcrumb/breadcrumb.ts
+++ b/packages/optimus-ui/src/breadcrumb/breadcrumb.ts
@@ -80,7 +80,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                         </a>
                     }
                 </li>
-                <li *ngIf="model && home" [class]="cx('separator')" [pBind]="ptm('separator')">
+                <li *ngIf="model && home" [class]="cx('separator')" [pBind]="ptm('separator')" aria-hidden="true">
                     <svg data-p-icon="chevron-right" *ngIf="!separatorTemplate && !_separatorTemplate" [pBind]="ptm('separatorIcon')" />
                     <ng-template *ngTemplateOutlet="separatorTemplate || _separatorTemplate"></ng-template>
                 </li>
@@ -157,7 +157,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                             </a>
                         }
                     </li>
-                    <li *ngIf="!end && menuitem.visible !== false" [class]="cx('separator')" [pBind]="ptm('separator')">
+                    <li *ngIf="!end && menuitem.visible !== false" [class]="cx('separator')" [pBind]="ptm('separator')" aria-hidden="true">
                         <svg data-p-icon="chevron-right" *ngIf="!separatorTemplate && !_separatorTemplate" [pBind]="ptm('separatorIcon')" />
                         <ng-template *ngTemplateOutlet="separatorTemplate || _separatorTemplate"></ng-template>
                     </li>


### PR DESCRIPTION
## What

Adds `aria-hidden="true"` to the breadcrumb separator list items so decorative chevron separators are not exposed to assistive technology.

## Why

Breadcrumb separators are visual-only delimiters. Without hiding them, screen readers can announce separator glyphs between breadcrumb items, adding noise to the trail. This aligns decorative non-text content with WCAG 2.x SC 1.1.1.

## Notes

This ports a small accessibility fix I previously opened against PrimeNG before the repository was archived: primefaces/primeng#19568.

No behavior, CSS, or public API changes are included. Existing passthrough hooks remain in place for the separator and separator icon.

I am also happy to help with accessibility triage/review as Optimus UI moves toward its first release. I have been working through accessibility fixes in component libraries, including recent USWDS contributions and open accessibility PRs/issues in related UI ecosystems, and can help keep follow-up fixes small and reviewable here.

## Tests

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec prettier --check packages/optimus-ui/src/breadcrumb/breadcrumb.ts packages/optimus-ui/src/breadcrumb/breadcrumb.spec.ts`
- `corepack pnpm run build:optimus-ui`
- `corepack pnpm --filter @openng/optimus-ui test:unit`

The full Optimus UI unit test command completed successfully with `TOTAL: 7205 SUCCESS` and 90 skipped tests. The run emitted existing console/reporter warnings after completion, but exited with status 0.