### PR TITLE
fix(datepicker): defer popup motion until opened (performance issue)

### DIFF
--- a/packages/optimus-ui/src/datepicker/datepicker.spec.ts
+++ b/packages/optimus-ui/src/datepicker/datepicker.spec.ts
@@ -425,6 +425,25 @@ describe('DatePicker', () => {
             expect(inputElement.nativeElement.getAttribute('placeholder')).toBe('Select a date');
         });
 
+        it('should render popup calendar cells only after the overlay is opened', async () => {
+            const dayClassSpy = spyOn(DatePicker.prototype, 'dayClass').and.callThrough();
+            const lazyFixture = TestBed.createComponent(TestDatePickerComponent);
+
+            await lazyFixture.whenStable();
+
+            expect(dayClassSpy).not.toHaveBeenCalled();
+            expect(lazyFixture.debugElement.query(By.css('p-motion'))).toBeNull();
+
+            lazyFixture.debugElement.query(By.css('input')).nativeElement.click();
+            lazyFixture.changeDetectorRef.markForCheck();
+            await lazyFixture.whenStable();
+
+            expect(dayClassSpy).toHaveBeenCalled();
+            expect(lazyFixture.debugElement.query(By.css('p-motion'))).toBeTruthy();
+
+            lazyFixture.destroy();
+        });
+
         it('should open calendar on input click', async () => {
             const inputElement = testFixture.debugElement.query(By.css('input'));
             const datePickerComponent = testFixture.debugElement.query(By.css('p-datepicker')).componentInstance;
@@ -434,6 +453,21 @@ describe('DatePicker', () => {
             await testFixture.whenStable();
 
             expect(datePickerComponent.overlayVisible).toBe(true);
+        });
+
+        it('should keep popup motion mounted until overlay cleanup finishes', async () => {
+            const datePickerComponent = testFixture.debugElement.query(By.css('p-datepicker')).componentInstance as DatePicker;
+            datePickerComponent.overlay = document.createElement('div');
+            datePickerComponent.cd.markForCheck();
+            await testFixture.whenStable();
+
+            expect(testFixture.debugElement.query(By.css('p-motion'))).toBeTruthy();
+
+            datePickerComponent.onOverlayHide();
+            datePickerComponent.cd.markForCheck();
+            await testFixture.whenStable();
+
+            expect(testFixture.debugElement.query(By.css('p-motion'))).toBeNull();
         });
 
         it('should handle date selection', async () => {
@@ -620,6 +654,7 @@ describe('DatePicker', () => {
 
             const datePickerComponent = testFixture.debugElement.query(By.css('p-datepicker')).componentInstance;
             expect(datePickerComponent.inline).toBe(true);
+            expect(testFixture.debugElement.query(By.css('p-motion'))).toBeTruthy();
         });
     });
 

--- a/packages/optimus-ui/src/datepicker/datepicker.test.ts
+++ b/packages/optimus-ui/src/datepicker/datepicker.test.ts
@@ -425,6 +425,25 @@ describe('DatePicker', () => {
             expect(inputElement.nativeElement.getAttribute('placeholder')).toBe('Select a date');
         });
 
+        it('should render popup calendar cells only after the overlay is opened', async () => {
+            const dayClassSpy = vi.spyOn(DatePicker.prototype, 'dayClass');
+            const lazyFixture = TestBed.createComponent(TestDatePickerComponent);
+
+            await lazyFixture.whenStable();
+
+            expect(dayClassSpy).not.toHaveBeenCalled();
+            expect(lazyFixture.debugElement.query(By.css('p-motion'))).toBeNull();
+
+            lazyFixture.debugElement.query(By.css('input')).nativeElement.click();
+            lazyFixture.changeDetectorRef.markForCheck();
+            await lazyFixture.whenStable();
+
+            expect(dayClassSpy).toHaveBeenCalled();
+            expect(lazyFixture.debugElement.query(By.css('p-motion'))).toBeTruthy();
+
+            lazyFixture.destroy();
+        });
+
         it('should open calendar on input click', async () => {
             const inputElement = testFixture.debugElement.query(By.css('input'));
             const datePickerComponent = testFixture.debugElement.query(By.css('p-datepicker')).componentInstance;
@@ -434,6 +453,21 @@ describe('DatePicker', () => {
             await testFixture.whenStable();
 
             expect(datePickerComponent.overlayVisible).toBe(true);
+        });
+
+        it('should keep popup motion mounted until overlay cleanup finishes', async () => {
+            const datePickerComponent = testFixture.debugElement.query(By.css('p-datepicker')).componentInstance as DatePicker;
+            datePickerComponent.overlay = document.createElement('div');
+            datePickerComponent.cd.markForCheck();
+            await testFixture.whenStable();
+
+            expect(testFixture.debugElement.query(By.css('p-motion'))).toBeTruthy();
+
+            datePickerComponent.onOverlayHide();
+            datePickerComponent.cd.markForCheck();
+            await testFixture.whenStable();
+
+            expect(testFixture.debugElement.query(By.css('p-motion'))).toBeNull();
         });
 
         it('should handle date selection', async () => {
@@ -620,6 +654,7 @@ describe('DatePicker', () => {
 
             const datePickerComponent = testFixture.debugElement.query(By.css('p-datepicker')).componentInstance;
             expect(datePickerComponent.inline).toBe(true);
+            expect(testFixture.debugElement.query(By.css('p-motion'))).toBeTruthy();
         });
     });
 

--- a/packages/optimus-ui/src/datepicker/datepicker.ts
+++ b/packages/optimus-ui/src/datepicker/datepicker.ts
@@ -147,7 +147,15 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                 </span>
             </ng-container>
         </ng-template>
-        <p-motion [visible]="inline || overlayVisible" name="p-anchored-overlay" [appear]="!inline" [options]="computedMotionOptions()" (onBeforeEnter)="onOverlayBeforeEnter($event)" (onAfterLeave)="onOverlayAfterLeave($event)">
+        <p-motion
+            *ngIf="inline || overlayVisible || overlay"
+            [visible]="inline || overlayVisible"
+            name="p-anchored-overlay"
+            [appear]="!inline"
+            [options]="computedMotionOptions()"
+            (onBeforeEnter)="onOverlayBeforeEnter($event)"
+            (onAfterLeave)="onOverlayAfterLeave($event)"
+        >
             <div
                 #contentWrapper
                 [attr.id]="panelId"


### PR DESCRIPTION
## Description

Before the v21 motion migration, the popup panel itself was guarded by a structural `*ngIf`. The current template always creates `p-motion` and passes the complete calendar panel as projected content. As a result, a closed popup DatePicker still creates Motion/BaseComponent infrastructure and evaluates the hidden calendar-cell view.

This becomes visible as synchronous dialog-opening jank when several DatePickers are created at once. See the videos below (Screenrecording from Chrome, even worse in Firefox).

## Related issues

Fixes #180 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [x] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Before

https://github.com/user-attachments/assets/195304d1-1f8a-418c-8b6d-66668e475034

After 


https://github.com/user-attachments/assets/3b18135a-8785-486c-b79b-74de4f2cfb68


