### PR TITLE
fix(autocomplete): Fix Autocomplete Chips features

### DIFF
--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -119,7 +119,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             [pInputTextUnstyled]="unstyled()"
         />
         <ng-container *ngIf="$filled() && !$disabled() && showClear && !loading">
-            <svg data-p-icon="times" *ngIf="!clearIconTemplate && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true" />
+            <svg data-p-icon="times" *ngIf="!clearIconTemplate && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true"></svg>
             <span *ngIf="clearIconTemplate || _clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true">
                 <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
             </span>
@@ -163,7 +163,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                     <ng-container *ngTemplateOutlet="selectedItemTemplate || _selectedItemTemplate; context: { $implicit: option }"></ng-container>
                     <ng-template #removeicon>
                         <span *ngIf="!removeIconTemplate && !_removeIconTemplate" [pBind]="ptm('chipIcon')" [class]="cx('chipIcon')" (click)="!readonly && !$disabled() ? removeOption($event, i) : ''">
-                            <svg data-p-icon="times-circle" [class]="cx('chipIcon')" [attr.aria-hidden]="true" />
+                            <svg data-p-icon="times-circle" [class]="cx('chipIcon')" [attr.aria-hidden]="true"></svg>
                         </span>
                         <span *ngIf="removeIconTemplate || _removeIconTemplate" [pBind]="ptm('chipIcon')" [attr.aria-hidden]="true">
                             <ng-template *ngTemplateOutlet="removeIconTemplate || _removeIconTemplate; context: { removeCallback: removeOption.bind(this), index: i, class: cx('chipIcon') }"></ng-template>
@@ -213,7 +213,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             </li>
         </ul>
         <ng-container *ngIf="loading">
-            <svg data-p-icon="spinner" *ngIf="!loadingIconTemplate && !_loadingIconTemplate" [pBind]="ptm('loader')" [class]="cx('loader')" [spin]="true" [attr.aria-hidden]="true" />
+            <svg data-p-icon="spinner" *ngIf="!loadingIconTemplate && !_loadingIconTemplate" [pBind]="ptm('loader')" [class]="cx('loader')" [spin]="true" [attr.aria-hidden]="true"></svg>
             <span *ngIf="loadingIconTemplate || _loadingIconTemplate" [pBind]="ptm('loader')" [class]="cx('loader')" [attr.aria-hidden]="true">
                 <ng-template *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate"></ng-template>
             </span>
@@ -221,7 +221,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
         <button #ddBtn type="button" [pBind]="ptm('dropdown')" [attr.aria-label]="dropdownAriaLabel" [class]="cx('dropdown')" [disabled]="$disabled()" pRipple (click)="handleDropdownClick($event)" *ngIf="dropdown" [attr.tabindex]="tabindex">
             <span *ngIf="dropdownIcon" [ngClass]="dropdownIcon" [attr.aria-hidden]="true"></span>
             <ng-container *ngIf="!dropdownIcon">
-                <svg data-p-icon="chevron-down" [pBind]="ptm('dropdown')" *ngIf="!dropdownIconTemplate && !_dropdownIconTemplate" />
+                <svg data-p-icon="chevron-down" [pBind]="ptm('dropdown')" *ngIf="!dropdownIconTemplate && !_dropdownIconTemplate"></svg>
                 <ng-template *ngTemplateOutlet="dropdownIconTemplate || _dropdownIconTemplate"></ng-template>
             </ng-container>
         </button>
@@ -656,6 +656,12 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
      * @group Props
      */
     @Input() separator: string | RegExp | undefined;
+    /**
+     * Whether to allow duplicates when typeahead is false and multiple mode is enabled.
+     * @defaultValue false
+     * @group Props
+     */
+    @Input({ transform: booleanAttribute }) allowDuplicates: boolean = false;
     /**
      * Target element to attach the overlay, valid values are "body" or a local ng-template variable of another element (note: use binding with brackets for template variables, e.g. [appendTo]="mydiv" for a div element having #mydiv as variable name).
      * @defaultValue 'self'
@@ -1408,17 +1414,19 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
     handleSeparatorKey(event) {
         if (this.separator && this.multiple && !this.typeahead) {
             if (this.separator === event.key || (typeof this.separator === 'string' && event.key === this.separator) || (this.separator instanceof RegExp && event.key.match(this.separator))) {
-                const inputValue = (this.multiInputEl?.nativeElement?.value || event.target.value || '').trim();
-                if (inputValue && !this.isSelected(inputValue)) {
+                const inputValue: string = (this.multiInputEl?.nativeElement?.value || event.target.value || '').trim();
+
+                if (inputValue && (this.allowDuplicates || !this.isSelected(inputValue))) {
                     this.updateModel([...(this.modelValue() || []), inputValue]);
                     this.onAdd.emit({ originalEvent: event, value: inputValue });
-                    if (this.multiInputEl?.nativeElement) {
-                        this.multiInputEl.nativeElement.value = '';
-                    } else {
-                        event.target.value = '';
-                    }
-                    event.preventDefault();
                 }
+
+                if (this.multiInputEl?.nativeElement) {
+                    this.multiInputEl.nativeElement.value = '';
+                } else {
+                    event.target.value = '';
+                }
+                event.preventDefault();
             }
         }
     }


### PR DESCRIPTION
## Description

The Chips input component was deprecated in v18 and removed in v19+.
Autocomplete should be the replacement with `typeahead ` set false and `multipe ` set true and `separator`, but the separator feature is not quite equivalent and somewhat buggy.
This PR apply the fix for this issue.
Addtionaly introduces the boolean input `allowDuplicate` to allow duplicates for "chip" configuration, when typeahead is false and multiple is true.

With these changes, Autocomplete can be configured to have the same behavior as the removed Chips component: https://v17.primeng.org/chips

## Related issues

<!-- Link issues this PR addresses, e.g. Fixes #123, Closes #456, or Relates to #789 -->

Fixes #267


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

<!-- If this is a breaking change, describe what changed and how consumers should migrate. Otherwise, write "None". -->

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [ ] `npm test`
- [x] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->
