### PR TITLE
fix(confirmdialog): add draggable to confirmation interface

### DIFF
--- a/packages/optimus-ui/src/api/confirmation.ts
+++ b/packages/optimus-ui/src/api/confirmation.ts
@@ -110,6 +110,10 @@ export interface Confirmation {
      */
     position?: string;
     /**
+     * Enables dragging to change the position using header.
+     */
+    draggable?: boolean;
+    /**
      * Specifies whether the dialog displayed as modal or not.
      * @defaultValue true
      */


### PR DESCRIPTION
## Summary
- add the missing draggable option to the Confirmation interface
- align the confirmation service payload type with the existing ConfirmDialog draggable input

Fixes #60

## Test plan
- pnpm run build:lib