### PR TITLE
fix(autocomplete): fix autocomplete with objects containing value pro…

### DIFF
--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -1794,7 +1794,7 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
     }
 
     getOptionValue(option) {
-        return this.optionValue ? resolveFieldData(option, this.optionValue) : option && option.value != undefined ? option.value : option;
+        return this.optionValue ? resolveFieldData(option, this.optionValue) : option;
     }
 
     getOptionIndex(index, scrollerOptions) {


### PR DESCRIPTION
fix issue https://github.com/primefaces/primeng/issues/17469 "Autocomplete doesn't work as expected when working with Objects if the Object contains key named value"

## Description

When suggestions contanis a list of objects and the objects contained a property named `value`. i.e. `[{display:'one', value: 1}, {display: 'two', value: 2}]`, selecting the first value would result in the ngmodel containing only `1`, instead of `{display:'one', value: 1}`. Changing value to let's say `code` puts the object into the ngModel after selecting an option.

This behaviour is fixed by this PR.

NOTE: If you WANT to only have the value in the ngModel this still works by providing the attribute `optionValue="value"` in the html template to the p-autocomplete element.

## Related issues

https://github.com/primefaces/primeng/issues/17469 (for some reason i do not understand this issue did not get migrated to the new repo)

Fixes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

Breaking only in case of extreme edge case. Not sure weather to put breaking change or none breaking change. this behaviour used to be working in older versions of primeng.

## Breaking changes

if you actually only want the value property inside the ngmodel provide `optionValue="value"` like you would have to do for any other object-property other than `value`.

None

## Test plan

manual testing plus `pnpm run test:unit`

## Checklist

- [ x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x ] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)
