### PR TITLE
chore: use maintained prettier vscode extension id

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
         "dbaeumer.vscode-eslint",
-        "prettier.prettier-vscode"
+        "esbenp.prettier-vscode"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,13 +3,13 @@
         "source.fixAll.eslint": "explicit",
         "source.organizeImports": "explicit"
     },
-    "editor.defaultFormatter": "prettier.prettier-vscode",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "[javascript]": {
-        "editor.defaultFormatter": "prettier.prettier-vscode",
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
     },
     "[html]": {
-        "editor.defaultFormatter": "prettier.prettier-vscode",
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
     },
     "[typescript]": {


### PR DESCRIPTION
## Description

- Updated the VS Code extension recommendation to replace the deprecated `prettier.prettier-vscode` extension

## Related issues

N/A

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [X] Refactor, test, or chore (no user-facing change)

## Breaking changes

<!-- If this is a breaking change, describe what changed and how consumers should migrate. Otherwise, write "None". -->

None

## Test plan

N/A - doesn't affect build or tests

## Checklist

- [X] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [X] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

N/A
