### PR TITLE
fix(table): guard row grouping against an empty sort meta array

### DIFF
--- a/packages/optimus-ui/src/table/table.spec.ts
+++ b/packages/optimus-ui/src/table/table.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
-import { SharedModule } from '@openng/optimus-ui/api';
+import { SharedModule, SortMeta } from '@openng/optimus-ui/api';
 import { Select } from '@openng/optimus-ui/select';
 import { Table, TableModule, TableService } from './table';
 
@@ -115,6 +115,28 @@ describe('Table', () => {
             { id: '1002', name: 'Wireless Mouse', price: 29.99, category: 'Accessories' },
             { id: '1003', name: 'Mechanical Keyboard', price: 149.99, category: 'Accessories' }
         ];
+    }
+
+    @Component({
+        standalone: false,
+        template: `
+            <p-table [value]="products" [sortMode]="'multiple'" [multiSortMeta]="multiSortMeta" [groupRowsBy]="'category'">
+                <ng-template #body let-product>
+                    <tr>
+                        <td>{{ product.name }}</td>
+                        <td>{{ product.category }}</td>
+                    </tr>
+                </ng-template>
+            </p-table>
+        `
+    })
+    class TestGroupedSortingTableComponent {
+        products = [
+            { id: '1001', name: 'Gaming Laptop', price: 1299.99, category: 'Electronics' },
+            { id: '1002', name: 'Wireless Mouse', price: 29.99, category: 'Accessories' },
+            { id: '1003', name: 'Mechanical Keyboard', price: 149.99, category: 'Accessories' }
+        ];
+        multiSortMeta: SortMeta[] = [];
     }
 
     @Component({
@@ -264,7 +286,17 @@ describe('Table', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [Table, TestBasicTableComponent, TestSelectionTableComponent, TestSortingTableComponent, TestFilteringTableComponent, TestVirtualScrollTableComponent, TestLazyLoadTableComponent, TestTemplatesTableComponent],
+            declarations: [
+                Table,
+                TestBasicTableComponent,
+                TestSelectionTableComponent,
+                TestSortingTableComponent,
+                TestGroupedSortingTableComponent,
+                TestFilteringTableComponent,
+                TestVirtualScrollTableComponent,
+                TestLazyLoadTableComponent,
+                TestTemplatesTableComponent
+            ],
             imports: [CommonModule, FormsModule, TableModule, SharedModule, Select],
             providers: [TableService, provideZonelessChangeDetection()]
         }).compileComponents();
@@ -362,6 +394,43 @@ describe('Table', () => {
         it('should have sortable columns', () => {
             const sortableColumns = testFixture.debugElement.queryAll(By.css('[pSortableColumn]'));
             expect(sortableColumns.length).toBe(3);
+        });
+
+        describe('Row Grouping With An Empty multiSortMeta', () => {
+            let groupedComponent: TestGroupedSortingTableComponent;
+            let groupedFixture: ComponentFixture<TestGroupedSortingTableComponent>;
+
+            const createGroupedFixture = async () => {
+                groupedFixture = TestBed.createComponent(TestGroupedSortingTableComponent);
+                groupedComponent = groupedFixture.componentInstance;
+                await groupedFixture.whenStable();
+                groupedFixture.detectChanges();
+            };
+
+            it('should not throw when multiSortMeta starts out as an empty array', async () => {
+                await expectAsync(createGroupedFixture()).toBeResolved();
+            });
+
+            it('should sort by the grouped field when multiSortMeta is empty', async () => {
+                await createGroupedFixture();
+
+                const tableInstance: Table = groupedFixture.debugElement.query(By.css('p-table')).componentInstance;
+
+                expect(tableInstance.multiSortMeta).toEqual([{ field: 'category', order: 1 }]);
+                expect(tableInstance.value.map((product: any) => product.category)).toEqual(['Accessories', 'Accessories', 'Electronics']);
+            });
+
+            it('should keep the grouped field first when multiSortMeta is emptied later', async () => {
+                await createGroupedFixture();
+
+                groupedComponent.multiSortMeta = [];
+                groupedFixture.detectChanges();
+                await groupedFixture.whenStable();
+
+                const tableInstance: Table = groupedFixture.debugElement.query(By.css('p-table')).componentInstance;
+
+                expect(tableInstance.multiSortMeta).toEqual([{ field: 'category', order: 1 }]);
+            });
         });
     });
 

--- a/packages/optimus-ui/src/table/table.ts
+++ b/packages/optimus-ui/src/table/table.ts
@@ -1650,8 +1650,8 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
 
     sortMultiple() {
         if (this.groupRowsBy) {
-            if (!this._multiSortMeta) this._multiSortMeta = [this.getGroupRowsMeta()];
-            else if ((<SortMeta[]>this.multiSortMeta)[0].field !== this.groupRowsBy) this._multiSortMeta = [this.getGroupRowsMeta(), ...this._multiSortMeta];
+            if (!this._multiSortMeta || !this._multiSortMeta.length) this._multiSortMeta = [this.getGroupRowsMeta()];
+            else if (this._multiSortMeta[0].field !== this.groupRowsBy) this._multiSortMeta = [this.getGroupRowsMeta(), ...this._multiSortMeta];
         }
         if (this.multiSortMeta && this.multiSortMeta.length > 0) {
             if (this.lazy) {


### PR DESCRIPTION
## What

`Table.sortMultiple()` prepends the row-grouping sort meta when `groupRowsBy` is set, but it only treated `null`/`undefined` as "no existing meta". An empty array is truthy, so it fell through to the `else if` and read index 0 of an empty array:

```ts
if (!this._multiSortMeta) this._multiSortMeta = [this.getGroupRowsMeta()];
else if ((<SortMeta[]>this.multiSortMeta)[0].field !== this.groupRowsBy) // 💥
```

This throws `TypeError: Cannot read properties of undefined (reading 'field')`, matching the trace in #29.

`ngOnChanges` routes both the `value` and `multiSortMeta` changes into `sortMultiple()`, so binding `[multiSortMeta]="[]"` alongside `groupRowsBy` reproduces it on the first change detection pass — before the user interacts with anything.

The fix treats an empty array the same as a missing one, so the grouped field becomes the only sort meta. The type cast is no longer needed once the length check narrows `_multiSortMeta`.

## Verification

Reproduced first, on unpatched `main`:

```
TypeError: Cannot read properties of undefined (reading 'field')
    at Table.sortMultiple (src/table/table.ts:1654:58)
    at Table.onChanges (src/table/table.ts:1375:104)
    at Table.ngOnChanges (src/basecomponent/basecomponent.ts:219:14)
```

- 3 new specs in `table.spec.ts` (new `TestGroupedSortingTableComponent`): all 3 fail before the change, pass after.
- Table spec: 68/68 pass.
- Full suite: 7207 pass. One unrelated pre-existing failure — `RadioButton Performance Tests should handle frequent selection changes efficiently`, a wall-clock assertion (`Expected 1602.5 to be less than 1000`) at `radiobutton.spec.ts:726`.
- `prettier --check` clean on both changed files.

No public API or template changes, so no impact on theming, PT, or the docs app.

Closes #29
