### PR TITLE
fix(breadcrumb): give the icon-only home link an accessible name

### DIFF
--- a/apps/docs/doc/breadcrumb/accessibility-doc.ts
+++ b/apps/docs/doc/breadcrumb/accessibility-doc.ts
@@ -1,15 +1,20 @@
 import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'accessibility-doc',
     standalone: true,
-    imports: [AppDocSectionText],
+    imports: [RouterModule, AppDocSectionText],
     template: ` <app-docsectiontext>
         <h3>Screen Reader</h3>
         <p>
             Breadcrumb uses the <i>nav</i> element and since any attribute is passed to the root implicitly <i>aria-labelledby</i> or <i>aria-label</i> can be used to describe the component. Inside an ordered list is used where the list item
             separators have <i>aria-hidden</i> to be able to ignored by the screen readers. If the last link represents the current route, <i>aria-current</i> is added with "page" as the value.
+        </p>
+        <p>
+            The home item renders an icon, so when it has no <i>label</i> the link is named with the <i>homeAriaLabel</i> property. When <i>homeAriaLabel</i> is not defined either, the <i>aria.home</i> key of the
+            <a routerLink="/configuration" fragment="locale">locale</a> configuration is used as the default.
         </p>
 
         <h3>Keyboard Support</h3>

--- a/apps/docs/doc/configuration/locale/apidoc.ts
+++ b/apps/docs/doc/configuration/locale/apidoc.ts
@@ -323,6 +323,10 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
                         <td>Navigation</td>
                     </tr>
                     <tr>
+                        <td>aria.home</td>
+                        <td>Home</td>
+                    </tr>
+                    <tr>
                         <td>aria.scrollTop</td>
                         <td>Scroll Top</td>
                     </tr>

--- a/packages/optimus-ui/src/api/translation.ts
+++ b/packages/optimus-ui/src/api/translation.ts
@@ -92,6 +92,7 @@ export interface Aria {
     previous?: string;
     next?: string;
     navigation?: string;
+    home?: string;
     scrollTop?: string;
     moveTop?: string;
     moveUp?: string;

--- a/packages/optimus-ui/src/breadcrumb/breadcrumb.spec.ts
+++ b/packages/optimus-ui/src/breadcrumb/breadcrumb.spec.ts
@@ -5,6 +5,7 @@ import { By } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MenuItem } from '@openng/optimus-ui/api';
+import { Optimus } from '@openng/optimus-ui/config';
 import { BreadcrumbItemClickEvent } from '@openng/optimus-ui/types/breadcrumb';
 import { Breadcrumb } from './breadcrumb';
 
@@ -826,6 +827,59 @@ describe('Breadcrumb', () => {
             } else {
                 expect(breadcrumbInstance.homeAriaLabel).toBe('Go to homepage');
             }
+        });
+
+        it('should label the icon only home link with the default aria.home translation', async () => {
+            component.home = { icon: 'pi pi-home' };
+            component.homeAriaLabel = undefined;
+            fixture.changeDetectorRef.markForCheck();
+
+            await fixture.whenStable();
+
+            fixture.detectChanges();
+
+            const homeLink = fixture.debugElement.query(By.css('[data-pc-section="homeitem"] a'));
+            expect(homeLink.nativeElement.getAttribute('aria-label')).toBe('Home');
+        });
+
+        it('should label the icon only home link with the configured aria.home translation', async () => {
+            TestBed.inject(Optimus).setTranslation({ aria: { home: 'Startseite' } });
+            component.home = { icon: 'pi pi-home' };
+            component.homeAriaLabel = undefined;
+            fixture.changeDetectorRef.markForCheck();
+
+            await fixture.whenStable();
+
+            fixture.detectChanges();
+
+            const homeLink = fixture.debugElement.query(By.css('[data-pc-section="homeitem"] a'));
+            expect(homeLink.nativeElement.getAttribute('aria-label')).toBe('Startseite');
+        });
+
+        it('should prefer homeAriaLabel over the aria.home translation', async () => {
+            component.home = { icon: 'pi pi-home' };
+            component.homeAriaLabel = 'Go to homepage';
+            fixture.changeDetectorRef.markForCheck();
+
+            await fixture.whenStable();
+
+            fixture.detectChanges();
+
+            const homeLink = fixture.debugElement.query(By.css('[data-pc-section="homeitem"] a'));
+            expect(homeLink.nativeElement.getAttribute('aria-label')).toBe('Go to homepage');
+        });
+
+        it('should not override a visible home label with the aria.home translation', async () => {
+            component.home = { icon: 'pi pi-home', label: 'Dashboard' };
+            component.homeAriaLabel = undefined;
+            fixture.changeDetectorRef.markForCheck();
+
+            await fixture.whenStable();
+
+            fixture.detectChanges();
+
+            const homeLink = fixture.debugElement.query(By.css('[data-pc-section="homeitem"] a'));
+            expect(homeLink.nativeElement.hasAttribute('aria-label')).toBe(false);
         });
 
         it('should handle tabindex for disabled items', async () => {

--- a/packages/optimus-ui/src/breadcrumb/breadcrumb.ts
+++ b/packages/optimus-ui/src/breadcrumb/breadcrumb.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ContentChild, ContentChildren, EventEmitter, inject, InjectionToken, Input, NgModule, Output, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, RouterModule } from '@angular/router';
-import { MenuItem, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
+import { MenuItem, PrimeTemplate, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { Badge } from '@openng/optimus-ui/badge';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
@@ -30,7 +30,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                         <a
                             [href]="home.url ? home.url : null"
                             *ngIf="!home.routerLink"
-                            [attr.aria-label]="homeAriaLabel"
+                            [attr.aria-label]="homeLinkAriaLabel"
                             [class]="cn(cx('itemLink'), home.linkClass)"
                             [ngStyle]="home.linkStyle"
                             (click)="onClick($event, home)"
@@ -52,7 +52,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                             *ngIf="home.routerLink"
                             [routerLink]="home.routerLink"
                             routerLinkActive="p-menuitem-link-active"
-                            [attr.aria-label]="homeAriaLabel"
+                            [attr.aria-label]="homeLinkAriaLabel"
                             [queryParams]="home.queryParams"
                             [routerLinkActiveOptions]="home.routerLinkActiveOptions || { exact: false }"
                             [class]="cn(cx('itemLink'), home.linkClass)"
@@ -195,7 +195,7 @@ export class Breadcrumb extends BaseComponent<BreadcrumbPassThrough> {
      */
     @Input() home: MenuItem | undefined;
     /**
-     * Defines a string that labels the home icon for accessibility.
+     * Defines a string that labels the home icon for accessibility. Defaults to the `aria.home` translation when the home item has no visible label.
      * @group Props
      */
     @Input() homeAriaLabel: string | undefined;
@@ -209,6 +209,15 @@ export class Breadcrumb extends BaseComponent<BreadcrumbPassThrough> {
     _componentStyle = inject(BreadCrumbStyle);
 
     router = inject(Router);
+
+    get homeLinkAriaLabel(): string | undefined {
+        if (this.homeAriaLabel) {
+            return this.homeAriaLabel;
+        }
+
+        // A visible label already names the link, so an aria-label would only override it.
+        return this.home?.label ? undefined : this.config.getTranslation(TranslationKeys.ARIA)?.home;
+    }
 
     onClick(event: MouseEvent, item: MenuItem) {
         if (item.disabled) {

--- a/packages/optimus-ui/src/config/optimus.ts
+++ b/packages/optimus-ui/src/config/optimus.ts
@@ -118,6 +118,7 @@ export class Optimus extends ThemeProvider {
             previous: 'Previous',
             next: 'Next',
             navigation: 'Navigation',
+            home: 'Home',
             scrollTop: 'Scroll Top',
             moveTop: 'Move Top',
             moveUp: 'Move Up',


### PR DESCRIPTION
## Defect Fix

Fixes #1403

## Problem

Breadcrumb always renders an icon for the home item (either `home.icon` or the built-in SVG), but `homeAriaLabel` had no default. `[attr.aria-label]="homeAriaLabel"` therefore resolved to `undefined` and the attribute was never rendered.

With the default icon-only pattern (`home = { icon: 'pi pi-home' }`, as used by the Basic demo) the link ends up with no accessible name:

- axe reports a `link-name` violation (WCAG 2.4.4 / 4.1.2)
- screen readers announce only "link"
- the accessibility tree shows `link ""`

## Solution

The home link now falls back to a new `aria.home` translation key (`"Home"` by default) instead of hardcoded English, so the label is localizable through the locale configuration, consistent with how the other components resolve their aria labels.

Precedence:

1. `homeAriaLabel` when provided — unchanged behaviour
2. otherwise the `aria.home` translation, but only when `home.label` is not set

The second condition matters: when the home item has a visible label, that label already names the link, and adding an `aria-label` would override it (WCAG 2.5.3 Label in Name). So the fallback only kicks in for the icon-only case that actually lacks a name.

## Changes

- `packages/optimus-ui/src/api/translation.ts` — add `home?: string` to the `Aria` interface
- `packages/optimus-ui/src/config/optimus.ts` — default `aria.home` to `'Home'`
- `packages/optimus-ui/src/breadcrumb/breadcrumb.ts` — resolve the home link's `aria-label` through a `homeLinkAriaLabel` getter (both the `href` and the `routerLink` anchor)
- `packages/optimus-ui/src/breadcrumb/breadcrumb.spec.ts` — tests for the default translation, a configured translation, `homeAriaLabel` precedence, and the visible-label case
- `apps/docs/doc/breadcrumb/accessibility-doc.ts` — document how the home link is named
- `apps/docs/doc/configuration/locale/apidoc.ts` — document the `aria.home` key

## Verification

`ng test optimus-ui --include='**/breadcrumb/*.spec.ts'` → 89/89 passing (4 new).
Prettier and lint clean on the touched files.

The generated API docs (`apps/docs/doc/apidoc/index.json`, `apps/docs/public/llms/**`, `apps/docs/api-generator/typedoc.json`) are left untouched since they are produced by `build:docs:content`.

## Breaking Changes

None. Consumers that already set `homeAriaLabel` or `home.label` are unaffected; only the previously unnamed icon-only link gains a name.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
