### PR TITLE
fix: Table ColumnFilter leaves stale ZIndexUtils entries on close

### DIFF
--- a/packages/optimus-ui/src/table/table.ts
+++ b/packages/optimus-ui/src/table/table.ts
@@ -6095,8 +6095,11 @@ export class ColumnFilter extends BaseComponent {
     }
 
     toggleMenu(event: Event) {
-        this.overlayVisible = !this.overlayVisible;
-        this.renderOverlay.set(!this.renderOverlay());
+        if (this.overlayVisible) {
+            this.hide();
+        } else {
+            this.show();
+        }
         event.stopPropagation();
     }
 
@@ -6104,7 +6107,7 @@ export class ColumnFilter extends BaseComponent {
         switch (event.key) {
             case 'Escape':
             case 'Tab':
-                this.overlayVisible = false;
+                this.hide();
                 break;
 
             case 'ArrowDown':
@@ -6127,7 +6130,7 @@ export class ColumnFilter extends BaseComponent {
     }
 
     onEscape() {
-        this.overlayVisible = false;
+        this.hide();
         this.icon?.nativeElement.focus();
     }
 
@@ -6177,12 +6180,12 @@ export class ColumnFilter extends BaseComponent {
 
     onOverlayAnimationAfterLeave(event: MotionEvent) {
         this.restoreOverlayAppend();
+        ZIndexUtils.clear(this.overlay);
         this.onOverlayHide();
         this.renderOverlay.set(false);
         if (this.overlaySubscription) {
             this.overlaySubscription.unsubscribe();
         }
-        ZIndexUtils.clear(this.overlay);
 
         this.onHide.emit({ originalEvent: event as any });
     }
@@ -6300,6 +6303,12 @@ export class ColumnFilter extends BaseComponent {
         if (this.scrollHandler) {
             this.scrollHandler.unbindScrollListener();
         }
+    }
+
+    show() {
+        this.renderOverlay.set(true);
+        this.overlayVisible = true;
+        this.cd.markForCheck();
     }
 
     hide() {


### PR DESCRIPTION
## Description
Fixes:
1. `ZIndexUtils.clear(this.overlay);` is not called with a null value. 
2.  `onOverlayAnimationAfterLeave` would not be called due to `this.renderOverlay.set(false);` being called to early, resulting in `ZIndexUtils.clear(this.overlay)` not being called.

## Related issues

<!-- Link issues this PR addresses, e.g. Fixes #123, Closes #456, or Relates to #789 -->

Fixes #1356 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

<!-- If this is a breaking change, describe what changed and how consumers should migrate. Otherwise, write "None". -->

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->
