### PR TITLE
fix(confirmpopup): accept/reject button props label were not rendering

### DIFF
--- a/packages/optimus-ui/src/confirmpopup/confirmpopup.ts
+++ b/packages/optimus-ui/src/confirmpopup/confirmpopup.ts
@@ -596,11 +596,11 @@ export class ConfirmPopup extends BaseComponent<ConfirmPopupPassThrough> {
     }
 
     get acceptButtonLabel(): string {
-        return this.confirmation?.acceptLabel || this.config.getTranslation(TranslationKeys.ACCEPT);
+        return this.confirmation?.acceptLabel || this.confirmation?.acceptButtonProps?.label || this.config.getTranslation(TranslationKeys.ACCEPT);
     }
 
     get rejectButtonLabel(): string {
-        return this.confirmation?.rejectLabel || this.config.getTranslation(TranslationKeys.REJECT);
+        return this.confirmation?.rejectLabel || this.confirmation?.rejectButtonProps?.label || this.config.getTranslation(TranslationKeys.REJECT);
     }
 
     onDestroy() {


### PR DESCRIPTION
## Description

If you pass a label through `acceptButtonProps` / `rejectButtonProps` in ConfirmPopup, it never shows up. You get the default translated label instead.

I also tried typing `acceptButtonProps` / `rejectButtonProps` / `closeButtonProps` as `ButtonProps` instead of `any`, but it breaks the build:

```
Entry point @openng/optimus-ui/api has a circular dependency on @openng/optimus-ui/types/button
```

`types/button` imports `PassThrough` from `api`, and api is the base entry point, so it can't import back. Fixing it means moving the passthrough types out of api into their own entry point. That's a bigger change, so I left the `any` alone here.

<img width="1663" height="289" alt="image" src="https://github.com/user-attachments/assets/d085948f-2a69-4372-b2d8-e9cc59160665" />

## Related issues

fix #40 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)
