### PR TITLE
fix(toast): return null for inline styles insteat of false

### DIFF
--- a/packages/optimus-ui/src/toast/style/toaststyle.ts
+++ b/packages/optimus-ui/src/toast/style/toaststyle.ts
@@ -10,8 +10,8 @@ const inlineStyles = {
         return {
             position: 'fixed',
             top: _position === 'top-right' || _position === 'top-left' || _position === 'top-center' ? '20px' : _position === 'center' ? '50%' : null,
-            right: (_position === 'top-right' || _position === 'bottom-right') && '20px',
-            bottom: (_position === 'bottom-left' || _position === 'bottom-right' || _position === 'bottom-center') && '20px',
+            right: (_position === 'top-right' || _position === 'bottom-right') ? '20px' : null,
+            bottom: (_position === 'bottom-left' || _position === 'bottom-right' || _position === 'bottom-center') ? '20px' : null,
             left: _position === 'top-left' || _position === 'bottom-left' ? '20px' : _position === 'center' || _position === 'top-center' || _position === 'bottom-center' ? '50%' : null
         };
     }


### PR DESCRIPTION
## Description

Fixes angular v22 warnings
```
_debug_node-chunk.mjs:16747 NG0318: `[style.bottom]` was bound to an invalid value. Expected a string, number, SafeValue, null, or undefined, but received `boolean` (`false`). Find more at https://v22.angular.dev/errors/NG0318
```

## Related issues

<!-- Link issues this PR addresses, e.g. Fixes #123, Closes #456, or Relates to #789 -->

Fixes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

<!-- If this is a breaking change, describe what changed and how consumers should migrate. Otherwise, write "None". -->

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->
