### PR TITLE
fix(treetable): sync frozen columns vertically when they arrive after init

### DIFF
--- a/packages/optimus-ui/src/treetable/treetable.spec.ts
+++ b/packages/optimus-ui/src/treetable/treetable.spec.ts
@@ -6,7 +6,7 @@ import { By } from '@angular/platform-browser';
 import { TreeNode } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { of } from 'rxjs';
-import { TreeTable, TreeTableModule } from './treetable';
+import { TreeTable, TreeTableModule, TTScrollableView } from './treetable';
 
 describe('TreeTable', () => {
     let component: TestBasicTreeTableComponent;
@@ -3846,5 +3846,142 @@ describe('TreeTable Inline PT', () => {
 
         const host = fixture.nativeElement.querySelector('p-treetable');
         expect(host?.classList.contains('INLINE_HOST_CLASS')).toBe(true);
+    });
+});
+
+// Case 13: frozen columns resolved after the scrollable views are initialized
+@Component({
+    standalone: false,
+    template: `
+        <p-treetable [value]="nodes" [columns]="scrollableCols" [frozenColumns]="frozenCols" [scrollable]="true" [virtualScroll]="virtualScroll" [virtualScrollItemSize]="34" scrollHeight="200px" frozenWidth="200px">
+            <ng-template #header let-columns>
+                <tr>
+                    <th *ngFor="let col of columns">{{ col.header }}</th>
+                </tr>
+            </ng-template>
+            <ng-template #body let-rowData="rowData" let-columns="columns">
+                <tr>
+                    <td *ngFor="let col of columns">{{ rowData[col.field] }}</td>
+                </tr>
+            </ng-template>
+        </p-treetable>
+    `
+})
+class TestAsyncFrozenColumnsComponent {
+    virtualScroll = true;
+
+    nodes: TreeNode[] = Array.from({ length: 50 }, (_, i) => ({
+        data: { name: `Row ${i}`, size: `${i}kb`, type: 'File' }
+    }));
+
+    frozenCols: any[] | null = null;
+
+    scrollableCols = [
+        { field: 'size', header: 'Size' },
+        { field: 'type', header: 'Type' }
+    ];
+}
+
+describe('TreeTable Frozen Columns Scroll Sync', () => {
+    let fixture: ComponentFixture<TestAsyncFrozenColumnsComponent>;
+
+    async function build(virtualScroll: boolean) {
+        await TestBed.configureTestingModule({
+            declarations: [TestAsyncFrozenColumnsComponent],
+            imports: [TreeTableModule],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestAsyncFrozenColumnsComponent);
+        fixture.componentInstance.virtualScroll = virtualScroll;
+        fixture.changeDetectorRef.markForCheck();
+        await fixture.whenStable();
+        fixture.detectChanges();
+    }
+
+    async function settle() {
+        fixture.changeDetectorRef.markForCheck();
+        await fixture.whenStable();
+        fixture.detectChanges();
+    }
+
+    function unfrozenView(): TTScrollableView {
+        return fixture.debugElement
+            .queryAll(By.directive(TTScrollableView))
+            .map((debugElement) => debugElement.componentInstance as TTScrollableView)
+            .find((view) => !view.frozen)!;
+    }
+
+    function frozenBodyElement(selector: string): Element | null {
+        return fixture.nativeElement.querySelector(`.p-treetable-frozen-view ${selector}`);
+    }
+
+    afterEach(() => TestBed.resetTestingModule());
+
+    it('should resolve the frozen sibling body when frozen columns arrive after init (virtual scroll)', async () => {
+        await build(true);
+
+        const unfrozen = unfrozenView();
+        expect(unfrozen.frozenSiblingBody).toBeFalsy();
+
+        fixture.componentInstance.frozenCols = [{ field: 'name', header: 'Name' }];
+        await settle();
+        await settle();
+
+        expect(unfrozenView().frozenSiblingBody).toBe(frozenBodyElement('[data-pc-name="virtualscroller"]')!);
+    });
+
+    it('should resolve the frozen sibling body when frozen columns arrive after init (without virtual scroll)', async () => {
+        await build(false);
+
+        fixture.componentInstance.frozenCols = [{ field: 'name', header: 'Name' }];
+        await settle();
+        await settle();
+
+        expect(unfrozenView().frozenSiblingBody).toBe(frozenBodyElement('[data-pc-section="scrollablebody"]')!);
+    });
+
+    it('should mark the sibling view as unfrozen once frozen columns arrive', async () => {
+        await build(true);
+
+        expect(fixture.nativeElement.querySelector('.p-treetable-unfrozen-view')).toBeNull();
+
+        fixture.componentInstance.frozenCols = [{ field: 'name', header: 'Name' }];
+        await settle();
+        await settle();
+
+        expect(fixture.nativeElement.querySelector('.p-treetable-unfrozen-view')).toBeTruthy();
+    });
+
+    it('should propagate the vertical scroll position to the frozen sibling body', async () => {
+        await build(true);
+
+        fixture.componentInstance.frozenCols = [{ field: 'name', header: 'Name' }];
+        await settle();
+        await settle();
+
+        const unfrozen = unfrozenView();
+        const frozenBody = { scrollTop: 0 } as unknown as Element;
+        unfrozen.frozenSiblingBody = frozenBody;
+
+        unfrozen.onBodyScroll({ target: { scrollTop: 340, scrollLeft: 0 } });
+
+        expect(frozenBody.scrollTop).toBe(340);
+    });
+
+    it('should release the frozen sibling body when frozen columns are removed', async () => {
+        await build(true);
+
+        fixture.componentInstance.frozenCols = [{ field: 'name', header: 'Name' }];
+        await settle();
+        await settle();
+        expect(unfrozenView().frozenSiblingBody).toBeTruthy();
+
+        fixture.componentInstance.frozenCols = null;
+        await settle();
+        await settle();
+
+        expect(unfrozenView().frozenSiblingBody).toBeNull();
+        expect(fixture.nativeElement.querySelector('.p-treetable-unfrozen-view')).toBeNull();
     });
 });

--- a/packages/optimus-ui/src/treetable/treetable.ts
+++ b/packages/optimus-ui/src/treetable/treetable.ts
@@ -2593,15 +2593,7 @@ export class TTScrollableView extends BaseComponent {
     onAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
             if (!this.frozen) {
-                if (this.tt.frozenColumns || this.tt.frozenBodyTemplate || this.tt._frozenBodyTemplate) {
-                    addClass(this.el.nativeElement, 'p-treetable-unfrozen-view');
-                }
-
-                let frozenView = this.el.nativeElement.previousElementSibling;
-                if (frozenView) {
-                    if (this.tt.virtualScroll) this.frozenSiblingBody = findSingle(frozenView, '[data-pc-name="virtualscroller"]');
-                    else this.frozenSiblingBody = findSingle(frozenView, '[data-pc-section="scrollablebody"]');
-                }
+                this.bindFrozenSiblingBody();
 
                 if (this.scrollHeight) {
                     let scrollBarWidth = calculateScrollbarWidth();
@@ -2621,6 +2613,36 @@ export class TTScrollableView extends BaseComponent {
 
             this.bindEvents();
         }
+    }
+
+    onAfterViewChecked() {
+        if (isPlatformBrowser(this.platformId) && !this.frozen) {
+            this.bindFrozenSiblingBody();
+        }
+    }
+
+    /**
+     * Resolves the scrollable body of the frozen sibling view, used to keep both views vertically in sync.
+     * The frozen view may only show up after this view is initialized, for instance when `frozenColumns` is
+     * bound to data that resolves asynchronously, so the lookup is repeated until a connected sibling is found.
+     */
+    bindFrozenSiblingBody() {
+        if (!this.tt.frozenColumns && !this.tt.frozenBodyTemplate && !this.tt._frozenBodyTemplate) {
+            removeClass(this.el.nativeElement, 'p-treetable-unfrozen-view');
+            this.frozenSiblingBody = null;
+            return;
+        }
+
+        addClass(this.el.nativeElement, 'p-treetable-unfrozen-view');
+
+        if (this.frozenSiblingBody?.isConnected) {
+            return;
+        }
+
+        const frozenView = this.el.nativeElement.previousElementSibling;
+        const selector = this.tt.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="scrollablebody"]';
+
+        this.frozenSiblingBody = frozenView ? findSingle(frozenView, selector) : null;
     }
 
     bindEvents() {


### PR DESCRIPTION
## Defect Fix

Fixes #942

## Problem

`TTScrollableView` resolved its frozen sibling exactly once, in `ngAfterViewInit`:

```ts
if (this.tt.frozenColumns || this.tt.frozenBodyTemplate || this.tt._frozenBodyTemplate) {
    addClass(this.el.nativeElement, 'p-treetable-unfrozen-view');
}

let frozenView = this.el.nativeElement.previousElementSibling;
if (frozenView) { /* ... findSingle ... */ }
```

The frozen view is rendered by `*ngIf="frozenColumns || frozenBodyTemplate || _frozenBodyTemplate"`. When none of those are set on the first render — the ordinary case of `frozenColumns` bound to data that resolves asynchronously — the frozen view does not exist yet, so the unfrozen view initializes with:

- `frozenSiblingBody` left `undefined`, and
- the `p-treetable-unfrozen-view` class never added.

Neither is ever re-evaluated once the frozen view appears, which leaves the component permanently in a broken state:

- **Vertical scrolling does not sync.** `onBodyScroll` guards on `if (this.frozenSiblingBody)`, so the frozen rows never follow the scrollable rows. Horizontal scrolling still works because it does not go through that reference — matching the report exactly.
- **The layout breaks.** `.p-treetable-unfrozen-view { position: absolute; top: 0; }` never applies, so the scrollable view stacks *below* the frozen view instead of beside it.

Measured on the docs demo with `frozenColumns` supplied asynchronously (Chrome, `virtualScroll` on, `scrollHeight="250px"`):

| | before | after |
|---|---|---|
| `unfrozen.scrollTop = 180` → `frozen.scrollTop` | `0` | `180` |
| `p-treetable-unfrozen-view` applied | no | yes |
| frozen / unfrozen view `top` | `195` / `484` (stacked) | equal (side by side) |

This also explains the workarounds in the issue thread: every one of them re-attaches the scroll listener from the consumer's own `ngAfterViewInit` / `ngAfterViewChecked`.

## Solution

Move the resolution into `bindFrozenSiblingBody()` and call it from `ngAfterViewChecked` as well as `ngAfterViewInit`, so a frozen view that appears later is picked up. The lookup short-circuits on `frozenSiblingBody?.isConnected`, so the steady state is a single property read per check — the `querySelector` only runs while the reference is missing or stale.

Removing the frozen columns again is handled symmetrically: the class is dropped and the reference released, so a view that stops being "unfrozen" does not keep a detached node alive.

The selector split between `[data-pc-name="virtualscroller"]` (virtual scroll) and `[data-pc-section="scrollablebody"]` is unchanged, and is now also re-evaluated if `virtualScroll` is toggled, since that swaps the body element out.

## Changes

- `packages/optimus-ui/src/treetable/treetable.ts` — extract `bindFrozenSiblingBody()`, call it from `ngAfterViewChecked`, release the reference and class when frozen columns are removed
- `packages/optimus-ui/src/treetable/treetable.spec.ts` — 5 tests covering late-arriving frozen columns (virtual and non-virtual), the unfrozen class, scroll propagation, and teardown

## Verification

`ng test optimus-ui --include='**/treetable/*.spec.ts'` → 179/179 passing (5 new). Full `optimus-ui` unit suite green.

Behaviour confirmed in Chrome against the docs TreeTable demo, before and after the change, for both `scrollHeight="250px"` and `scrollHeight="flex"`, with and without `virtualScroll`. The pre-existing synchronous case (frozen columns or a `#frozenbody` template available on first render) was already working and is unchanged.

## Breaking Changes

None.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
