### PR TITLE
docs: use standalone Button in install docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ ng add @openng/optimus-ui
 The schematic asks which theme preset you want, adds the packages, wires `provideOptimus` into your root providers and installs everything.
 
 ```ts
-import { ButtonModule } from '@openng/optimus-ui/button';
+import { Button } from '@openng/optimus-ui/button';
 ```
 
 ```html

--- a/apps/docs/doc/installation/verify-doc.ts
+++ b/apps/docs/doc/installation/verify-doc.ts
@@ -2,12 +2,12 @@ import { AppCode } from '@/components/doc/app.code';
 import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
-import { ButtonModule } from '@openng/optimus-ui/button';
+import { Button } from '@openng/optimus-ui/button';
 
 @Component({
     selector: 'verify-doc',
     standalone: true,
-    imports: [AppDocSectionText, AppCode, ButtonModule],
+    imports: [AppDocSectionText, AppCode, Button],
     template: `
         <app-docsectiontext>
             <p>
@@ -25,12 +25,12 @@ import { ButtonModule } from '@openng/optimus-ui/button';
 export class VerifyDoc {
     code1: Code = {
         typescript: `import { Component } from '@angular/core';
-import { ButtonModule } from '@openng/optimus-ui/button';
+import { Button } from '@openng/optimus-ui/button';
 
 @Component({
     selector: 'button-demo',
     templateUrl: './button-demo.html',
-    imports: [ButtonModule]
+    imports: [Button]
 })
 export class ButtonDemo {}`
     };


### PR DESCRIPTION
## Description

The Quick start in `README.md` and the Verify section of the installation docs import the legacy `ButtonModule`. Both now import the standalone `Button`, including the code sample shown to users.

## Related issues

Fixes #1459

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [x] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None. `ButtonModule` still exists.

## Test plan

- [x] `npx prettier --check` passes on both files
- [x] `pnpm --filter docs build:llm-docs` produces no content change (the llms mirrors do not carry this snippet)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [x] Documentation updated (README, JSDoc, migration notes as needed)
- [x] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Other component docs still use their `*Module` variants; not touched here.
