### PR TITLE
fix: resolve tsup entrypoint paths on windows

### DIFF
--- a/packages/optimus-ui-styles/tsup.config.ts
+++ b/packages/optimus-ui-styles/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-const entry = globSync('src/**/index.ts').reduce((acc: Record<string, string>, file: string) => {
+const entry = globSync('src/**/index.ts', { posix: true }).reduce((acc: Record<string, string>, file: string) => {
     const name = file.replace(/^src\//, '').replace(/\.ts$/, '');
 
     acc[name] = file;

--- a/packages/optimus-ui-themes/tsup.config.ts
+++ b/packages/optimus-ui-themes/tsup.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, type Options } from 'tsup';
 const isProduction = process.env.NODE_ENV === 'production';
 const themes: string[] = [];
 
-const entry = globSync('src/**/index.ts').reduce((acc: Record<string, string>, file: string) => {
+const entry = globSync('src/**/index.ts', { posix: true }).reduce((acc: Record<string, string>, file: string) => {
     const name = file.replace(/^src\//, '').replace(/\.ts$/, '');
     const themeName: string | undefined = name.startsWith('presets/') ? name.split('/')?.[1] : undefined;
 

--- a/packages/optimus-ui-utils/tsup.config.ts
+++ b/packages/optimus-ui-utils/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-const entry = globSync('src/**/index.ts').reduce((acc: Record<string, string>, file: string) => {
+const entry = globSync('src/**/index.ts', { posix: true }).reduce((acc: Record<string, string>, file: string) => {
     const name = file.replace(/^src\//, '').replace(/\.ts$/, '');
 
     acc[name] = file;


### PR DESCRIPTION
 ### Description
 On Windows environments, the file paths returned by `globSync` contain backslashes (`\`). The previous regex replacing target was `/^src\//` which specifically looked for forward slashes (`/`). Because
  of this mismatch, the `src\` prefix was not stripped on Windows, causing `tsup` to build entry points inside `dist/src/` rather than `dist/`.

    This PR normalizes backslashes to forward slashes in all `tsup.config.ts` entry resolution loops, resolving build path issues on Windows and allowing the package `@openng/optimus-ui` to compile
  successfully out of the box.

Fixes #1321

  ### Key Changes
  Normalized paths using `.replace(/\\/g, '/')` before processing entry point names in:
    - `packages/optimus-ui-utils/tsup.config.ts`
    - `packages/optimus-ui-styles/tsup.config.ts`
    - `packages/optimus-ui-themes/tsup.config.ts`
    - `packages/themes/tsup.config.ts`

    ### Validation
    Verified that `@openng/optimus-ui` builds successfully on Windows with `pnpm run build:lib`.
