### PR TITLE
feat(docs): add migration guide from PrimeNG

### DIFF
--- a/apps/docs/assets/data/menu.json
+++ b/apps/docs/assets/data/menu.json
@@ -544,16 +544,8 @@
             "icon": "pi pi-arrow-up",
             "children": [
                 {
-                    "name": "Updating to v21",
-                    "routerLink": "/migration/v21"
-                },
-                {
-                    "name": "Updating to v20",
-                    "routerLink": "/migration/v20"
-                },
-                {
-                    "name": "Updating to v19",
-                    "routerLink": "/migration/v19"
+                    "name": "From PrimeNG",
+                    "routerLink": "/migration/primeng"
                 }
             ]
         },

--- a/apps/docs/doc/migration/primeng/automated-doc.ts
+++ b/apps/docs/doc/migration/primeng/automated-doc.ts
@@ -1,0 +1,39 @@
+import { Code } from '@/domain/code';
+import { Component } from '@angular/core';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { AppCode } from '@/components/doc/app.code';
+
+@Component({
+    selector: 'automated-doc',
+    standalone: true,
+    imports: [AppDocSectionText, AppCode],
+    template: `
+        <app-docsectiontext>
+            <p>
+                The recommended way to migrate is the <i>migrate-from-primeng</i> schematic. Install <i>&#64;openng/optimus-ui</i> first so the Angular CLI can resolve it, then run the schematic: packages are swapped, imports are rewritten and
+                dependencies are installed.
+            </p>
+            <app-code [code]="migrateCode" [hideToggleCode]="true"></app-code>
+            <p>
+                Note that <i>ng add</i> does not run the migration. It only sets up Optimus UI in a fresh project and makes no changes when <i>primeng</i> is detected. The schematic can be re-run at any time, for example after pulling in unmigrated
+                code, and accepts a couple of flags. <i>--skip-install</i> skips the package install task and <i>--force</i> bypasses the PrimeNG v21 version check.
+            </p>
+            <app-code [code]="flagsCode" [hideToggleCode]="true"></app-code>
+            <p>
+                After rewriting, the schematic scans the workspace and prints a report of any remaining <i>primeng</i>, <i>primeicons</i> or <i>&#64;primeuix</i> references it could not migrate automatically, with file and line numbers. Review these
+                manually using the tables in the manual migration section below.
+            </p>
+        </app-docsectiontext>
+    `
+})
+export class AutomatedDoc {
+    migrateCode: Code = {
+        command: `npm install @openng/optimus-ui
+ng generate @openng/optimus-ui:migrate-from-primeng`
+    };
+
+    flagsCode: Code = {
+        command: `ng generate @openng/optimus-ui:migrate-from-primeng --skip-install
+ng generate @openng/optimus-ui:migrate-from-primeng --force`
+    };
+}

--- a/apps/docs/doc/migration/primeng/manual-doc.ts
+++ b/apps/docs/doc/migration/primeng/manual-doc.ts
@@ -1,0 +1,151 @@
+import { Code } from '@/domain/code';
+import { Component } from '@angular/core';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { AppCode } from '@/components/doc/app.code';
+
+@Component({
+    selector: 'manual-doc',
+    standalone: true,
+    imports: [AppDocSectionText, AppCode],
+    template: `
+        <app-docsectiontext>
+            <p>If you prefer to migrate by hand, or need to finish references the schematic reported as leftovers, apply the renames below. Start by replacing the packages.</p>
+            <app-code [code]="installCode" [hideToggleCode]="true"></app-code>
+            <h3>Packages</h3>
+            <p>Replace the packages in <i>package.json</i> and in every import path. Subpath imports keep their suffix, for example <i>primeng/button</i> becomes <i>&#64;openng/optimus-ui/button</i>.</p>
+        </app-docsectiontext>
+        <div class="doc-tablewrapper">
+            <table class="doc-table">
+                <thead>
+                    <tr>
+                        <th>PrimeNG</th>
+                        <th>Optimus UI</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>primeng</td>
+                        <td>&#64;openng/optimus-ui</td>
+                    </tr>
+                    <tr>
+                        <td>primeicons</td>
+                        <td>&#64;openng/icons</td>
+                    </tr>
+                    <tr>
+                        <td>&#64;primeuix/themes</td>
+                        <td>&#64;openng/optimus-ui-themes</td>
+                    </tr>
+                    <tr>
+                        <td>&#64;primeuix/styled</td>
+                        <td>&#64;openng/optimus-ui-styled</td>
+                    </tr>
+                    <tr>
+                        <td>&#64;primeuix/styles</td>
+                        <td>&#64;openng/optimus-ui-styles</td>
+                    </tr>
+                    <tr>
+                        <td>&#64;primeuix/utils</td>
+                        <td>&#64;openng/optimus-ui-utils</td>
+                    </tr>
+                    <tr>
+                        <td>&#64;primeuix/motion</td>
+                        <td>&#64;openng/optimus-ui-motion</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <app-docsectiontext>
+            <h3>Identifiers</h3>
+            <p>Rename the following exported identifiers. The <i>PrimeIcons</i> constants class still compiles through a deprecated alias, however <i>OpenngIcons</i> is the current API.</p>
+        </app-docsectiontext>
+        <div class="doc-tablewrapper">
+            <table class="doc-table">
+                <thead>
+                    <tr>
+                        <th>PrimeNG</th>
+                        <th>Optimus UI</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>providePrimeNG</td>
+                        <td>provideOptimus</td>
+                    </tr>
+                    <tr>
+                        <td>PrimeNG</td>
+                        <td>Optimus</td>
+                    </tr>
+                    <tr>
+                        <td>PrimeNGConfigType</td>
+                        <td>OptimusConfigType</td>
+                    </tr>
+                    <tr>
+                        <td>PrimeIcons</td>
+                        <td>OpenngIcons</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <app-docsectiontext>
+            <h3>Assets</h3>
+            <p>
+                The PrimeIcons stylesheet moved along with the package rename. Update references in global stylesheets and in the <i>styles</i> arrays of <i>angular.json</i> or <i>project.json</i> from <i>primeicons/primeicons.css</i> to
+                <i>&#64;openng/icons/openng-icons.css</i>.
+            </p>
+            <h3>Example</h3>
+            <p>A typical <i>app.config.ts</i> and component before the migration.</p>
+            <app-code [code]="beforeCode" [hideToggleCode]="true"></app-code>
+            <p>The same code after the migration.</p>
+            <app-code [code]="afterCode" [hideToggleCode]="true"></app-code>
+        </app-docsectiontext>
+    `
+})
+export class ManualDoc {
+    installCode: Code = {
+        command: `# Using npm
+npm uninstall primeng primeicons @primeuix/themes
+npm install @openng/optimus-ui @openng/optimus-ui-themes @openng/icons
+
+# Using pnpm
+pnpm remove primeng primeicons @primeuix/themes
+pnpm add @openng/optimus-ui @openng/optimus-ui-themes @openng/icons`
+    };
+
+    beforeCode: Code = {
+        typescript: `import { ApplicationConfig } from '@angular/core';
+import { providePrimeNG } from 'primeng/config';
+import Aura from '@primeuix/themes/aura';
+
+export const appConfig: ApplicationConfig = {
+    providers: [
+        providePrimeNG({
+            theme: {
+                preset: Aura
+            }
+        })
+    ]
+};
+
+// component
+import { ButtonModule } from 'primeng/button';`
+    };
+
+    afterCode: Code = {
+        typescript: `import { ApplicationConfig } from '@angular/core';
+import { provideOptimus } from '@openng/optimus-ui/config';
+import Aura from '@openng/optimus-ui-themes/aura';
+
+export const appConfig: ApplicationConfig = {
+    providers: [
+        provideOptimus({
+            theme: {
+                preset: Aura
+            }
+        })
+    ]
+};
+
+// component
+import { ButtonModule } from '@openng/optimus-ui/button';`
+    };
+}

--- a/apps/docs/doc/migration/primeng/overview-doc.ts
+++ b/apps/docs/doc/migration/primeng/overview-doc.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+
+@Component({
+    selector: 'overview-doc',
+    standalone: true,
+    imports: [AppDocSectionText],
+    template: `
+        <app-docsectiontext>
+            <p>
+                Optimus UI is the open-source MIT licensed continuation of PrimeNG (now closed-source), rebranded due to trademark restrictions. Optimus UI v1 targets Angular 21 and is fully API-compatible with PrimeNG v21, so migrating is a rename
+                rather than a rewrite. From v1 onward, Optimus UI evolves independently and future versions will diverge from PrimeNG, so v1 is the smoothest point to switch.
+            </p>
+            <p>Component selectors keep the <i>p-</i> prefix and icon classes keep the <i>pi-</i> prefix, so your templates are not affected by the migration.</p>
+        </app-docsectiontext>
+    `
+})
+export class OverviewDoc {}

--- a/apps/docs/doc/migration/primeng/prerequisites-doc.ts
+++ b/apps/docs/doc/migration/primeng/prerequisites-doc.ts
@@ -1,0 +1,28 @@
+import { Code } from '@/domain/code';
+import { Component } from '@angular/core';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { AppCode } from '@/components/doc/app.code';
+
+@Component({
+    selector: 'prerequisites-doc',
+    standalone: true,
+    imports: [AppDocSectionText, AppCode],
+    template: `
+        <app-docsectiontext>
+            <p>
+                Your project must be on PrimeNG v21 before migrating, as Optimus UI v1 mirrors the PrimeNG v21 API. If you are on an older version, update PrimeNG first by following its
+                <a href="https://v21.primeng.org/migration/v21" target="_blank" rel="noopener noreferrer">v21 migration guide</a>.
+            </p>
+            <app-code [code]="code" [hideToggleCode]="true"></app-code>
+            <p>
+                The migration schematic verifies this requirement and aborts when PrimeNG is missing or older than v21. The check can be bypassed with the <i>--force</i> flag, for example in workspaces where the dependency is declared in a
+                non-standard location.
+            </p>
+        </app-docsectiontext>
+    `
+})
+export class PrerequisitesDoc {
+    code: Code = {
+        command: `ng update primeng@21`
+    };
+}

--- a/apps/docs/doc/migration/primeng/schematic-details-doc.ts
+++ b/apps/docs/doc/migration/primeng/schematic-details-doc.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+
+@Component({
+    selector: 'schematic-details-doc',
+    standalone: true,
+    imports: [AppDocSectionText],
+    template: `
+        <app-docsectiontext>
+            <p>The schematic performs the following steps across the whole workspace, skipping build output and dependency folders.</p>
+            <ul class="leading-relaxed">
+                <li>Swaps the PrimeNG package family for the Optimus UI equivalents in every <i>package.json</i>.</li>
+                <li>Rewrites import specifiers and renamed identifiers, such as <i>providePrimeNG</i>, in all <i>.ts</i> and <i>.mts</i> source files.</li>
+                <li>Updates asset references, such as the PrimeIcons stylesheet, in stylesheets and in <i>angular.json</i> / <i>project.json</i>.</li>
+                <li>Prints a report of leftover references that require manual review.</li>
+                <li>Schedules a package install, unless <i>--skip-install</i> is set.</li>
+            </ul>
+        </app-docsectiontext>
+    `
+})
+export class SchematicDetailsDoc {}

--- a/apps/docs/doc/migration/primeng/verify-doc.ts
+++ b/apps/docs/doc/migration/primeng/verify-doc.ts
@@ -1,0 +1,26 @@
+import { Code } from '@/domain/code';
+import { Component } from '@angular/core';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { AppCode } from '@/components/doc/app.code';
+
+@Component({
+    selector: 'verify-doc',
+    standalone: true,
+    imports: [AppDocSectionText, AppCode],
+    template: `
+        <app-docsectiontext>
+            <p>
+                Build the application and run your test suite to confirm the migration. Searching the project for the old package names is a quick way to find anything left behind. The schematic scans for the same pattern when it prints its leftover
+                report.
+            </p>
+            <app-code [code]="code" [hideToggleCode]="true"></app-code>
+        </app-docsectiontext>
+    `
+})
+export class VerifyDoc {
+    code: Code = {
+        command: `ng build
+
+grep -riEn "primeng|primeicons|@primeuix" src/`
+    };
+}

--- a/apps/docs/pages/migration/primeng/index.ts
+++ b/apps/docs/pages/migration/primeng/index.ts
@@ -1,0 +1,48 @@
+import { AutomatedDoc } from '@/doc/migration/primeng/automated-doc';
+import { ManualDoc } from '@/doc/migration/primeng/manual-doc';
+import { OverviewDoc } from '@/doc/migration/primeng/overview-doc';
+import { PrerequisitesDoc } from '@/doc/migration/primeng/prerequisites-doc';
+import { SchematicDetailsDoc } from '@/doc/migration/primeng/schematic-details-doc';
+import { VerifyDoc } from '@/doc/migration/primeng/verify-doc';
+import { Component } from '@angular/core';
+import { AppDoc } from '@/components/doc/app.doc';
+
+@Component({
+    standalone: true,
+    imports: [AppDoc],
+    template: `<app-doc docTitle="Migrate from PrimeNG - Optimus UI" header="Migrate from PrimeNG" description="Moving a PrimeNG v21 application to Optimus UI." [docs]="docs" docType="page"></app-doc>`
+})
+export class MigrationPrimengDemo {
+    docs = [
+        {
+            id: 'overview',
+            label: 'Overview',
+            component: OverviewDoc
+        },
+        {
+            id: 'prerequisites',
+            label: 'Prerequisites',
+            component: PrerequisitesDoc
+        },
+        {
+            id: 'automated',
+            label: 'Automated Migration',
+            component: AutomatedDoc
+        },
+        {
+            id: 'schematic',
+            label: 'What the Schematic Does',
+            component: SchematicDetailsDoc
+        },
+        {
+            id: 'manual',
+            label: 'Manual Migration',
+            component: ManualDoc
+        },
+        {
+            id: 'verify',
+            label: 'Verify',
+            component: VerifyDoc
+        }
+    ];
+}

--- a/apps/docs/pages/migration/routes.ts
+++ b/apps/docs/pages/migration/routes.ts
@@ -1,1 +1,8 @@
-export default [];
+import { MigrationPrimengDemo } from './primeng';
+
+export default [
+    {
+        path: 'primeng',
+        component: MigrationPrimengDemo
+    }
+];

--- a/apps/docs/public/demos.json
+++ b/apps/docs/public/demos.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-24T08:33:32.541Z",
+  "generatedAt": "2026-07-27T06:35:09.418Z",
   "totalDemos": 803,
   "demos": {
     "Image-template-demo": {

--- a/apps/docs/public/llms/components.json
+++ b/apps/docs/public/llms/components.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-07-24",
+  "generatedAt": "2026-07-27",
   "components": [
     {
       "name": "accordion",

--- a/apps/docs/public/llms/llms-full.txt
+++ b/apps/docs/public/llms/llms-full.txt
@@ -1,6 +1,6 @@
 # Optimus UI Documentation
 
-Generated: 2026-07-24
+Generated: 2026-07-27
 
 ---
 

--- a/apps/docs/router/routes.txt
+++ b/apps/docs/router/routes.txt
@@ -115,6 +115,4 @@
 /tree
 /treeselect
 /treetable
-/migration/v21
-/migration/v20
-/migration/v19
+/migration/primeng

--- a/apps/docs/server/server.ts
+++ b/apps/docs/server/server.ts
@@ -39,7 +39,7 @@ export function app(): express.Express {
 
     // Pages that have their own markdown files (not components)
     // These are defined in GUIDE_PAGES in build-llm-docs.mjs
-    const pageNames = new Set(['installation', 'configuration', 'styled', 'unstyled', 'icons', 'customicons', 'passthrough', 'tailwind', 'llms', 'accessibility', 'animations', 'rtl', 'v19', 'v20']);
+    const pageNames = new Set(['installation', 'configuration', 'styled', 'unstyled', 'icons', 'customicons', 'passthrough', 'tailwind', 'llms', 'accessibility', 'animations', 'rtl']);
 
     // Serve markdown files - handles both components and pages
     server.get('/:name.md', (req, res, next) => {
@@ -70,7 +70,7 @@ export function app(): express.Express {
         res.send(content);
     });
 
-    // Serve nested page markdown files (e.g., /theming/styled.md, /guides/accessibility.md, /migration/v19.md)
+    // Serve nested page markdown files (e.g., /theming/styled.md, /guides/accessibility.md)
     // Using regex pattern to properly match .md extension in nested paths
     server.get(/^\/([^/]+)\/([^/]+)\.md$/, (req, res, next) => {
         const page = req.params[1]; // Second capture group is the page name


### PR DESCRIPTION
## Description

Replace the removed PrimeNG version migration pages with a guide at /migration/primeng covering installation, the automated ng add / migrate-from-primeng schematic flow and a complete manual fallback with package, identifier and asset rename tables. Update the sidebar menu and prerender routes accordingly and drop stale v19/v20 leftovers from the SSR server.

## Related issues

<!-- Link issues this PR addresses, e.g. Fixes #123, Closes #456, or Relates to #789 -->

Fixes #1334

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [x] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

<!-- If this is a breaking change, describe what changed and how consumers should migrate. Otherwise, write "None". -->

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->
