### PR TITLE
fix(password): support mediumRegex/strongRegex on pPassword directive

### DIFF
--- a/packages/optimus-ui/src/password/password.spec.ts
+++ b/packages/optimus-ui/src/password/password.spec.ts
@@ -214,7 +214,9 @@ class TestPasswordRefTemplateComponent {
 
 @Component({
     standalone: false,
-    template: ` <input type="password" pPassword [(ngModel)]="value" [feedback]="feedback" [promptLabel]="promptLabel" [weakLabel]="weakLabel" [mediumLabel]="mediumLabel" [strongLabel]="strongLabel" /> `
+    template: `
+        <input type="password" pPassword [(ngModel)]="value" [feedback]="feedback" [promptLabel]="promptLabel" [weakLabel]="weakLabel" [mediumLabel]="mediumLabel" [strongLabel]="strongLabel" [mediumRegex]="mediumRegex" [strongRegex]="strongRegex" />
+    `
 })
 class TestPasswordDirectiveComponent {
     value: string | null = null as any;
@@ -223,6 +225,8 @@ class TestPasswordDirectiveComponent {
     weakLabel: string = 'Weak';
     mediumLabel: string = 'Medium';
     strongLabel: string = 'Strong';
+    mediumRegex: string = '^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})';
+    strongRegex: string = '^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})';
 }
 
 @Component({
@@ -1290,22 +1294,26 @@ describe('PasswordDirective', () => {
             expect(directive.mediumLabel).toBe('Medium');
             expect(directive.strongLabel).toBe('Strong');
             expect(directive.feedback).toBe(true);
+            expect(directive.mediumRegex).toContain('(?=.*[a-z])(?=.*[A-Z])');
+            expect(directive.strongRegex).toContain('(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])');
         });
     });
 
     describe('Password Strength Algorithm', () => {
-        it('should test strength correctly', () => {
+        it('should test strength correctly using the default medium/strong regex', () => {
             expect(directive.testStrength('')).toBe(0);
-            expect(directive.testStrength('a')).toBeGreaterThan(0);
-            expect(directive.testStrength('aA')).toBeGreaterThan(directive.testStrength('a'));
-            expect(directive.testStrength('aA1')).toBeGreaterThan(directive.testStrength('aA'));
-            expect(directive.testStrength('aA1!')).toBeGreaterThan(directive.testStrength('aA1'));
+            expect(directive.testStrength('abc')).toBe(1);
+            expect(directive.testStrength('abcDEF')).toBe(2);
+            expect(directive.testStrength('abcDEF123')).toBe(3);
         });
 
-        it('should normalize values correctly', () => {
-            expect(directive.normalize(1, 2)).toBe(0.5);
-            expect(directive.normalize(2, 2)).toBe(1);
-            expect(directive.normalize(3, 2)).toBeGreaterThan(1);
+        it('should respect custom mediumRegex and strongRegex inputs', () => {
+            directive.mediumRegex = '^(?=.{4,})';
+            directive.strongRegex = '^(?=.{8,})';
+
+            expect(directive.testStrength('abc')).toBe(1);
+            expect(directive.testStrength('abcd')).toBe(2);
+            expect(directive.testStrength('abcdefgh')).toBe(3);
         });
     });
 

--- a/packages/optimus-ui/src/password/password.ts
+++ b/packages/optimus-ui/src/password/password.ts
@@ -110,6 +110,16 @@ export class PasswordDirective extends BaseEditableHolder {
      */
     @Input() strongLabel: string = 'Strong';
     /**
+     * Regex value for medium regex.
+     * @group Props
+     */
+    @Input() mediumRegex: string = '^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})';
+    /**
+     * Regex value for strong regex.
+     * @group Props
+     */
+    @Input() strongRegex: string = '^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})';
+    /**
      * Whether to show the strength indicator or not.
      * @group Props
      */
@@ -272,15 +282,15 @@ export class PasswordDirective extends BaseEditableHolder {
                 label = this.promptLabel;
                 meterPos = '0px 0px';
             } else {
-                var score = this.testStrength(value);
+                var level = this.testStrength(value);
 
-                if (score < 30) {
+                if (level === 1) {
                     label = this.weakLabel;
                     meterPos = '0px -10px';
-                } else if (score >= 30 && score < 80) {
+                } else if (level === 2) {
                     label = this.mediumLabel;
                     meterPos = '0px -20px';
-                } else if (score >= 80) {
+                } else if (level === 3) {
                     label = this.strongLabel;
                     meterPos = '0px -30px';
                 }
@@ -324,31 +334,13 @@ export class PasswordDirective extends BaseEditableHolder {
     }
 
     testStrength(str: string) {
-        let grade: number = 0;
-        let val: Nullable<RegExpMatchArray>;
+        let level = 0;
 
-        val = str.match('[0-9]');
-        grade += this.normalize(val ? val.length : 1 / 4, 1) * 25;
+        if (new RegExp(this.strongRegex).test(str)) level = 3;
+        else if (new RegExp(this.mediumRegex).test(str)) level = 2;
+        else if (str.length) level = 1;
 
-        val = str.match('[a-zA-Z]');
-        grade += this.normalize(val ? val.length : 1 / 2, 3) * 10;
-
-        val = str.match('[!@#$%^&*?_~.,;=]');
-        grade += this.normalize(val ? val.length : 1 / 6, 1) * 35;
-
-        val = str.match('[A-Z]');
-        grade += this.normalize(val ? val.length : 1 / 6, 1) * 30;
-
-        grade *= str.length / 8;
-
-        return grade > 100 ? 100 : grade;
-    }
-
-    normalize(x: number, y: number) {
-        let diff = x - y;
-
-        if (diff <= 0) return x / y;
-        else return 1 + 0.5 * (x / (x + y / 4));
+        return level;
     }
 
     bindScrollListener() {


### PR DESCRIPTION
## Summary
- `pPassword` directive used its own hardcoded scoring algorithm for password strength, unlike `p-password` which exposes `mediumRegex`/`strongRegex` inputs to control the weak/medium/strong thresholds.
- Adds `mediumRegex`/`strongRegex` `@Input()`s to `PasswordDirective` (same defaults as the `Password` component) and switches `testStrength()`/`onKeyup()` to the same regex-based level detection used by the component, so both now behave identically and are equally configurable.

Fixes #953

## Test plan
- [x] `ng test optimus-ui --include='**/password/password.spec.ts'` — 138/138 passing (updated directive tests to cover default and custom `mediumRegex`/`strongRegex`)
- [x] Manually verified in a running app: with `mediumRegex="^(?=.{4,})"` and `strongRegex="^(?=.{8,})"` bound on `pPassword`, typing 2/4/8 characters correctly shows Weak/Medium/Strong

![Strong password state driven by custom strongRegex](https://raw.githubusercontent.com/rene-schakmann/optimus-ui/assets/issue-953-screenshot/.github/issue-assets/issue-953-password-directive-strong.png)

---
Drafted with assistance from [Claude Code](https://claude.com/claude-code).
