### PR TITLE
refactor(showcase): use provideAppInitializer instead of APP_INITIALIZER

### DIFF
--- a/apps/docs/app/app.config.ts
+++ b/apps/docs/app/app.config.ts
@@ -2,14 +2,10 @@ import { routes } from '@/router/app.routes';
 import { DemoCodeService } from '@/service/democodeservice';
 import Noir from '@/themes/app-theme';
 import { provideHttpClient, withFetch } from '@angular/common/http';
-import { APP_INITIALIZER, ApplicationConfig, provideZonelessChangeDetection } from '@angular/core';
+import { ApplicationConfig, inject, provideAppInitializer, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter, withInMemoryScrolling } from '@angular/router';
 import { ConfirmationService, MessageService } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
-
-function initializeDemoCode(demoCodeService: DemoCodeService) {
-    return () => demoCodeService.loadDemos();
-}
 
 export const appConfig: ApplicationConfig = {
     providers: [
@@ -20,13 +16,11 @@ export const appConfig: ApplicationConfig = {
             theme: Noir,
             ripple: false
         }),
+        provideAppInitializer(() => {
+            const demoCodeService = inject(DemoCodeService);
+            demoCodeService.loadDemos();
+        }),
         MessageService,
-        ConfirmationService,
-        {
-            provide: APP_INITIALIZER,
-            useFactory: initializeDemoCode,
-            deps: [DemoCodeService],
-            multi: true
-        }
+        ConfirmationService
     ]
 };


### PR DESCRIPTION
## Description

Adopts Angular's provideAppInitializer helper to replace the deprecated APP_INITIALIZER multi-provider pattern for loading demo code.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [X] Refactor, test, or chore (no user-facing change)

## Breaking changes

None