### PR TITLE
fix(schematics): rename stylesheet @layer declarations alongside the …

### DIFF
--- a/packages/optimus-ui/schematics/migrate-from-primeng/index.ts
+++ b/packages/optimus-ui/schematics/migrate-from-primeng/index.ts
@@ -3,7 +3,7 @@ import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import { createIgnoreMatcher, IgnoreMatcher } from '../utils/gitignore';
 import { mapAssetReference, SPECIFIER_RENAMES } from '../utils/mappings';
 import { findPrimengMajor, SKIP_DIRS, swapDependencies } from '../utils/package-json';
-import { rewriteSource } from '../utils/rewrite';
+import { renameStylesheetLayers, rewriteSource } from '../utils/rewrite';
 import { Schema } from './schema';
 
 const REPORT_EXTENSIONS = ['.ts', '.mts', '.js', '.mjs', '.html', '.scss', '.css', '.sass', '.less', '.json', '.md'];
@@ -53,15 +53,22 @@ export function migrateFromPrimeng(options: Schema): Rule {
         for (const path of packageJsonPaths) {
             migratePackageJson(tree, context, path);
         }
+        // Layer tokens renamed inside cssLayer name/order strings (e.g. primeng-overwrites →
+        // optimus-overwrites), collected across all sources so the matching `@layer` declarations
+        // in stylesheets can be renamed to keep following the configured order.
+        const layerRenames = new Map<string, string>();
         for (const path of sourcePaths) {
             const original = tree.read(path)!.toString();
-            const { text, changed } = rewriteSource(path, original);
+            const { text, changed, layerRenames: fileLayerRenames } = rewriteSource(path, original);
+            for (const [from, to] of fileLayerRenames) {
+                layerRenames.set(from, to);
+            }
             if (changed) {
                 tree.overwrite(path, text);
             }
         }
         for (const path of assetReferencePaths) {
-            migrateAssetReferences(tree, path);
+            migrateAssetReferences(tree, path, layerRenames);
         }
 
         reportLeftovers(tree, context, isIgnored);
@@ -98,7 +105,7 @@ function migratePackageJson(tree: Tree, context: SchematicContext, path: string)
     context.logger.info(`${path}: replaced ${result.removed.join(', ')} with ${result.added.join(', ')}`);
 }
 
-function migrateAssetReferences(tree: Tree, path: string): void {
+function migrateAssetReferences(tree: Tree, path: string, layerRenames: ReadonlyMap<string, string>): void {
     let text = tree.read(path)!.toString();
     let changed = false;
     for (const [from, to] of SPECIFIER_RENAMES) {
@@ -120,6 +127,11 @@ function migrateAssetReferences(tree: Tree, path: string): void {
     } else {
         text = text.replace(STYLE_AT_RULE_RE, (match, rule: string, quote: string, value: string) => rewrite(value, (mapped) => `${rule}${quote}${mapped}${quote}`, match));
         text = text.replace(URL_REFERENCE_RE, (match, quote: string, value: string) => rewrite(value, (mapped) => `url(${quote}${mapped}${quote})`, match));
+        const layered = renameStylesheetLayers(text, layerRenames);
+        if (layered.changed) {
+            text = layered.text;
+            changed = true;
+        }
     }
     if (changed) {
         tree.overwrite(path, text);

--- a/packages/optimus-ui/schematics/test/migrate-from-primeng.spec.ts
+++ b/packages/optimus-ui/schematics/test/migrate-from-primeng.spec.ts
@@ -119,6 +119,33 @@ describe('migrate-from-primeng', () => {
         expect(appConfig).not.toContain('primeng');
     });
 
+    it('renames @layer declarations in stylesheets to match the rewritten cssLayer config', async () => {
+        const runner = createRunner();
+        const tree = primengTree({
+            '/src/app/app.config.ts':
+                `import { ApplicationConfig } from '@angular/core';\n` +
+                `import { providePrimeNG } from 'primeng/config';\n` +
+                `import Aura from '@primeuix/themes/aura';\n\n` +
+                `export const appConfig: ApplicationConfig = {\n` +
+                `    providers: [providePrimeNG({ theme: { preset: Aura, options: { cssLayer: { name: 'primeng', order: 'theme, base, primeng, primeng-overwrites' } } } })]\n` +
+                `};\n`,
+            '/src/primeng-overwrites.scss': `@layer primeng-overwrites {\n    .p-button { margin: 0; }\n}\n`,
+            '/src/styles.scss': `@layer theme, base, primeng, primeng-overwrites;\n@import url(overrides.css) layer(primeng);\n`
+        });
+        const result = await runner.runSchematic('migrate-from-primeng', { skipInstall: true }, tree);
+
+        expect(result.readContent('/src/app/app.config.ts')).toContain(`cssLayer: { name: 'optimus', order: 'theme, base, optimus, optimus-overwrites' }`);
+        expect(result.readContent('/src/primeng-overwrites.scss')).toBe(`@layer optimus-overwrites {\n    .p-button { margin: 0; }\n}\n`);
+        expect(result.readContent('/src/styles.scss')).toBe(`@layer theme, base, optimus, optimus-overwrites;\n@import url(overrides.css) layer(optimus);\n`);
+    });
+
+    it('leaves stylesheet @layer declarations alone when no cssLayer config was rewritten', async () => {
+        const runner = createRunner();
+        const styles = `@layer theme, app;\n@layer app {\n    .btn { color: red; }\n}\n`;
+        const result = await runner.runSchematic('migrate-from-primeng', { skipInstall: true }, primengTree({ '/src/styles.scss': styles }));
+        expect(result.readContent('/src/styles.scss')).toBe(styles);
+    });
+
     it('migrates primeicons: dependency, stylesheet imports, and angular.json styles', async () => {
         const runner = createRunner();
         const tree = primengTree(

--- a/packages/optimus-ui/schematics/utils/rewrite.spec.ts
+++ b/packages/optimus-ui/schematics/utils/rewrite.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { rewriteSource } from './rewrite';
+import { renameStylesheetLayers, rewriteSource } from './rewrite';
 
 const rw = (text: string) => rewriteSource('/src/test.ts', text);
 
@@ -167,5 +167,65 @@ describe('rewriteSource — cssLayer names', () => {
         const input = `const c = { cssLayer: true };\n`;
         const { changed } = rw(input);
         expect(changed).toBe(false);
+    });
+
+    it('rewrites custom layer names carrying the primeng token, like primeng-overwrites', () => {
+        const { text } = rw(`const c = { cssLayer: { name: 'primeng', order: 'theme, base, primeng, primeng-overwrites' } };\n`);
+        expect(text).toContain(`order: 'theme, base, optimus, optimus-overwrites'`);
+    });
+
+    it('collects the renamed layer tokens for the stylesheet pass', () => {
+        const { layerRenames } = rw(`const c = { cssLayer: { name: 'primeng', order: 'theme, base, primeng, primeng-overwrites' } };\n`);
+        expect(layerRenames.get('primeng')).toBe('optimus');
+        expect(layerRenames.get('primeng-overwrites')).toBe('optimus-overwrites');
+        expect(layerRenames.size).toBe(2);
+    });
+
+    it('collects no layer renames when cssLayer holds no primeng token', () => {
+        const { layerRenames } = rw(`const c = { cssLayer: { name: 'app', order: 'theme, app' } };\n`);
+        expect(layerRenames.size).toBe(0);
+    });
+});
+
+describe('renameStylesheetLayers', () => {
+    const RENAMES = new Map([
+        ['primeng', 'optimus'],
+        ['primeng-overwrites', 'optimus-overwrites']
+    ]);
+
+    it('renames a renamed layer in an @layer block declaration', () => {
+        const { text, changed } = renameStylesheetLayers(`@layer primeng-overwrites {\n    .btn { color: red; }\n}\n`, RENAMES);
+        expect(changed).toBe(true);
+        expect(text).toBe(`@layer optimus-overwrites {\n    .btn { color: red; }\n}\n`);
+    });
+
+    it('renames layers in an @layer ordering statement', () => {
+        const { text } = renameStylesheetLayers(`@layer theme, base, primeng, primeng-overwrites;\n`, RENAMES);
+        expect(text).toBe(`@layer theme, base, optimus, optimus-overwrites;\n`);
+    });
+
+    it('renames the layer of an @import ... layer(...) clause', () => {
+        const { text } = renameStylesheetLayers(`@import url(theme.css) layer(primeng);\n`, RENAMES);
+        expect(text).toBe(`@import url(theme.css) layer(optimus);\n`);
+    });
+
+    it('does not rename the primeng token inside a longer layer name without its own rename', () => {
+        const { text, changed } = renameStylesheetLayers(`@layer primeng-extras;\n`, new Map([['primeng', 'optimus']]));
+        expect(changed).toBe(false);
+        expect(text).toBe(`@layer primeng-extras;\n`);
+    });
+
+    it('leaves matching tokens outside @layer and layer() contexts alone', () => {
+        const input = `.primeng-overwrites { color: red; }\n/* primeng */\n.a { content: 'primeng'; }\n`;
+        const { text, changed } = renameStylesheetLayers(input, RENAMES);
+        expect(changed).toBe(false);
+        expect(text).toBe(input);
+    });
+
+    it('is a no-op when there are no renames', () => {
+        const input = `@layer primeng { .btn { color: red; } }\n`;
+        const { text, changed } = renameStylesheetLayers(input, new Map());
+        expect(changed).toBe(false);
+        expect(text).toBe(input);
     });
 });

--- a/packages/optimus-ui/schematics/utils/rewrite.ts
+++ b/packages/optimus-ui/schematics/utils/rewrite.ts
@@ -7,9 +7,22 @@ interface Edit {
     replacement: string;
 }
 
-export function rewriteSource(fileName: string, text: string): { text: string; changed: boolean } {
+export interface RewriteResult {
+    text: string;
+    changed: boolean;
+    /**
+     * CSS cascade layer tokens renamed inside cssLayer name/order strings (old name → new name),
+     * e.g. `primeng` → `optimus` and `primeng-overwrites` → `optimus-overwrites`. The caller uses
+     * these to rename the matching `@layer` declarations in stylesheets, which would otherwise
+     * silently detach from the configured layer order.
+     */
+    layerRenames: Map<string, string>;
+}
+
+export function rewriteSource(fileName: string, text: string): RewriteResult {
     const sourceFile = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
     const edits: Edit[] = [];
+    const layerRenames = new Map<string, string>();
     // local names (imported un-aliased from a primeng module) whose usages must be renamed file-wide
     const renamedLocals = new Map<string, string>();
     // names already declared in the file (vars, destructured bindings, params, functions/classes/etc.) —
@@ -87,17 +100,17 @@ export function rewriteSource(fileName: string, text: string): { text: string; c
         visitUsages(sourceFile);
     }
 
-    rewriteCssLayerNames(sourceFile, text, edits);
+    rewriteCssLayerNames(sourceFile, text, edits, layerRenames);
 
     if (edits.length === 0) {
-        return { text, changed: false };
+        return { text, changed: false, layerRenames };
     }
     edits.sort((a, b) => b.start - a.start);
     let result = text;
     for (const edit of edits) {
         result = result.slice(0, edit.start) + edit.replacement + result.slice(edit.end);
     }
-    return { text: result, changed: true };
+    return { text: result, changed: true, layerRenames };
 }
 
 // Collects identifier names that are declaration names anywhere in the file (variables,
@@ -181,7 +194,7 @@ function usageReplacement(node: ts.Identifier, newName: string): string | null {
 //   cssLayer: { name: 'primeng', order: 'theme, base, primeng' }
 const CSS_LAYER_TOKEN_RE = /\bprimeng\b/g;
 
-function rewriteCssLayerNames(sourceFile: ts.SourceFile, text: string, edits: Edit[]): void {
+function rewriteCssLayerNames(sourceFile: ts.SourceFile, text: string, edits: Edit[], layerRenames: Map<string, string>): void {
     const visit = (node: ts.Node): void => {
         if (ts.isPropertyAssignment(node) && propertyKeyText(node.name) === 'cssLayer' && ts.isObjectLiteralExpression(node.initializer)) {
             for (const prop of node.initializer.properties) {
@@ -197,6 +210,16 @@ function rewriteCssLayerNames(sourceFile: ts.SourceFile, text: string, edits: Ed
                 if (replaced === literal.text) {
                     continue;
                 }
+                // Record every layer token this edit renames (`order` is a comma-separated list,
+                // `name` a single layer) so the matching `@layer` declarations in stylesheets can
+                // be renamed too — see renameStylesheetLayers.
+                for (const token of literal.text.split(',')) {
+                    const from = token.trim();
+                    const to = from.replace(CSS_LAYER_TOKEN_RE, 'optimus');
+                    if (from.length > 0 && to !== from) {
+                        layerRenames.set(from, to);
+                    }
+                }
                 const quote = text[literal.getStart(sourceFile)];
                 edits.push({ start: literal.getStart(sourceFile), end: literal.getEnd(), replacement: `${quote}${replaced}${quote}` });
             }
@@ -204,6 +227,47 @@ function rewriteCssLayerNames(sourceFile: ts.SourceFile, text: string, edits: Ed
         ts.forEachChild(node, visit);
     };
     visit(sourceFile);
+}
+
+// `@layer` at-rule preludes — both the ordering statement (`@layer a, b;`) and the block form
+// (`@layer name { ... }`). The prelude runs until the `{` or `;`, which is left in place.
+const LAYER_AT_RULE_RE = /(@layer\b)([^{;}]*)(?=[{;])/g;
+// The `layer(name)` function of `@import url(...) layer(name);`. The bare `layer` keyword
+// (anonymous layer) has no name to rename.
+const LAYER_FUNCTION_RE = /(\blayer\(\s*)([^)]*)(?=\))/g;
+
+/**
+ * Renames CSS cascade layer tokens in the `@layer` preludes and `@import ... layer(...)` clauses
+ * of a stylesheet, using the renames collected from cssLayer name/order strings by rewriteSource.
+ * Keeps user stylesheets in sync with the rewritten theme config: a `@layer primeng-overwrites`
+ * declaration must follow its `order: '..., primeng-overwrites'` entry when the latter becomes
+ * `optimus-overwrites`, or the layer silently drops out of the configured order.
+ */
+export function renameStylesheetLayers(text: string, renames: ReadonlyMap<string, string>): { text: string; changed: boolean } {
+    if (renames.size === 0) {
+        return { text, changed: false };
+    }
+    let changed = false;
+    const renameTokens = (segment: string): string => {
+        let result = segment;
+        for (const [from, to] of renames) {
+            // Custom boundaries treating `-` as part of the layer name: the `primeng` rename must
+            // not match inside `primeng-overwrites` (which has its own rename entry).
+            const tokenRe = new RegExp(`(?<![\\w-])${escapeRegExp(from)}(?![\\w-])`, 'g');
+            const next = result.replace(tokenRe, to);
+            if (next !== result) {
+                changed = true;
+                result = next;
+            }
+        }
+        return result;
+    };
+    const rewritten = text.replace(LAYER_AT_RULE_RE, (_match, atRule: string, names: string) => `${atRule}${renameTokens(names)}`).replace(LAYER_FUNCTION_RE, (_match, fn: string, names: string) => `${fn}${renameTokens(names)}`);
+    return { text: rewritten, changed };
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // The text of an object-literal property key when it is a plain identifier or string literal

--- a/packages/optimus-ui/schematics/utils/rewrite.ts
+++ b/packages/optimus-ui/schematics/utils/rewrite.ts
@@ -234,7 +234,7 @@ function rewriteCssLayerNames(sourceFile: ts.SourceFile, text: string, edits: Ed
 const LAYER_AT_RULE_RE = /(@layer\b)([^{;}]*)(?=[{;])/g;
 // The `layer(name)` function of `@import url(...) layer(name);`. The bare `layer` keyword
 // (anonymous layer) has no name to rename.
-const LAYER_FUNCTION_RE = /(\blayer\(\s*)([^)]*)(?=\))/g;
+const LAYER_FUNCTION_RE = /(@import\b[^;{]*?\blayer\(\s*)([^)]*)(?=\))/g;
 
 /**
  * Renames CSS cascade layer tokens in the `@layer` preludes and `@import ... layer(...)` clauses


### PR DESCRIPTION
…cssLayer config

The migration rewrites primeng layer tokens in the theme's cssLayer name/order strings, including custom names like primeng-overwrites, but left the matching @layer declarations in stylesheets untouched — the renamed order entry then no longer referenced the user's layer.

rewriteSource now collects the layer tokens it renames, and the stylesheet pass renames those tokens in @layer preludes and @import ... layer(...) clauses, leaving unrelated selectors and strings alone.

Closes the report in discussion #1414 (discussioncomment-17823918).

## Description

<!-- What changed and why? For bug fixes, describe before/after behavior. -->

## Related issues

<!-- Link issues this PR addresses, e.g. Fixes #123, Closes #456, or Relates to #789 -->

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

<!-- If this is a breaking change, describe what changed and how consumers should migrate. Otherwise, write "None". -->

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->
