### PR TITLE
fix(toggleswitch): apply size styles

### DIFF
--- a/packages/optimus-ui-styles/src/toggleswitch/index.ts
+++ b/packages/optimus-ui-styles/src/toggleswitch/index.ts
@@ -112,4 +112,34 @@ export const style = /*css*/ `
     .p-toggleswitch.p-disabled .p-toggleswitch-handle {
         background: dt('toggleswitch.handle.disabled.background');
     }
+
+    .p-toggleswitch-sm {
+        width: 2rem;
+        height: 1.25rem;
+    }
+
+    .p-toggleswitch-sm .p-toggleswitch-handle {
+        width: 0.75rem;
+        height: 0.75rem;
+        margin-block-start: -0.375rem;
+    }
+
+    .p-toggleswitch-sm.p-toggleswitch-checked .p-toggleswitch-handle {
+        inset-inline-start: calc(2rem - (0.75rem + dt('toggleswitch.gap')));
+    }
+
+    .p-toggleswitch-lg {
+        width: 3rem;
+        height: 1.75rem;
+    }
+
+    .p-toggleswitch-lg .p-toggleswitch-handle {
+        width: 1.25rem;
+        height: 1.25rem;
+        margin-block-start: -0.625rem;
+    }
+
+    .p-toggleswitch-lg.p-toggleswitch-checked .p-toggleswitch-handle {
+        inset-inline-start: calc(3rem - (1.25rem + dt('toggleswitch.gap')));
+    }
 `;

--- a/packages/optimus-ui/src/toggleswitch/style/toggleswitchstyle.ts
+++ b/packages/optimus-ui/src/toggleswitch/style/toggleswitchstyle.ts
@@ -21,7 +21,9 @@ const classes = {
             'p-toggleswitch p-component': true,
             'p-toggleswitch-checked': instance.checked(),
             'p-disabled': instance.$disabled(),
-            'p-invalid': instance.invalid()
+            'p-invalid': instance.invalid(),
+            'p-toggleswitch-sm p-inputfield-sm': instance.size() === 'small',
+            'p-toggleswitch-lg p-inputfield-lg': instance.size() === 'large'
         }
     ],
 

--- a/packages/optimus-ui/src/toggleswitch/toggleswitch.spec.ts
+++ b/packages/optimus-ui/src/toggleswitch/toggleswitch.spec.ts
@@ -560,6 +560,37 @@ describe('ToggleSwitch', () => {
             expect(component.styleClass).toBe('custom-toggle');
         });
 
+        it('should not apply size classes by default', () => {
+            fixture.detectChanges();
+
+            expect(fixture.nativeElement.classList.contains('p-toggleswitch-sm')).toBe(false);
+            expect(fixture.nativeElement.classList.contains('p-toggleswitch-lg')).toBe(false);
+            expect(fixture.nativeElement.classList.contains('p-inputfield-sm')).toBe(false);
+            expect(fixture.nativeElement.classList.contains('p-inputfield-lg')).toBe(false);
+        });
+
+        it('should apply small size classes', async () => {
+            fixture.componentRef.setInput('size', 'small');
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            expect(fixture.nativeElement.classList.contains('p-toggleswitch-sm')).toBe(true);
+            expect(fixture.nativeElement.classList.contains('p-inputfield-sm')).toBe(true);
+            expect(fixture.nativeElement.classList.contains('p-toggleswitch-lg')).toBe(false);
+            expect(fixture.nativeElement.classList.contains('p-inputfield-lg')).toBe(false);
+        });
+
+        it('should apply large size classes', async () => {
+            fixture.componentRef.setInput('size', 'large');
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            expect(fixture.nativeElement.classList.contains('p-toggleswitch-lg')).toBe(true);
+            expect(fixture.nativeElement.classList.contains('p-inputfield-lg')).toBe(true);
+            expect(fixture.nativeElement.classList.contains('p-toggleswitch-sm')).toBe(false);
+            expect(fixture.nativeElement.classList.contains('p-inputfield-sm')).toBe(false);
+        });
+
         it('should handle inputId', () => {
             component.inputId = 'my-toggle-input';
             fixture.detectChanges();


### PR DESCRIPTION
## Summary
- apply small and large size classes from the ToggleSwitch size input
- add ToggleSwitch CSS rules for small and large dimensions
- add regression coverage for default, small, and large size classes

Fixes #86

## Test plan
- pnpm --filter @openng/optimus-ui test:unit --include=src/toggleswitch/toggleswitch.spec.ts
- pnpm --filter @openng/optimus-ui-styles build
- pnpm run build:lib