### PR TITLE
fix(togglebutton): allow undefined as size

### DIFF
--- a/packages/optimus-ui/src/togglebutton/style/togglebuttonstyle.ts
+++ b/packages/optimus-ui/src/togglebutton/style/togglebuttonstyle.ts
@@ -22,8 +22,8 @@ const classes = {
             'p-togglebutton-checked': instance.checked,
             'p-invalid': instance.invalid(),
             'p-disabled': instance.$disabled(),
-            'p-togglebutton-sm p-inputfield-sm': instance.size === 'small',
-            'p-togglebutton-lg p-inputfield-lg': instance.size === 'large',
+            'p-togglebutton-sm p-inputfield-sm': instance.size() === 'small',
+            'p-togglebutton-lg p-inputfield-lg': instance.size() === 'large',
             'p-togglebutton-fluid': instance.fluid()
         }
     ],

--- a/packages/optimus-ui/src/togglebutton/togglebutton.spec.ts
+++ b/packages/optimus-ui/src/togglebutton/togglebutton.spec.ts
@@ -383,7 +383,7 @@ describe('ToggleButton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(toggleButtonInstance.size).toBe('large');
+            expect(toggleButtonInstance.size()).toBe('large');
         });
     });
 

--- a/packages/optimus-ui/src/togglebutton/togglebutton.ts
+++ b/packages/optimus-ui/src/togglebutton/togglebutton.ts
@@ -171,9 +171,10 @@ export class ToggleButton extends BaseEditableHolder<ToggleButtonPassThrough> {
     @Input({ transform: booleanAttribute }) autofocus: boolean | undefined;
     /**
      * Defines the size of the component.
+     * @defaultValue undefined
      * @group Props
      */
-    @Input() size: 'large' | 'small';
+    size = input<'small' | 'large' | undefined>();
     /**
      * Whether selection can not be cleared.
      * @group Props
@@ -270,7 +271,7 @@ export class ToggleButton extends BaseEditableHolder<ToggleButtonPassThrough> {
         return this.cn({
             checked: this.active,
             invalid: this.invalid(),
-            [this.size as string]: this.size
+            [this.size() as string]: this.size()
         });
     }
 }


### PR DESCRIPTION
## Summary
- Allow `undefined` for ToggleButton `size` so the default/normal size can be set programmatically, matching other components (Checkbox, SelectButton, etc.).
- Migrate `size` to an `input()` signal and update style/tests accordingly.
- Fixes #19

## Test plan
- [ ] `[size]=undefined` / unbound size compiles without TS2322
- [ ] `size=small` / `size=large` still apply the correct CSS classes
- [ ] Existing ToggleButton unit test for size passes

Made with [Cursor](https://cursor.com)