### PR TITLE
feat(commitlint): enforce rule to reject AI co-authored commit messages

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,10 +1,25 @@
-export default {
+import type { UserConfig } from '@commitlint/types';
+import { findAiCoAuthorTrailers } from './scripts/commitlint/no-ai-co-author';
+
+const config: UserConfig = {
     extends: ['@commitlint/config-conventional'],
+    plugins: [
+        {
+            rules: {
+                'no-ai-co-author': (parsed) => {
+                    const aiCoAuthors = findAiCoAuthorTrailers(parsed.raw ?? '');
+
+                    return [aiCoAuthors.length === 0, `commit message must not credit an AI agent as Co-authored-by (found: ${aiCoAuthors.join(', ')})`];
+                }
+            }
+        }
+    ],
     rules: {
         'type-enum': [2, 'always', ['feat', 'fix', 'docs', 'style', 'refactor', 'test', 'chore']],
         'subject-case': [1, 'always', ['sentence-case', 'lower-case']],
         'body-max-line-length': [0],
-        'references-empty': [1, 'never']
+        'references-empty': [1, 'never'],
+        'no-ai-co-author': [2, 'always']
     },
     ignores: [(commit: string) => commit.startsWith('Merge')],
     parserPreset: {
@@ -13,3 +28,5 @@ export default {
         }
     }
 };
+
+export default config;

--- a/scripts/commitlint/no-ai-co-author.ts
+++ b/scripts/commitlint/no-ai-co-author.ts
@@ -1,0 +1,21 @@
+export const AI_CO_AUTHOR_MARKERS: readonly string[] = [
+    'claude', 'anthropic', 'chatgpt', 'openai', 'gpt-', 'copilot', 'gemini', 'bard', 'devin', 'codeium', 'cursor',
+    'windsurf', 'tabnine', 'aider', 'cody', 'jules'
+];
+
+const CO_AUTHOR_TRAILER = /^co-authored-by:\s*(.+)$/gim;
+
+export function findAiCoAuthorTrailers(message: string): string[] {
+    const found: string[] = [];
+
+    for (const match of message.matchAll(CO_AUTHOR_TRAILER)) {
+        const value = match[1].trim();
+        const lowerValue = value.toLowerCase();
+
+        if (AI_CO_AUTHOR_MARKERS.some((marker) => lowerValue.includes(marker))) {
+            found.push(value);
+        }
+    }
+
+    return found;
+}


### PR DESCRIPTION
## Description

Adds a commitlint rule (`no-ai-co-author`) that rejects any commit message containing a `Co-authored-by:` trailer referencing a known AI agent (Claude, ChatGPT, Copilot, Gemini, Devin, Cursor, etc.), while still allowing legitimate human co-author trailers.

The rule is enforced both locally, via the existing husky `commit-msg` hook, and in CI, via the existing `commitlint` job on pull requests.

## Related issues

Fixes #1367

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [x] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)
- [x] `pnpm exec commitlint` manually against sample commit messages (AI co-author rejected, human co-author accepted)
- [x] Verified the husky `commit-msg` hook blocks a real local commit with an AI co-author trailer
- [x] Simulated the CI `commitlint` job locally with `act` against a real PR event payload
- [x] Test real CI with fake Claude co-author commit message

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

None