### PR TITLE
fix(virtualscroller): fix row height CSS

### DIFF
--- a/packages/optimus-ui/src/scroller/style/scrollerstyle.ts
+++ b/packages/optimus-ui/src/scroller/style/scrollerstyle.ts
@@ -15,7 +15,6 @@ const css = /*css*/ `
     position: absolute;
     top: 0;
     left: 0;
-    min-height: 100%;
     min-width: 100%;
     will-change: transform;
 }
@@ -54,6 +53,7 @@ const css = /*css*/ `
 
 .p-virtualscroller-horizontal > .p-virtualscroller-content {
     display: flex;
+    min-height: 100%;
 }
 
 .p-virtualscroller-inline .p-virtualscroller-content {


### PR DESCRIPTION
## Description

Min-height was making rows too high, but is needed elsewhere - in the horizontal scroller where it makes the items full-height. So the fix was to move the min-height from all scrollers to just the horizontal one.

## Related issues

Fixes #1457

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context


