### PR TITLE
fix(autocomplete): use selected item template in single mode

### DIFF
--- a/packages/optimus-ui/src/autocomplete/autocomplete.spec.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.spec.ts
@@ -1068,6 +1068,22 @@ describe('AutoComplete', () => {
         });
 
         describe('Selected Item Template (_selectedItemTemplate)', () => {
+            it('should use pTemplate="selecteditem" as the input display value in single mode', async () => {
+                pTemplateComponent.multiple = false;
+                pTemplateFixture.detectChanges();
+                await pTemplateFixture.whenStable();
+
+                const autocompleteInstance = pTemplateFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+
+                autocompleteInstance.onOptionSelect(new Event('click'), mockCountries[0], false);
+                pTemplateFixture.detectChanges();
+                await pTemplateFixture.whenStable();
+
+                const inputElement = pTemplateFixture.debugElement.query(By.css('input')).nativeElement;
+
+                expect(inputElement.value).toBe('🏳️Afghanistan');
+            });
+
             it('should render pTemplate="selecteditem" with item context in multiple mode', async () => {
                 pTemplateComponent.multiple = true;
                 pTemplateComponent.selectedValue = [mockCountries[0]];

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -6,6 +6,7 @@ import {
     computed,
     ContentChild,
     ContentChildren,
+    EmbeddedViewRef,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -885,6 +886,8 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
 
     focusedOptionIndex = signal<number>(-1);
 
+    selectedItemTemplateLabel = signal<string | null>(null);
+
     _componentStyle = inject(AutoCompleteStyle);
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
@@ -899,6 +902,12 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
 
         if (isNotEmpty(modelValue)) {
             if (typeof modelValue === 'object' || this.optionValueSelected) {
+                const selectedItemTemplateLabel = this.selectedItemTemplateLabel();
+
+                if (selectedItemTemplateLabel) {
+                    return selectedItemTemplateLabel;
+                }
+
                 const label = this.getOptionLabel(selectedOption);
 
                 return label != null ? label : modelValue;
@@ -1661,6 +1670,7 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
         }
 
         this.value = value;
+        this.updateSelectedItemTemplateLabel(options);
         this.writeModelValue(options);
         this.onModelChange(value);
         this.updateInputValue();
@@ -1793,6 +1803,32 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
         return this.optionLabel ? resolveFieldData(option, this.optionLabel) : option && option.label != undefined ? option.label : option;
     }
 
+    getSelectedItemTemplateLabel(option: any) {
+        const template = this.selectedItemTemplate || this._selectedItemTemplate;
+
+        if (!template || option == null) {
+            return null;
+        }
+
+        const embeddedView: EmbeddedViewRef<AutoCompleteSelectedItemTemplateContext> = template.createEmbeddedView({ $implicit: option });
+
+        embeddedView.detectChanges();
+
+        const label = embeddedView.rootNodes
+            .map((node: Node) => node.textContent || '')
+            .join(' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+
+        embeddedView.destroy();
+
+        return label || null;
+    }
+
+    updateSelectedItemTemplateLabel(option: any) {
+        this.selectedItemTemplateLabel.set(!this.multiple ? this.getSelectedItemTemplateLabel(option) : null);
+    }
+
     getOptionValue(option) {
         return this.optionValue ? resolveFieldData(option, this.optionValue) : option && option.value != undefined ? option.value : option;
     }
@@ -1876,19 +1912,29 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
      * Writes the value to the control.
      */
     writeControlValue(value: any, setModelValue: (value: any) => void): void {
+        let resolvedValue = value;
+
         if (this.multiple) {
             const resolved = (value || []).map((val: any) => {
                 const match = this.visibleOptions().find((option: any) => equals(val, option, this.equalityKey()));
                 return match ?? val;
             });
-            setModelValue(isEmpty(value) ? value : resolved);
+            resolvedValue = isEmpty(value) ? value : resolved;
         } else {
             const option = this.visibleOptions().find((option: any) => equals(value, option, this.equalityKey()));
-            setModelValue(isEmpty(option) ? value : option);
+            resolvedValue = isEmpty(option) ? value : option;
         }
 
+        setModelValue(resolvedValue);
         this.value = value;
         this.updateInputValue();
+
+        queueMicrotask(() => {
+            this.updateSelectedItemTemplateLabel(resolvedValue);
+            this.updateInputValue();
+            this.cd.markForCheck();
+        });
+
         this.cd.markForCheck();
     }
 


### PR DESCRIPTION
## Summary
- use the selectedItem template text for the single-mode AutoComplete input display
- keep the existing optionLabel fallback when no selectedItem template is present
- add a regression test for selecting an item in single mode with pTemplate="selecteditem"

Fixes #938

## Test plan
- pnpm --filter @openng/optimus-ui test:unit --include=src/autocomplete/autocomplete.spec.ts --reporters=progress
- pnpm run build:lib