### PR TITLE
fix(logo): replace PrimeNG icon in `notfound` and logo respect color scheme&darkmode

### DIFF
--- a/apps/showcase/components/layout/topbar/app.topbar.component.ts
+++ b/apps/showcase/components/layout/topbar/app.topbar.component.ts
@@ -2,7 +2,7 @@ import Versions from '@/assets/data/versions.json';
 import { AppConfiguratorComponent } from '@/components/layout/configurator/app.configurator.component';
 import { AppConfigService } from '@/service/appconfigservice';
 import { DISCORD_URL, GITHUB_DISCUSSIONS_URL, GITHUB_REPO_URL } from '@/utils/constants';
-import { CommonModule, DOCUMENT, NgOptimizedImage } from '@angular/common';
+import { CommonModule, DOCUMENT } from '@angular/common';
 import { afterNextRender, booleanAttribute, Component, computed, ElementRef, Inject, Input, OnDestroy, Renderer2 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
@@ -14,15 +14,15 @@ import { SelectModule } from '@openng/optimus-ui/select';
 @Component({
     selector: 'app-topbar',
     standalone: true,
-    imports: [CommonModule, FormsModule, StyleClass, RouterModule, AppConfiguratorComponent, SelectModule, NgOptimizedImage],
+    imports: [CommonModule, FormsModule, StyleClass, RouterModule, AppConfiguratorComponent, SelectModule],
     template: `<div class="layout-topbar">
         <div class="layout-topbar-inner">
             <div class="layout-topbar-logo-container">
                 <a [routerLink]="['/']" class="layout-topbar-logo" aria-label="Optimus UI Logo">
-                    <img ngSrc="logo.svg" height="40" width="200" />
+                    <div class="h-[50px] w-[200px] bg-surface-950 dark:bg-surface-50 [mask:url('/logo.svg')_center/100%_100%_no-repeat] [-webkit-mask:url('/logo.svg')_center/100%_100%_no-repeat]"></div>
                 </a>
                 <a [routerLink]="['/']" class="layout-topbar-icon" aria-label="Optimus UI Logo">
-                    <img ngSrc="logo-icon.svg" height="32" width="32" />
+                    <div class="h-[32px] w-[32px] bg-surface-950 dark:bg-surface-50 [mask:url('/logo-icon.svg')_center/100%_100%_no-repeat] [-webkit-mask:url('/logo-icon.svg')_center/100%_100%_no-repeat]"></div>
                 </a>
             </div>
 

--- a/apps/showcase/pages/landing/footersection.component.ts
+++ b/apps/showcase/pages/landing/footersection.component.ts
@@ -1,12 +1,12 @@
 import { DISCORD_URL, GITHUB_DISCUSSIONS_URL, GITHUB_REPO_URL } from '@/utils/constants';
-import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 @Component({
     selector: 'footer-section',
     standalone: true,
-    imports: [CommonModule, RouterModule, NgOptimizedImage],
+    imports: [CommonModule, RouterModule],
     template: `
         <section class="landing-footer pt-20 px-8 lg:px-20">
             <div class="landing-footer-container">
@@ -60,7 +60,7 @@ import { RouterModule } from '@angular/router';
                 <hr class="section-divider" />
 
                 <div class="flex flex-wrap justify-between py-12 gap-8">
-                    <img ngSrc="logo.svg" height="40" width="200" alt="" />
+                    <div class="h-[50px] w-[200px] bg-surface-950 dark:bg-surface-50 [mask:url('/logo.svg')_center/100%_100%_no-repeat] [-webkit-mask:url('/logo.svg')_center/100%_100%_no-repeat]"></div>
                     <div class="flex items-center gap-2">
                         <a [href]="githubRepoUrl" target="_blank" rel="noopener noreferrer" class="linkbox linkbox-icon">
                             <i class="pi pi-github"></i>

--- a/apps/showcase/pages/landing/herosection.component.ts
+++ b/apps/showcase/pages/landing/herosection.component.ts
@@ -47,8 +47,7 @@ import { OverviewApp } from './samples/overviewapp.component';
         DrawerModule,
         OverlayBadgeModule,
         KnobModule,
-        ButtonModule,
-        NgOptimizedImage
+        ButtonModule
     ],
     template: `
         <section class="landing-hero py-20 px-8 lg:px-20">
@@ -96,7 +95,7 @@ import { OverviewApp } from './samples/overviewapp.component';
                         >
                             <div class="flex items-center gap-3">
                                 <div class="w-11 h-11 border border-primary rounded-xl flex items-center justify-center">
-                                    <img ngSrc="logo-icon.svg" height="30" width="30" />
+                                    <span class="h-[30px] w-[30px] bg-[var(--p-primary-color)] [mask:url('/logo-icon.svg')_center/contain_no-repeat] [-webkit-mask:url('/logo-icon.svg')_center/contain_no-repeat]"></span>
                                 </div>
                                 <div
                                     [ngClass]="{

--- a/apps/showcase/pages/notfound/index.ts
+++ b/apps/showcase/pages/notfound/index.ts
@@ -11,7 +11,7 @@ import { CommonModule } from '@angular/common';
             <div class="flex flex-col sm:flex-row items-center justify-center gap-4 text-primary">
                 <span class="font-bold text-9xl"> 4 </span>
                 <div class="flex items-center justify-center bg-primary text-primary-contrast rounded-full w-28 h-28">
-                    <i class="pi pi-prime !text-6xl"></i>
+                    <span class="h-[70px] w-[70px] bg-surface-0 dark:bg-surface-950 [mask:url('/logo-icon.svg')_center/contain_no-repeat] [-webkit-mask:url('/logo-icon.svg')_center/contain_no-repeat]"></span>
                 </div>
                 <span class="font-bold text-9xl"> 4 </span>
             </div>


### PR DESCRIPTION
## Description

- fix: logo should now respect dark mode in the topbar and footer. Now there is single color (ignoring schema/uses only `bg-surface-*`).
- fix: HeroSection respect primary selected color
- refactor: replaces the `/notfound` PrimeNG icon with the project Angui logo

SVG seems to be full some `base64` and I have not found clearer solution than use mask for that. It is first time I used it in css (I am not sure about Safari for example). Please check it.

## Related issues

Issue: https://github.com/openng-org/optimus-ui/issues/1368
Follow-up: https://github.com/openng-org/optimus-ui/pull/1309, https://github.com/openng-org/optimus-ui/pull/1358

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [x] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context 

`topbar` (footer too + mobile icon only tested too)
<img width="454" height="145" alt="image" src="https://github.com/user-attachments/assets/e17af003-17e1-4723-8d81-75a60665801e" />
<img width="289" height="138" alt="image" src="https://github.com/user-attachments/assets/6bac3a2a-18b5-4312-a9cb-b509e28dab56" />

`HeroSection`
<img width="466" height="189" alt="image" src="https://github.com/user-attachments/assets/8c7a0675-cdad-4fa2-9efc-ca8adcaaceb2" />
<img width="459" height="175" alt="image" src="https://github.com/user-attachments/assets/044756d7-23e8-4792-85db-bb07f7fe51a0" />
<img width="370" height="161" alt="image" src="https://github.com/user-attachments/assets/37e3fdf3-76a8-4fa7-b8d9-f80ccba302ee" />

`/notfound`
<img width="350" height="342" alt="image" src="https://github.com/user-attachments/assets/d5631058-fed3-485a-9bcf-505bfd14bc8c" />
<img width="350" height="340" alt="image" src="https://github.com/user-attachments/assets/ad320181-547c-478a-9d92-6e332078c31b" />
<img width="354" height="355" alt="image" src="https://github.com/user-attachments/assets/ca59806d-3eec-47bc-ad82-a84ff34c0a17" />







