### PR TITLE
fix(tooltip): ignore mouseenter that follows no mouseleave

### DIFF
--- a/packages/optimus-ui/src/tooltip/tooltip.test.ts
+++ b/packages/optimus-ui/src/tooltip/tooltip.test.ts
@@ -281,6 +281,97 @@ describe('Tooltip', () => {
         });
     });
 
+    describe('Re-entrant Mouse Enter', () => {
+        let fixture: ComponentFixture<TestBasicTooltipComponent>;
+        let component: TestBasicTooltipComponent;
+        let tooltipDirective: Tooltip;
+        let inputElement: HTMLElement;
+
+        // Chrome dispatches a fresh mouseenter on the host when the element under the pointer is
+        // detached - for instance an overlay rendered inside the host closing on click. The pointer
+        // never moved, so no mouseleave precedes it. See issue #950.
+        const enter = () => inputElement.dispatchEvent(new MouseEvent('mouseenter'));
+        const leave = () => inputElement.dispatchEvent(new MouseEvent('mouseleave'));
+        const click = () => inputElement.dispatchEvent(new MouseEvent('click'));
+
+        beforeEach(() => {
+            fixture = TestBed.createComponent(TestBasicTooltipComponent);
+            component = fixture.componentInstance;
+            fixture.detectChanges();
+
+            const debugElement = fixture.debugElement.query(By.directive(Tooltip));
+            tooltipDirective = debugElement.injector.get(Tooltip);
+            inputElement = component.inputElement.nativeElement;
+        });
+
+        afterEach(() => {
+            tooltipDirective.deactivate();
+        });
+
+        it('should activate on the first mouse enter', () => {
+            const activateSpy = vi.spyOn(tooltipDirective, 'activate');
+
+            enter();
+
+            expect(activateSpy).toHaveBeenCalledTimes(1);
+            expect(document.querySelector('.p-tooltip')).toBeTruthy();
+        });
+
+        it('should ignore a mouse enter that is not preceded by a mouse leave', () => {
+            enter();
+            tooltipDirective.deactivate();
+
+            const activateSpy = vi.spyOn(tooltipDirective, 'activate');
+            enter();
+
+            expect(activateSpy).not.toHaveBeenCalled();
+        });
+
+        it('should activate again once the pointer has really left', () => {
+            const activateSpy = vi.spyOn(tooltipDirective, 'activate');
+
+            enter();
+            leave();
+            enter();
+
+            expect(activateSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('should stay hidden when a click is followed by a re-entrant mouse enter', () => {
+            enter();
+            expect(document.querySelector('.p-tooltip')).toBeTruthy();
+
+            // clicking the host dismisses the tooltip, then the detached-element enter arrives
+            click();
+            expect(document.querySelector('.p-tooltip')).toBeFalsy();
+
+            enter();
+
+            expect(document.querySelector('.p-tooltip')).toBeFalsy();
+        });
+
+        it('should show again after the pointer leaves and returns following a click', () => {
+            enter();
+            click();
+            enter();
+            expect(document.querySelector('.p-tooltip')).toBeFalsy();
+
+            leave();
+            enter();
+
+            expect(document.querySelector('.p-tooltip')).toBeTruthy();
+        });
+
+        it('should reset the pointer state when the events are unbound', () => {
+            enter();
+            expect(tooltipDirective.pointerInside).toBe(true);
+
+            tooltipDirective.unbindEvents();
+
+            expect(tooltipDirective.pointerInside).toBe(false);
+        });
+    });
+
     describe('Positioning', () => {
         let fixture: ComponentFixture<TestBasicTooltipComponent>;
         let component: TestBasicTooltipComponent;

--- a/packages/optimus-ui/src/tooltip/tooltip.ts
+++ b/packages/optimus-ui/src/tooltip/tooltip.ts
@@ -198,6 +198,8 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
 
     interactionInProgress = false;
 
+    pointerInside = false;
+
     /**
      * Used to pass attributes to DOM elements inside the Tooltip component.
      * @defaultValue undefined
@@ -375,12 +377,24 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
     }
 
     onMouseEnter(e: Event) {
+        // Chrome re-dispatches mouseenter on the host when the element the pointer sits on is
+        // detached (e.g. an overlay rendered inside the host closing on click), without the
+        // pointer ever leaving. An enter without a preceding leave is not a new hover, so
+        // ignore it - otherwise a tooltip dismissed by that very click comes straight back.
+        if (this.pointerInside) {
+            return;
+        }
+
+        this.pointerInside = true;
+
         if (!this.container && !this.showTimeout) {
             this.activate();
         }
     }
 
     onMouseLeave(e: MouseEvent) {
+        this.pointerInside = false;
+
         if (!this.isAutoHide()) {
             const valid = hasClass(e.relatedTarget as any, 'p-tooltip') || hasClass(e.relatedTarget as any, 'p-tooltip-text') || hasClass(e.relatedTarget as any, 'p-tooltip-arrow');
             !valid && this.deactivate();
@@ -769,6 +783,8 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
 
     unbindEvents() {
         const tooltipEvent = this.getOption('tooltipEvent');
+
+        this.pointerInside = false;
 
         if (tooltipEvent === 'hover' || tooltipEvent === 'both') {
             this.el.nativeElement.removeEventListener('mouseenter', this.mouseEnterListener);


### PR DESCRIPTION
Fixes #950 — tooltip reappears after selecting an item, with ripple enabled, in Chrome.

## Root cause

The overlay of a `p-select` / `p-dropdown` is rendered **inside** the tooltipped host (`appendTo` defaults to `'self'`), so the option `<li>` the pointer sits on is a descendant of the element `Tooltip` listens on.

Selecting an option detaches that `<li>` — together with the `<span class="p-ink">` of its running ripple animation. Chrome then re-runs its hover computation for the detached subtree and dispatches a **fresh `mouseenter` at the host**: no pointer movement, and no `mouseleave` in between. `Tooltip.onMouseEnter` only guarded on `!this.container && !this.showTimeout`, both true right after the click hid the tooltip, so it re-showed the tooltip that the very same click had just dismissed — leaving it on screen while the pointer is nowhere near the host.

Firefox only recomputes hover on real pointer movement, which is why the report is Chrome-only. Removing the ripple ink from the DOM makes the spurious enter disappear as well, matching "only when ripple is enabled" from the report.

Instrumented event log from the reproduction (pointer stationary throughout):

```
t=7900  click       on host (option click bubbles up) -> deactivate(), tooltip hidden
t=7912  mouseenter  on host, x/y unchanged, no mouseleave  -> activate(), tooltip back
```

## The fix

An enter that is not preceded by a leave is not a new hover. `Tooltip` now tracks whether the pointer is already inside the host and ignores those re-entrant events. Genuine hover, leave/re-enter, focus and touch paths are untouched.

## Verification

Reproduced in the environment named in the issue — Angular 15 + PrimeNG 15, ripple on via `PrimeNGConfig`, `pTooltip` on `p-dropdown`, Chrome 108 in Docker — driven over WebDriver with real pointer events and **no pointer movement after the item click**.

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/rene-schakmann/optimus-ui/assets/issue-950/before-fix-chrome108.png) | ![after](https://raw.githubusercontent.com/rene-schakmann/optimus-ui/assets/issue-950/after-fix-chrome108.png) |

"Rome" is selected in both; on the left the tooltip is stranded next to the closed dropdown.

- 6 new specs in `tooltip.spec.ts` covering the invariant end to end. 3 of them fail without the fix and pass with it.
- `pnpm run test:unit`: 7210 passing. The single failure is `ScrollTop Performance should handle rapid scroll events efficiently`, which is timing-sensitive under full-suite load and passes when `scrolltop.spec.ts` runs on its own — unrelated to this change.
- `pnpm run format:check` clean. Note: `pnpm run lint` fails on `main` as well (`eslint --ignore-path` is not valid with the flat config), so it could not be used as a gate here; `eslint` run directly on the changed files reports no errors.
- Checked in the docs app on Chrome 150 that hover, leave/re-hover and select-an-option all behave.

Co-authored by Claude.
