### PR TITLE
fix(treeselect): emit onFilter when the user types in the filter input

### DIFF
--- a/packages/optimus-ui/src/treeselect/treeselect.spec.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.spec.ts
@@ -1294,6 +1294,34 @@ describe('TreeSelect', () => {
             expect(treeSelectInstance.filterMode).toBe('lenient');
         });
 
+        it('should emit onFilter and update filteredNodes when the user types in the filter input', async () => {
+            testComponent.filter = true;
+            testComponent.filterBy = 'label';
+            testComponent.filterMode = 'lenient';
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const dropdown = testFixture.debugElement.query(By.css('.p-treeselect-dropdown'));
+            dropdown.nativeElement.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const filterInput = testFixture.debugElement.query(By.css('input[type="search"]'));
+            filterInput.nativeElement.value = 'Work';
+            filterInput.nativeElement.dispatchEvent(new Event('input'));
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            expect(testComponent.filterEvent).not.toBeNull();
+            expect(testComponent.filterEvent.filter).toBe('Work');
+
+            const treeSelectInstance = testFixture.debugElement.query(By.directive(TreeSelect)).componentInstance;
+            expect(treeSelectInstance.filterValue).toBe('Work');
+            expect(treeSelectInstance.filteredNodes).toEqual(testComponent.filterEvent.filteredValue);
+        });
+
         it('should handle empty state properly', async () => {
             testComponent.options = [];
             testComponent.emptyMessage = 'No nodes available';

--- a/packages/optimus-ui/src/treeselect/treeselect.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.ts
@@ -165,6 +165,7 @@ const TREESELECT_INSTANCE = new InjectionToken<TreeSelect>('TREESELECT_INSTANCE'
                             [filterPlaceholder]="filterPlaceholder"
                             [filterLocale]="filterLocale"
                             [filteredNodes]="filteredNodes"
+                            (onFilter)="onFilterInput($event)"
                             [virtualScroll]="virtualScroll"
                             [virtualScrollItemSize]="virtualScrollItemSize"
                             [virtualScrollOptions]="virtualScrollOptions"
@@ -820,13 +821,10 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
         }
     }
 
-    onFilterInput(event: Event) {
-        this.filterValue = (event.target as HTMLInputElement).value;
-        this.treeViewChild?._filter(this.filterValue);
-        this.onFilter.emit({
-            filter: this.filterValue,
-            filteredValue: this.treeViewChild?.filteredNodes
-        });
+    onFilterInput(event: TreeFilterEvent) {
+        this.filterValue = event.filter;
+        this.filteredNodes = event.filteredValue;
+        this.onFilter.emit(event);
         setTimeout(() => {
             this.overlayViewChild?.alignOverlay();
         });


### PR DESCRIPTION
## Description

`p-treeSelect`'s `onFilter` output was never emitted: the component's own `onFilterInput` method was dead code, since the filter `<input>` is actually rendered inside the internal `p-tree` (which has its own `onFilter` output that nothing was listening to).
This fix wires `(onFilter)="onFilterInput($event)"` on the internal `<p-tree>`, and updates `onFilterInput` to accept the `TreeFilterEvent` emitted by `p-tree`, sync `filterValue`/`filteredNodes`, and re-emit it as `TreeSelect`'s own `onFilter` event.
**Before:** typing in the filter box never fired `onFilter` on `p-treeSelect`.
**After:** `onFilter` fires with the current `filter` value and `filteredValue`, as documented.

## Related issues

Fixes #256

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [ ] `npm run build`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Multiple users confirmed the same root cause and workaround in the issue comments (subscribing to the internal `p-tree`'s `onFilter` and relaying it manually), this PR implements the equivalent fix directly in `TreeSelect`.
