### PR TITLE
fix(tooltip): reset escaped content without innerHTML

### DIFF
--- a/packages/optimus-ui/src/tooltip/tooltip.test.ts
+++ b/packages/optimus-ui/src/tooltip/tooltip.test.ts
@@ -486,6 +486,30 @@ describe('Tooltip', () => {
             expect(document.createTextNode).toHaveBeenCalledWith('Test content');
         });
 
+        it('should reset previous content without assigning innerHTML when escape is true', async () => {
+            const tooltipText = document.createElement('div');
+            tooltipText.appendChild(document.createTextNode('Previous content'));
+            Object.defineProperty(tooltipText, 'innerHTML', {
+                configurable: true,
+                get: () => '',
+                set: () => {
+                    // Mimics a Trusted Types enabled document rejecting plain string assignments
+                    throw new TypeError("Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment.");
+                }
+            });
+
+            tooltipDirective.tooltipText = tooltipText;
+            tooltipDirective.setOption({ escape: true });
+            tooltipDirective.setOption({ tooltipLabel: 'New content' });
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(() => tooltipDirective.updateText()).not.toThrow();
+            expect(tooltipText.childNodes.length).toBe(1);
+            expect(tooltipText.textContent).toBe('New content');
+        });
+
         it('should handle HTML content when escape is false', async () => {
             tooltipDirective.tooltipText = document.createElement('div');
             tooltipDirective.setOption({ escape: false });

--- a/packages/optimus-ui/src/tooltip/tooltip.ts
+++ b/packages/optimus-ui/src/tooltip/tooltip.ts
@@ -588,7 +588,7 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
             embeddedViewRef.detectChanges();
             embeddedViewRef.rootNodes.forEach((node) => this.tooltipText.appendChild(node));
         } else if (this.getOption('escape')) {
-            this.tooltipText.innerHTML = '';
+            this.tooltipText.textContent = '';
             this.tooltipText.appendChild(document.createTextNode(content));
         } else {
             this.tooltipText.innerHTML = content;


### PR DESCRIPTION
Fixes #223

## Problem

With a Trusted Types CSP (`require-trusted-types-for 'script'`), showing a tooltip throws:

> Uncaught TypeError: Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment.

`Tooltip.updateText()` assigned an empty string to `innerHTML` purely to clear previously rendered text before appending the escaped text node. Trusted Types rejects any plain-string `innerHTML` assignment, including the empty one.

## Change

Clear the tooltip text with `textContent = ''` instead. Same effect (removes all child nodes), no Trusted Types violation.

The `escape: false` branch still assigns `innerHTML` — that path intentionally renders HTML and is out of scope here.

## Test

Added a unit test that makes `innerHTML` throw on the tooltip text element (mimicking a Trusted Types document) and asserts `updateText()` still replaces the previous content.

`ng test optimus-ui --include='**/tooltip/tooltip.spec.ts'` → 45/45 passing.