### PR TITLE
refactor: add new logo icon to herosection example

### DIFF
--- a/apps/showcase/pages/landing/herosection.component.ts
+++ b/apps/showcase/pages/landing/herosection.component.ts
@@ -1,5 +1,5 @@
 import { AppConfigService } from '@/service/appconfigservice';
-import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { CommonModule, isPlatformBrowser, NgOptimizedImage } from '@angular/common';
 import { ChangeDetectorRef, Component, Inject, OnDestroy, OnInit, PLATFORM_ID } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
@@ -46,7 +46,8 @@ import { OverviewApp } from './samples/overviewapp.component';
         DrawerModule,
         OverlayBadgeModule,
         KnobModule,
-        ButtonModule
+        ButtonModule,
+        NgOptimizedImage
     ],
     template: `
         <section class="landing-hero py-20 px-8 lg:px-20">
@@ -94,23 +95,7 @@ import { OverviewApp } from './samples/overviewapp.component';
                         >
                             <div class="flex items-center gap-3">
                                 <div class="w-11 h-11 border border-primary rounded-xl flex items-center justify-center">
-                                    <svg width="20" height="24" viewBox="0 0 20 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                        <path d="M14.65 11.0645L13.1283 10.7253L14.3119 12.4216V17.6803L18.3698 14.2876V8.52002L16.5099 9.19856L14.65 11.0645Z" fill="var(--p-primary-color)" />
-                                        <path d="M5.18078 11.0645L6.70251 10.7253L5.51894 12.4216V17.6803L1.46098 14.2876V8.52002L3.32088 9.19856L5.18078 11.0645Z" fill="var(--p-primary-color)" />
-                                        <path
-                                            fill-rule="evenodd"
-                                            clip-rule="evenodd"
-                                            d="M6.02649 12.7634L7.37914 10.7278L8.22455 11.2367H11.6062L12.4516 10.7278L13.8042 12.7634V20.397L12.7898 21.9237L11.6062 23.1111H8.22455L7.04098 21.9237L6.02649 20.397V12.7634Z"
-                                            fill="var(--p-primary-color)"
-                                        />
-                                        <path d="M14.311 20.9058L16.5091 18.7005V16.4952L14.311 18.3612V20.9058Z" fill="var(--p-primary-color)" />
-                                        <path d="M5.51868 20.9058L3.32062 18.7005V16.4952L5.51868 18.3612V20.9058Z" fill="var(--p-primary-color)" />
-                                        <path fill-rule="evenodd" clip-rule="evenodd" d="M9.578 0.888672H7.7177L6.36505 4.11174L8.56311 10.5579H11.4375L13.4665 4.11174L12.1138 0.888672H10.2543V10.5578H9.578V0.888672Z" fill="var(--p-primary-color)" />
-                                        <path d="M8.56283 10.5575L1.29232 7.84329L0.277832 3.60242L6.53385 4.11132L8.73191 10.5575H8.56283Z" fill="var(--p-primary-color)" />
-                                        <path d="M11.4372 10.5575L18.7077 7.84329L19.7222 3.60242L13.2971 4.11132L11.2681 10.5575H11.4372Z" fill="var(--p-primary-color)" />
-                                        <path d="M13.8041 3.60283L17.3548 3.26356L14.9876 0.888672H12.6205L13.8041 3.60283Z" fill="var(--p-primary-color)" />
-                                        <path d="M6.02676 3.60283L2.47604 3.26356L4.84318 0.888672H7.21033L6.02676 3.60283Z" fill="var(--p-primary-color)" />
-                                    </svg>
+                                    <img ngSrc="logo-icon.svg" height="20" width="24" />
                                 </div>
                                 <div
                                     [ngClass]="{

--- a/apps/showcase/pages/landing/herosection.component.ts
+++ b/apps/showcase/pages/landing/herosection.component.ts
@@ -95,7 +95,7 @@ import { OverviewApp } from './samples/overviewapp.component';
                         >
                             <div class="flex items-center gap-3">
                                 <div class="w-11 h-11 border border-primary rounded-xl flex items-center justify-center">
-                                    <img ngSrc="logo-icon.svg" height="20" width="24" />
+                                    <img ngSrc="logo-icon.svg" height="30" width="30" />
                                 </div>
                                 <div
                                     [ngClass]="{


### PR DESCRIPTION
## Description
Replaced the old PrimeNG icon with the new Anguie mascot introduced in [#1309](https://github.com/openng-org/optimus-ui/pull/1309)

## Related issues

Follow-up to https://github.com/openng-org/optimus-ui/pull/1309

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [x] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Before
<img width="433" height="377" alt="image" src="https://github.com/user-attachments/assets/942e364b-0208-4837-9b6f-5d818e51ee99" />

After
<img width="458" height="332" alt="image" src="https://github.com/user-attachments/assets/7c7bdadd-b5dd-4f24-aa04-969638b939f5" />
