### PR TITLE
 test(table): cover column filter overlay z-index cleanup on close

### DIFF
--- a/packages/optimus-ui/src/table/table.test.ts
+++ b/packages/optimus-ui/src/table/table.test.ts
@@ -6,7 +6,8 @@ import { By } from '@angular/platform-browser';
 
 import { SharedModule, SortMeta } from '@openng/optimus-ui/api';
 import { Select } from '@openng/optimus-ui/select';
-import { Table, TableModule, TableService } from './table';
+import { ZIndexUtils } from '@openng/optimus-ui/utils';
+import { ColumnFilter, Table, TableModule, TableService } from './table';
 
 describe('Table', () => {
     let component: Table;
@@ -549,6 +550,26 @@ describe('Table', () => {
         it('should render column filters', () => {
             const columnFilters = testFixture.debugElement.queryAll(By.css('p-columnFilter'));
             expect(columnFilters.length).toBe(2);
+        });
+
+        it('should not leave stale ZIndexUtils entries after the filter overlay closes', () => {
+            const columnFilter: ColumnFilter = testFixture.debugElement.query(By.directive(ColumnFilter)).componentInstance;
+            const baseZIndex = columnFilter.config.zIndex.overlay;
+
+            const openOverlay = () => {
+                const overlay = document.createElement('div');
+                document.body.appendChild(overlay);
+                columnFilter.overlay = overlay;
+                ZIndexUtils.set('overlay', overlay, baseZIndex);
+                return ZIndexUtils.get(overlay);
+            };
+
+            const firstZIndex = openOverlay();
+            columnFilter.onOverlayAnimationAfterLeave({ element: columnFilter.overlay } as any);
+            const secondZIndex = openOverlay();
+            columnFilter.onOverlayAnimationAfterLeave({ element: columnFilter.overlay } as any);
+
+            expect(secondZIndex).toBe(firstZIndex);
         });
     });
 


### PR DESCRIPTION
## Description

#1357 fixed the underlying bug (`ZIndexUtils.clear(this.overlay)` ran after `onOverlayHide()` had already nulled `this.overlay`, so the stale overlay
entry was never removed and the z-index grew by 2 on every reopen), but merged without a regression test.

This PR adds that missing test. It exercises the real `ZIndexUtils` singleton and `ColumnFilter.onOverlayAnimationAfterLeave` directly: opens/closes the
overlay twice and asserts the second z-index equals the first. Against the pre-#1357 ordering this fails (second z-index is base+4 instead of base+2,
matching the reported x, x+2, x+4 growth); against current `main` it passes.

No production code changes, this only adds coverage for behavior that already shipped.

## Related issues

Relates to #1356 (fixed by #1357). This PR only backfills the regression test that PR didn't include.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [x] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [x] `npm run build`
- [x] `npm test` (ran the Table suite: 6 test which fails without the fix)
- [x] `npm run lint`
- [x] Verified in the demo app (if appli

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed) — not applicable
- [ ] Public API changes documented; breaking changes called out — not applicable
- [ ] CHANGELOG updated — not applicable, test-only change
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Originally opened with a duplicate fix commit alongside this test, before #1357 merged the fix independently. Per @geromegrignon's review, rebased onto `main` and reduced to just the regression test, moved to `table.test.ts` (Karma removed).