### PR TITLE
docs(#1449): improve TreeTable Controlled example code

### DIFF
--- a/apps/docs/doc/apidoc/index.json
+++ b/apps/docs/doc/apidoc/index.json
@@ -4099,21 +4099,21 @@
                             "name": "suggestions",
                             "optional": false,
                             "readonly": false,
-                            "type": "any[]",
+                            "type": "T[]",
                             "description": "An array of suggestions to display."
                         },
                         {
                             "name": "optionLabel",
                             "optional": false,
                             "readonly": false,
-                            "type": "string | ((item: any) => string)",
+                            "type": "string | ((item: T) => string)",
                             "description": "Property name or getter function to use as the label of an option."
                         },
                         {
                             "name": "optionValue",
                             "optional": false,
                             "readonly": false,
-                            "type": "string | ((item: any) => string)",
+                            "type": "string | ((item: T) => string)",
                             "description": "Property name or getter function to use as the value of an option."
                         },
                         {
@@ -4175,7 +4175,7 @@
                             "name": "optionDisabled",
                             "optional": false,
                             "readonly": false,
-                            "type": "string | ((item: any) => string)",
+                            "type": "string | ((item: T) => string)",
                             "description": "Property name or getter function to use as the disabled flag of an option, defaults to false when not defined."
                         },
                         {
@@ -4389,7 +4389,7 @@
                             "parameters": [
                                 {
                                     "name": "event",
-                                    "type": "AutoCompleteSelectEvent"
+                                    "type": "AutoCompleteSelectEvent<T"
                                 }
                             ],
                             "description": "Callback to invoke when a suggestion is selected."
@@ -4399,7 +4399,7 @@
                             "parameters": [
                                 {
                                     "name": "event",
-                                    "type": "AutoCompleteUnselectEvent"
+                                    "type": "AutoCompleteUnselectEvent<T"
                                 }
                             ],
                             "description": "Callback to invoke when a selected value is removed."
@@ -4409,7 +4409,7 @@
                             "parameters": [
                                 {
                                     "name": "event",
-                                    "type": "AutoCompleteAddEvent"
+                                    "type": "AutoCompleteAddEvent<string"
                                 }
                             ],
                             "description": "Callback to invoke when an item is added via addOnBlur or separator features."
@@ -4706,7 +4706,7 @@
                                 "name": "value",
                                 "optional": false,
                                 "readonly": false,
-                                "type": "any",
+                                "type": "unknown",
                                 "description": "Selected value."
                             }
                         ]
@@ -4726,7 +4726,7 @@
                                 "name": "value",
                                 "optional": false,
                                 "readonly": false,
-                                "type": "any",
+                                "type": "unknown",
                                 "description": "Removed value."
                             }
                         ]
@@ -4746,7 +4746,7 @@
                                 "name": "value",
                                 "optional": false,
                                 "readonly": false,
-                                "type": "any",
+                                "type": "unknown",
                                 "description": "Added value."
                             }
                         ]
@@ -5515,7 +5515,7 @@
                             "name": "severity",
                             "optional": false,
                             "readonly": false,
-                            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"secondary\" | \"contrast\"",
+                            "type": "BadgeSeverity",
                             "description": "Severity type of the badge."
                         },
                         {
@@ -5608,7 +5608,7 @@
                             "name": "severity",
                             "optional": false,
                             "readonly": false,
-                            "type": "InputSignal<\"success\" | \"info\" | \"warn\" | \"danger\" | \"secondary\" | \"contrast\">",
+                            "type": "InputSignal<BadgeSeverity>",
                             "default": "...",
                             "description": "Severity type of the badge."
                         },
@@ -5699,6 +5699,16 @@
                                 "description": "Used to pass attributes to the root's DOM element."
                             }
                         ]
+                    }
+                ]
+            },
+            "types": {
+                "description": "Defines the custom types used by the module.",
+                "values": [
+                    {
+                        "name": "BadgeSeverity",
+                        "value": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"secondary\" | \"contrast\"",
+                        "description": "Severity levels of the badge, also shared by the components that render one or follow the same severities, such as Tag, OverlayBadge and FileUpload."
                     }
                 ]
             }
@@ -6481,7 +6491,7 @@
                             "name": "badgeSeverity",
                             "optional": false,
                             "readonly": false,
-                            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"help\" | \"primary\" | \"secondary\" | \"contrast\"",
+                            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"secondary\" | \"contrast\" | \"help\" | \"primary\"",
                             "default": "secondary",
                             "description": "Severity type of the badge."
                         },
@@ -6771,6 +6781,16 @@
                                 "description": "Pass-through options for the loading icon element."
                             }
                         ]
+                    }
+                ]
+            },
+            "types": {
+                "description": "Defines the custom types used by the module.",
+                "values": [
+                    {
+                        "name": "ButtonSeverity",
+                        "value": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"help\" | \"primary\" | \"secondary\" | \"contrast\" | null | undefined",
+                        "description": "Severity levels of the button."
                     }
                 ]
             }
@@ -25360,7 +25380,7 @@
                             "name": "severity",
                             "optional": false,
                             "readonly": false,
-                            "type": "\"error\" | \"success\" | \"info\" | \"warn\" | \"secondary\" | \"contrast\"",
+                            "type": "MessageSeverity",
                             "default": "'info'",
                             "description": "Severity level of the message."
                         },
@@ -25669,6 +25689,16 @@
                                 "description": "Callback to close the message."
                             }
                         ]
+                    }
+                ]
+            },
+            "types": {
+                "description": "Defines the custom types used by the module.",
+                "values": [
+                    {
+                        "name": "MessageSeverity",
+                        "value": "\"success\" | \"info\" | \"warn\" | \"error\" | \"secondary\" | \"contrast\"",
+                        "description": "Severity levels of the message, using 'error' instead of 'danger'."
                     }
                 ]
             }
@@ -29845,7 +29875,7 @@
                             "name": "severity",
                             "optional": false,
                             "readonly": false,
-                            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"secondary\" | \"contrast\"",
+                            "type": "BadgeSeverity",
                             "description": "Severity type of the badge."
                         },
                         {
@@ -38646,7 +38676,7 @@
                             "name": "severity",
                             "optional": false,
                             "readonly": false,
-                            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"help\" | \"primary\" | \"secondary\" | \"contrast\"",
+                            "type": "ButtonSeverity",
                             "description": "Defines the style of the button."
                         },
                         {
@@ -43138,7 +43168,7 @@
                             "name": "severity",
                             "optional": false,
                             "readonly": false,
-                            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"secondary\" | \"contrast\"",
+                            "type": "BadgeSeverity",
                             "description": "Severity type of the tag."
                         },
                         {

--- a/apps/docs/doc/treetable/controlled-doc.ts
+++ b/apps/docs/doc/treetable/controlled-doc.ts
@@ -12,11 +12,14 @@ import { TreeTableModule } from '@openng/optimus-ui/treetable';
     standalone: true,
     imports: [TreeTableModule, ButtonModule, AppCode, AppDocSectionText, DeferredDemo],
     template: ` <app-docsectiontext>
-            <p>Expansion state is controlled with <i>expandedKeys</i> property.</p>
+            <p>Expansion state is controlled with the <i>expanded</i> property.</p>
         </app-docsectiontext>
         <div class="card">
-            <p-button (click)="toggleApplications()" label="Toggle Applications" class="block mb-4" />
             <p-deferred-demo (load)="loadDemoData()">
+                <div class="flex gap-2 mb-4">
+                    <p-button (click)="toggleApplications()" label="Toggle Applications" />
+                    <p-button (click)="toggleAll()" label="Toggle All" />
+                </div>
                 <p-treetable [value]="files" [scrollable]="true" [tableStyle]="{ 'min-width': '50rem' }">
                     <ng-template #header>
                         <tr>
@@ -63,6 +66,22 @@ export class ControlledDoc {
             const newFiles = [...this.files];
             newFiles[0] = { ...newFiles[0], expanded: !newFiles[0].expanded };
             this.files = newFiles;
+        }
+    }
+
+    toggleAll() {
+        if (!this.files || this.files.length === 0) return;
+        const newFiles = [...this.files];
+        for (const file of newFiles) {
+            this.toggleSubtree(file);
+        }
+        this.files = newFiles;
+    }
+
+    private toggleSubtree(node: TreeNode) {
+        node.expanded = !node.expanded;
+        for (const child of node.children || []) {
+            this.toggleSubtree(child);
         }
     }
 }

--- a/apps/docs/public/demos.json
+++ b/apps/docs/public/demos.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-20T21:26:44.471Z",
+  "generatedAt": "2026-08-27T06:40:47.519Z",
   "totalDemos": 803,
   "demos": {
     "Image-template-demo": {
@@ -15069,7 +15069,7 @@
       "component": "treetable",
       "section": "controlled",
       "code": {
-        "typescript": "import { Component, OnInit, inject } from '@angular/core';\nimport { TreeTableModule } from '@openng/optimus-ui/treetable';\nimport { NodeService } from '@/service/nodeservice';\nimport { TreeNode } from '@openng/optimus-ui/api';\n\n@Component({\n    template: `\n        <p-treetable [value]=\"files\" [scrollable]=\"true\" [tableStyle]=\"{ 'min-width': '50rem' }\">\n            <ng-template #header>\n                <tr>\n                    <th>Name</th>\n                    <th>Size</th>\n                    <th>Type</th>\n                </tr>\n            </ng-template>\n            <ng-template #body let-rowNode let-rowData=\"rowData\">\n                <tr [ttRow]=\"rowNode\">\n                    <td>\n                        <div class=\"flex items-center gap-2\">\n                            <p-treetable-toggler [rowNode]=\"rowNode\" />\n                            <span>{{ rowData.name }}</span>\n                        </div>\n                    </td>\n                    <td>{{ rowData.size }}</td>\n                    <td>{{ rowData.type }}</td>\n                </tr>\n            </ng-template>\n        </p-treetable>\n    `,\n    standalone: true,\n    imports: [TreeTableModule],\n    providers: [NodeService]\n})\nexport class TreetableControlledDemo implements OnInit {\n    private nodeService = inject(NodeService);\n    files!: TreeNode[];\n\n    ngOnInit() {\n        this.nodeService.getFilesystem().then((files) => {\n            this.files = files.slice(0, 5);\n        });\n    }\n\n    toggleApplications() {\n        if (this.files && this.files.length > 0) {\n            const newFiles = [...this.files];\n            newFiles[0] = { ...newFiles[0], expanded: !newFiles[0].expanded };\n            this.files = newFiles;\n        }\n    }\n}"
+        "typescript": "import { Component, OnInit, inject } from '@angular/core';\nimport { ButtonModule } from '@openng/optimus-ui/button';\nimport { TreeTableModule } from '@openng/optimus-ui/treetable';\nimport { NodeService } from '@/service/nodeservice';\nimport { TreeNode } from '@openng/optimus-ui/api';\n\n@Component({\n    template: `\n        <div class=\"flex gap-2 mb-4\">\n            <p-button (click)=\"toggleApplications()\" label=\"Toggle Applications\" />\n            <p-button (click)=\"toggleAll()\" label=\"Toggle All\" />\n        </div>\n        <p-treetable [value]=\"files\" [scrollable]=\"true\" [tableStyle]=\"{ 'min-width': '50rem' }\">\n            <ng-template #header>\n                <tr>\n                    <th>Name</th>\n                    <th>Size</th>\n                    <th>Type</th>\n                </tr>\n            </ng-template>\n            <ng-template #body let-rowNode let-rowData=\"rowData\">\n                <tr [ttRow]=\"rowNode\">\n                    <td>\n                        <div class=\"flex items-center gap-2\">\n                            <p-treetable-toggler [rowNode]=\"rowNode\" />\n                            <span>{{ rowData.name }}</span>\n                        </div>\n                    </td>\n                    <td>{{ rowData.size }}</td>\n                    <td>{{ rowData.type }}</td>\n                </tr>\n            </ng-template>\n        </p-treetable>\n    `,\n    standalone: true,\n    imports: [ButtonModule, TreeTableModule],\n    providers: [NodeService]\n})\nexport class TreetableControlledDemo implements OnInit {\n    private nodeService = inject(NodeService);\n    files!: TreeNode[];\n\n    ngOnInit() {\n        this.nodeService.getFilesystem().then((files) => {\n            this.files = files.slice(0, 5);\n        });\n    }\n\n    toggleApplications() {\n        if (this.files && this.files.length > 0) {\n            const newFiles = [...this.files];\n            newFiles[0] = { ...newFiles[0], expanded: !newFiles[0].expanded };\n            this.files = newFiles;\n        }\n    }\n\n    toggleAll() {\n        if (!this.files || this.files.length === 0) return;\n        const newFiles = [...this.files];\n        for (const file of newFiles) {\n            this.toggleSubtree(file);\n        }\n        this.files = newFiles;\n    }\n}"
       },
       "metadata": {
         "services": [
@@ -15078,6 +15078,7 @@
         "optimusServices": [],
         "extFiles": [],
         "imports": [
+          "ButtonModule",
           "TreeTableModule"
         ]
       }

--- a/apps/docs/public/llms/components.json
+++ b/apps/docs/public/llms/components.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-20",
+  "generatedAt": "2026-08-27",
   "components": [
     {
       "name": "Image",
@@ -1514,21 +1514,21 @@
           },
           {
             "name": "suggestions",
-            "type": "any[]",
+            "type": "T[]",
             "default": "-",
             "description": "An array of suggestions to display.",
             "deprecated": ""
           },
           {
             "name": "optionLabel",
-            "type": "string | ((item: any) => string)",
+            "type": "string | ((item: T) => string)",
             "default": "-",
             "description": "Property name or getter function to use as the label of an option.",
             "deprecated": ""
           },
           {
             "name": "optionValue",
-            "type": "string | ((item: any) => string)",
+            "type": "string | ((item: T) => string)",
             "default": "-",
             "description": "Property name or getter function to use as the value of an option.",
             "deprecated": ""
@@ -1584,7 +1584,7 @@
           },
           {
             "name": "optionDisabled",
-            "type": "string | ((item: any) => string)",
+            "type": "string | ((item: T) => string)",
             "default": "-",
             "description": "Property name or getter function to use as the disabled flag of an option, defaults to false when not defined.",
             "deprecated": ""
@@ -1831,7 +1831,7 @@
             "parameters": [
               {
                 "name": "event",
-                "type": "AutoCompleteSelectEvent"
+                "type": "AutoCompleteSelectEvent<T"
               }
             ],
             "description": "Callback to invoke when a suggestion is selected."
@@ -1841,7 +1841,7 @@
             "parameters": [
               {
                 "name": "event",
-                "type": "AutoCompleteUnselectEvent"
+                "type": "AutoCompleteUnselectEvent<T"
               }
             ],
             "description": "Callback to invoke when a selected value is removed."
@@ -1851,7 +1851,7 @@
             "parameters": [
               {
                 "name": "event",
-                "type": "AutoCompleteAddEvent"
+                "type": "AutoCompleteAddEvent<string"
               }
             ],
             "description": "Callback to invoke when an item is added via addOnBlur or separator features."
@@ -2938,7 +2938,7 @@
           },
           {
             "name": "severity",
-            "type": "InputSignal<\"success\" | \"info\" | \"warn\" | \"danger\" | \"secondary\" | \"contrast\">",
+            "type": "InputSignal<BadgeSeverity>",
             "default": "...",
             "description": "Severity type of the badge.",
             "deprecated": ""
@@ -3876,7 +3876,7 @@
           },
           {
             "name": "badgeSeverity",
-            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"help\" | \"primary\" | \"secondary\" | \"contrast\"",
+            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"secondary\" | \"contrast\" | \"help\" | \"primary\"",
             "default": "secondary",
             "description": "Severity type of the badge.",
             "deprecated": ""
@@ -22557,7 +22557,7 @@
           },
           {
             "name": "severity",
-            "type": "\"error\" | \"success\" | \"info\" | \"warn\" | \"secondary\" | \"contrast\"",
+            "type": "MessageSeverity",
             "default": "'info'",
             "description": "Severity level of the message.",
             "deprecated": ""
@@ -34134,7 +34134,7 @@
           },
           {
             "name": "severity",
-            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"help\" | \"primary\" | \"secondary\" | \"contrast\"",
+            "type": "ButtonSeverity",
             "default": "-",
             "description": "Defines the style of the button.",
             "deprecated": ""
@@ -37199,7 +37199,7 @@
           },
           {
             "name": "severity",
-            "type": "\"success\" | \"info\" | \"warn\" | \"danger\" | \"secondary\" | \"contrast\"",
+            "type": "BadgeSeverity",
             "default": "-",
             "description": "Severity type of the tag.",
             "deprecated": ""
@@ -42871,9 +42871,9 @@
         {
           "id": "controlled",
           "label": "Controlled",
-          "description": "Expansion state is controlled with expandedKeys property.",
+          "description": "Expansion state is controlled with the expanded property.",
           "examples": {
-            "typescript": "import { Component, OnInit, inject } from '@angular/core';\nimport { TreeTableModule } from '@openng/optimus-ui/treetable';\nimport { NodeService } from '@/service/nodeservice';\nimport { TreeNode } from '@openng/optimus-ui/api';\n\n@Component({\n    template: `\n        <p-treetable [value]=\"files\" [scrollable]=\"true\" [tableStyle]=\"{ 'min-width': '50rem' }\">\n            <ng-template #header>\n                <tr>\n                    <th>Name</th>\n                    <th>Size</th>\n                    <th>Type</th>\n                </tr>\n            </ng-template>\n            <ng-template #body let-rowNode let-rowData=\"rowData\">\n                <tr [ttRow]=\"rowNode\">\n                    <td>\n                        <div class=\"flex items-center gap-2\">\n                            <p-treetable-toggler [rowNode]=\"rowNode\" />\n                            <span>{{ rowData.name }}</span>\n                        </div>\n                    </td>\n                    <td>{{ rowData.size }}</td>\n                    <td>{{ rowData.type }}</td>\n                </tr>\n            </ng-template>\n        </p-treetable>\n    `,\n    standalone: true,\n    imports: [TreeTableModule],\n    providers: [NodeService]\n})\nexport class TreetableControlledDemo implements OnInit {\n    private nodeService = inject(NodeService);\n    files!: TreeNode[];\n\n    ngOnInit() {\n        this.nodeService.getFilesystem().then((files) => {\n            this.files = files.slice(0, 5);\n        });\n    }\n\n    toggleApplications() {\n        if (this.files && this.files.length > 0) {\n            const newFiles = [...this.files];\n            newFiles[0] = { ...newFiles[0], expanded: !newFiles[0].expanded };\n            this.files = newFiles;\n        }\n    }\n}"
+            "typescript": "import { Component, OnInit, inject } from '@angular/core';\nimport { ButtonModule } from '@openng/optimus-ui/button';\nimport { TreeTableModule } from '@openng/optimus-ui/treetable';\nimport { NodeService } from '@/service/nodeservice';\nimport { TreeNode } from '@openng/optimus-ui/api';\n\n@Component({\n    template: `\n        <div class=\"flex gap-2 mb-4\">\n            <p-button (click)=\"toggleApplications()\" label=\"Toggle Applications\" />\n            <p-button (click)=\"toggleAll()\" label=\"Toggle All\" />\n        </div>\n        <p-treetable [value]=\"files\" [scrollable]=\"true\" [tableStyle]=\"{ 'min-width': '50rem' }\">\n            <ng-template #header>\n                <tr>\n                    <th>Name</th>\n                    <th>Size</th>\n                    <th>Type</th>\n                </tr>\n            </ng-template>\n            <ng-template #body let-rowNode let-rowData=\"rowData\">\n                <tr [ttRow]=\"rowNode\">\n                    <td>\n                        <div class=\"flex items-center gap-2\">\n                            <p-treetable-toggler [rowNode]=\"rowNode\" />\n                            <span>{{ rowData.name }}</span>\n                        </div>\n                    </td>\n                    <td>{{ rowData.size }}</td>\n                    <td>{{ rowData.type }}</td>\n                </tr>\n            </ng-template>\n        </p-treetable>\n    `,\n    standalone: true,\n    imports: [ButtonModule, TreeTableModule],\n    providers: [NodeService]\n})\nexport class TreetableControlledDemo implements OnInit {\n    private nodeService = inject(NodeService);\n    files!: TreeNode[];\n\n    ngOnInit() {\n        this.nodeService.getFilesystem().then((files) => {\n            this.files = files.slice(0, 5);\n        });\n    }\n\n    toggleApplications() {\n        if (this.files && this.files.length > 0) {\n            const newFiles = [...this.files];\n            newFiles[0] = { ...newFiles[0], expanded: !newFiles[0].expanded };\n            this.files = newFiles;\n        }\n    }\n\n    toggleAll() {\n        if (!this.files || this.files.length === 0) return;\n        const newFiles = [...this.files];\n        for (const file of newFiles) {\n            this.toggleSubtree(file);\n        }\n        this.files = newFiles;\n    }\n}"
           }
         },
         {

--- a/apps/docs/public/llms/components/badge.md
+++ b/apps/docs/public/llms/components/badge.md
@@ -175,7 +175,7 @@ Badge is a small status indicator for another element.
 | styleClass | InputSignal<string> | ... | Class of the element. **(Deprecated)** |
 | badgeSize | InputSignal<"small" \| "large" \| "xlarge"> | ... | Size of the badge, valid options are "large" and "xlarge". |
 | size | InputSignal<"small" \| "large" \| "xlarge"> | ... | Size of the badge, valid options are "large" and "xlarge". |
-| severity | InputSignal<"success" \| "info" \| "warn" \| "danger" \| "secondary" \| "contrast"> | ... | Severity type of the badge. |
+| severity | InputSignal<BadgeSeverity> | ... | Severity type of the badge. |
 | value | InputSignal<string \| number> | ... | Value to display inside the badge. |
 | badgeDisabled | InputSignalWithTransform<boolean, boolean> | ... | When specified, disables the component. |
 | dt | InputSignal<Object> | undefined | Defines scoped design tokens of the component. |

--- a/apps/docs/public/llms/components/button.md
+++ b/apps/docs/public/llms/components/button.md
@@ -543,7 +543,7 @@ Button is an extension to standard button element with icons and theming.
 | style | { [klass: string]: any } | - | Inline style of the element. |
 | styleClass | string | - | Class of the element. |
 | badgeClass | string | - | Style class of the badge. **(Deprecated)** |
-| badgeSeverity | "success" \| "info" \| "warn" \| "danger" \| "help" \| "primary" \| "secondary" \| "contrast" | secondary | Severity type of the badge. |
+| badgeSeverity | "success" \| "info" \| "warn" \| "danger" \| "secondary" \| "contrast" \| "help" \| "primary" | secondary | Severity type of the badge. |
 | ariaLabel | string | - | Used to define a string that autocomplete attribute the current element. |
 | autofocus | boolean | false | When present, it specifies that the component should automatically get focus on load. |
 | iconPos | ButtonIconPosition | left | Position of the icon. |

--- a/apps/docs/public/llms/components/message.md
+++ b/apps/docs/public/llms/components/message.md
@@ -299,7 +299,7 @@ Message groups a collection of contents in tabs.
 | unstyled | InputSignal<boolean> | undefined | Indicates whether the component should be rendered without styles. |
 | pt | InputSignal<MessagePassThrough> | undefined | Used to pass attributes to DOM elements inside the component. |
 | ptOptions | InputSignal<PassThroughOptions> | undefined | Used to configure passthrough(pt) options of the component. |
-| severity | "error" \| "success" \| "info" \| "warn" \| "secondary" \| "contrast" | 'info' | Severity level of the message. |
+| severity | MessageSeverity | 'info' | Severity level of the message. |
 | text | string | - | Text content. **(Deprecated)** |
 | escape | boolean | true | Whether displaying messages would be escaped or not. **(Deprecated)** |
 | style | { [klass: string]: any } | - | Inline style of the component. |

--- a/apps/docs/public/llms/components/splitbutton.md
+++ b/apps/docs/public/llms/components/splitbutton.md
@@ -877,7 +877,7 @@ SplitButton groups a set of commands in an overlay with a default command.
 | pt | InputSignal<SplitButtonPassThrough> | undefined | Used to pass attributes to DOM elements inside the component. |
 | ptOptions | InputSignal<PassThroughOptions> | undefined | Used to configure passthrough(pt) options of the component. |
 | model | MenuItem[] | - | MenuModel instance to define the overlay items. |
-| severity | "success" \| "info" \| "warn" \| "danger" \| "help" \| "primary" \| "secondary" \| "contrast" | - | Defines the style of the button. |
+| severity | ButtonSeverity | - | Defines the style of the button. |
 | raised | boolean | false | Add a shadow to indicate elevation. |
 | rounded | boolean | false | Add a circular border radius to the button. |
 | text | boolean | false | Add a textual class to the button without a background initially. |

--- a/apps/docs/public/llms/components/tag.md
+++ b/apps/docs/public/llms/components/tag.md
@@ -143,7 +143,7 @@ Tag component is used to categorize content.
 | pt | InputSignal<TagPassThrough> | undefined | Used to pass attributes to DOM elements inside the component. |
 | ptOptions | InputSignal<PassThroughOptions> | undefined | Used to configure passthrough(pt) options of the component. |
 | styleClass | string | - | Style class of the component. **(Deprecated)** |
-| severity | "success" \| "info" \| "warn" \| "danger" \| "secondary" \| "contrast" | - | Severity type of the tag. |
+| severity | BadgeSeverity | - | Severity type of the tag. |
 | value | string | - | Value to display inside the tag. |
 | icon | string | - | Icon of the tag to display next to the value. |
 | rounded | boolean | false | Whether the corners of the tag are rounded. |

--- a/apps/docs/public/llms/components/treetable.md
+++ b/apps/docs/public/llms/components/treetable.md
@@ -793,16 +793,21 @@ export class TreetableContextmenuDemo implements OnInit {
 
 ## Controlled
 
-Expansion state is controlled with expandedKeys property.
+Expansion state is controlled with the expanded property.
 
 ```typescript
 import { Component, OnInit, inject } from '@angular/core';
+import { ButtonModule } from '@openng/optimus-ui/button';
 import { TreeTableModule } from '@openng/optimus-ui/treetable';
 import { NodeService } from '@/service/nodeservice';
 import { TreeNode } from '@openng/optimus-ui/api';
 
 @Component({
     template: `
+        <div class="flex gap-2 mb-4">
+            <p-button (click)="toggleApplications()" label="Toggle Applications" />
+            <p-button (click)="toggleAll()" label="Toggle All" />
+        </div>
         <p-treetable [value]="files" [scrollable]="true" [tableStyle]="{ 'min-width': '50rem' }">
             <ng-template #header>
                 <tr>
@@ -826,7 +831,7 @@ import { TreeNode } from '@openng/optimus-ui/api';
         </p-treetable>
     `,
     standalone: true,
-    imports: [TreeTableModule],
+    imports: [ButtonModule, TreeTableModule],
     providers: [NodeService]
 })
 export class TreetableControlledDemo implements OnInit {
@@ -845,6 +850,15 @@ export class TreetableControlledDemo implements OnInit {
             newFiles[0] = { ...newFiles[0], expanded: !newFiles[0].expanded };
             this.files = newFiles;
         }
+    }
+
+    toggleAll() {
+        if (!this.files || this.files.length === 0) return;
+        const newFiles = [...this.files];
+        for (const file of newFiles) {
+            this.toggleSubtree(file);
+        }
+        this.files = newFiles;
     }
 }
 ```

--- a/apps/docs/public/llms/llms-full.txt
+++ b/apps/docs/public/llms/llms-full.txt
@@ -1,6 +1,6 @@
 # Optimus UI Documentation
 
-Generated: 2026-08-20
+Generated: 2026-08-27
 
 ---
 
@@ -2723,9 +2723,9 @@ AutoComplete is an input component that provides real-time suggestions when bein
 | optionGroupChildren | string | items | Name of the options field of an option group. |
 | optionGroupLabel | string | label | Name of the label field of an option group. |
 | overlayOptions | OverlayOptions | - | Options for the overlay element. |
-| suggestions | any[] | - | An array of suggestions to display. |
-| optionLabel | string \| ((item: any) => string) | - | Property name or getter function to use as the label of an option. |
-| optionValue | string \| ((item: any) => string) | - | Property name or getter function to use as the value of an option. |
+| suggestions | T[] | - | An array of suggestions to display. |
+| optionLabel | string \| ((item: T) => string) | - | Property name or getter function to use as the label of an option. |
+| optionValue | string \| ((item: T) => string) | - | Property name or getter function to use as the value of an option. |
 | id | string | - | Unique identifier of the component. |
 | searchMessage | string | '{0} results are available' | Text to display when the search is active. Defaults to global value in i18n translation configuration. |
 | emptySelectionMessage | string | 'No selected item' | Text to display when filtering does not return any results. Defaults to global value in i18n translation configuration. |
@@ -2733,7 +2733,7 @@ AutoComplete is an input component that provides real-time suggestions when bein
 | autoOptionFocus | boolean | false | Whether to focus on the first visible or selected element when the overlay panel is shown. |
 | selectOnFocus | boolean | false | When enabled, the focused option is selected. |
 | searchLocale | boolean | false | Locale to use in searching. The default locale is the host environment's current locale. |
-| optionDisabled | string \| ((item: any) => string) | - | Property name or getter function to use as the disabled flag of an option, defaults to false when not defined. |
+| optionDisabled | string \| ((item: T) => string) | - | Property name or getter function to use as the disabled flag of an option, defaults to false when not defined. |
 | focusOnHover | boolean | true | When enabled, the hovered option will be focused. |
 | typeahead | boolean | true | Whether typeahead is active or not. |
 | addOnBlur | boolean | false | Whether to add an item on blur event if the input has value and typeahead is false with multiple mode. |
@@ -2764,9 +2764,9 @@ AutoComplete is an input component that provides real-time suggestions when bein
 | Name | Parameters | Description |
 |------|------------|-------------|
 | completeMethod | event: AutoCompleteCompleteEvent | Callback to invoke to search for suggestions. |
-| onSelect | event: AutoCompleteSelectEvent | Callback to invoke when a suggestion is selected. |
-| onUnselect | event: AutoCompleteUnselectEvent | Callback to invoke when a selected value is removed. |
-| onAdd | event: AutoCompleteAddEvent | Callback to invoke when an item is added via addOnBlur or separator features. |
+| onSelect | event: AutoCompleteSelectEvent<T | Callback to invoke when a suggestion is selected. |
+| onUnselect | event: AutoCompleteUnselectEvent<T | Callback to invoke when a selected value is removed. |
+| onAdd | event: AutoCompleteAddEvent<string | Callback to invoke when an item is added via addOnBlur or separator features. |
 | onFocus | event: Event | Callback to invoke when the component receives focus. |
 | onBlur | event: Event | Callback to invoke when the component loses focus. |
 | onDropdownClick | event: AutoCompleteDropdownClickEvent | Callback to invoke to when dropdown button is clicked. |
@@ -3587,7 +3587,7 @@ Badge Directive is directive usage of badge component.
 | disabled | boolean | false | When specified, disables the component. |
 | badgeSize | "small" \| "large" \| "xlarge" | - | Size of the badge, valid options are "large" and "xlarge". |
 | size | "small" \| "large" \| "xlarge" | - | Size of the badge, valid options are "large" and "xlarge". **(Deprecated)** |
-| severity | "success" \| "info" \| "warn" \| "danger" \| "secondary" \| "contrast" | - | Severity type of the badge. |
+| severity | BadgeSeverity | - | Severity type of the badge. |
 | value | string \| number | - | Value to display inside the badge. |
 | badgeStyle | { [klass: string]: any } | - | Inline style of the element. |
 | badgeStyleClass | string | - | Class of the element. |
@@ -3607,7 +3607,7 @@ Badge is a small status indicator for another element.
 | styleClass | InputSignal<string> | ... | Class of the element. **(Deprecated)** |
 | badgeSize | InputSignal<"small" \| "large" \| "xlarge"> | ... | Size of the badge, valid options are "large" and "xlarge". |
 | size | InputSignal<"small" \| "large" \| "xlarge"> | ... | Size of the badge, valid options are "large" and "xlarge". |
-| severity | InputSignal<"success" \| "info" \| "warn" \| "danger" \| "secondary" \| "contrast"> | ... | Severity type of the badge. |
+| severity | InputSignal<BadgeSeverity> | ... | Severity type of the badge. |
 | value | InputSignal<string \| number> | ... | Value to display inside the badge. |
 | badgeDisabled | InputSignalWithTransform<boolean, boolean> | ... | When specified, disables the component. |
 | dt | InputSignal<Object> | undefined | Defines scoped design tokens of the component. |
@@ -4579,7 +4579,7 @@ Button is an extension to standard button element with icons and theming.
 | style | { [klass: string]: any } | - | Inline style of the element. |
 | styleClass | string | - | Class of the element. |
 | badgeClass | string | - | Style class of the badge. **(Deprecated)** |
-| badgeSeverity | "success" \| "info" \| "warn" \| "danger" \| "help" \| "primary" \| "secondary" \| "contrast" | secondary | Severity type of the badge. |
+| badgeSeverity | "success" \| "info" \| "warn" \| "danger" \| "secondary" \| "contrast" \| "help" \| "primary" | secondary | Severity type of the badge. |
 | ariaLabel | string | - | Used to define a string that autocomplete attribute the current element. |
 | autofocus | boolean | false | When present, it specifies that the component should automatically get focus on load. |
 | iconPos | ButtonIconPosition | left | Position of the icon. |
@@ -23238,7 +23238,7 @@ Message groups a collection of contents in tabs.
 | unstyled | InputSignal<boolean> | undefined | Indicates whether the component should be rendered without styles. |
 | pt | InputSignal<MessagePassThrough> | undefined | Used to pass attributes to DOM elements inside the component. |
 | ptOptions | InputSignal<PassThroughOptions> | undefined | Used to configure passthrough(pt) options of the component. |
-| severity | "error" \| "success" \| "info" \| "warn" \| "secondary" \| "contrast" | 'info' | Severity level of the message. |
+| severity | MessageSeverity | 'info' | Severity level of the message. |
 | text | string | - | Text content. **(Deprecated)** |
 | escape | boolean | true | Whether displaying messages would be escaped or not. **(Deprecated)** |
 | style | { [klass: string]: any } | - | Inline style of the component. |
@@ -33626,7 +33626,7 @@ SplitButton groups a set of commands in an overlay with a default command.
 | pt | InputSignal<SplitButtonPassThrough> | undefined | Used to pass attributes to DOM elements inside the component. |
 | ptOptions | InputSignal<PassThroughOptions> | undefined | Used to configure passthrough(pt) options of the component. |
 | model | MenuItem[] | - | MenuModel instance to define the overlay items. |
-| severity | "success" \| "info" \| "warn" \| "danger" \| "help" \| "primary" \| "secondary" \| "contrast" | - | Defines the style of the button. |
+| severity | ButtonSeverity | - | Defines the style of the button. |
 | raised | boolean | false | Add a shadow to indicate elevation. |
 | rounded | boolean | false | Add a circular border radius to the button. |
 | text | boolean | false | Add a textual class to the button without a background initially. |
@@ -39899,7 +39899,7 @@ Tag component is used to categorize content.
 | pt | InputSignal<TagPassThrough> | undefined | Used to pass attributes to DOM elements inside the component. |
 | ptOptions | InputSignal<PassThroughOptions> | undefined | Used to configure passthrough(pt) options of the component. |
 | styleClass | string | - | Style class of the component. **(Deprecated)** |
-| severity | "success" \| "info" \| "warn" \| "danger" \| "secondary" \| "contrast" | - | Severity type of the tag. |
+| severity | BadgeSeverity | - | Severity type of the tag. |
 | value | string | - | Value to display inside the tag. |
 | icon | string | - | Icon of the tag to display next to the value. |
 | rounded | boolean | false | Whether the corners of the tag are rounded. |
@@ -45756,18 +45756,23 @@ export class TreetableContextmenuDemo implements OnInit {
 
 ## Controlled
 
-Expansion state is controlled with expandedKeys property.
+Expansion state is controlled with the expanded property.
 
 **Example:**
 
 ```typescript
 import { Component, OnInit, inject } from '@angular/core';
+import { ButtonModule } from '@openng/optimus-ui/button';
 import { TreeTableModule } from '@openng/optimus-ui/treetable';
 import { NodeService } from '@/service/nodeservice';
 import { TreeNode } from '@openng/optimus-ui/api';
 
 @Component({
     template: `
+        <div class="flex gap-2 mb-4">
+            <p-button (click)="toggleApplications()" label="Toggle Applications" />
+            <p-button (click)="toggleAll()" label="Toggle All" />
+        </div>
         <p-treetable [value]="files" [scrollable]="true" [tableStyle]="{ 'min-width': '50rem' }">
             <ng-template #header>
                 <tr>
@@ -45791,7 +45796,7 @@ import { TreeNode } from '@openng/optimus-ui/api';
         </p-treetable>
     `,
     standalone: true,
-    imports: [TreeTableModule],
+    imports: [ButtonModule, TreeTableModule],
     providers: [NodeService]
 })
 export class TreetableControlledDemo implements OnInit {
@@ -45810,6 +45815,15 @@ export class TreetableControlledDemo implements OnInit {
             newFiles[0] = { ...newFiles[0], expanded: !newFiles[0].expanded };
             this.files = newFiles;
         }
+    }
+
+    toggleAll() {
+        if (!this.files || this.files.length === 0) return;
+        const newFiles = [...this.files];
+        for (const file of newFiles) {
+            this.toggleSubtree(file);
+        }
+        this.files = newFiles;
     }
 }
 ```


### PR DESCRIPTION
## Description
Improved the TreeTable Controlled documentation by adding the buttons to the example code, as well as adding a "Toggle All" button, and fixing the description.

## Related issues
Fixes https://github.com/openng-org/optimus-ui/issues/1449

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [x] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [x] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->
<img width="1075" height="1081" alt="Screenshot from 2026-08-07 22-23-05" src="https://github.com/user-attachments/assets/ae1c919e-d6fb-4f66-a534-51a6a8c72d0a" />
