### PR TITLE
fix(cascadeselect): bind aria-label to the listLabel getter

### DIFF
--- a/packages/optimus-ui/src/cascadeselect/cascadeselect.test.ts
+++ b/packages/optimus-ui/src/cascadeselect/cascadeselect.test.ts
@@ -854,6 +854,22 @@ describe('CascadeSelect', () => {
             expect(ariaRequired === null || ariaRequired === 'false').toBe(true);
             expect(hiddenInput.nativeElement.getAttribute('aria-label')).toBeTruthy();
         });
+
+        it('should set an aria-label on the option list', async () => {
+            testComponent.options = mockCountries;
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const trigger = testFixture.debugElement.query(By.css('.p-cascadeselect-dropdown'));
+            trigger.nativeElement.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            testFixture.changeDetectorRef.markForCheck();
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            const optionList = testFixture.debugElement.query(By.css('ul[role="tree"]'));
+            expect(optionList.nativeElement.getAttribute('aria-label')).toBe('Option List');
+        });
     });
 
     describe('Complex Situations and Edge Cases', () => {

--- a/packages/optimus-ui/src/cascadeselect/cascadeselect.ts
+++ b/packages/optimus-ui/src/cascadeselect/cascadeselect.ts
@@ -369,7 +369,7 @@ export class CascadeSelectSub extends BaseComponent {
                             [attr.role]="'tree'"
                             [attr.aria-orientation]="'horizontal'"
                             [pBind]="ptm('list')"
-                            [attr.aria-label]="listlabel"
+                            [attr.aria-label]="listLabel"
                             [pt]="pt"
                             [unstyled]="unstyled()"
                         ></ul>


### PR DESCRIPTION
## Summary

The CascadeSelect option list's `[attr.aria-label]` binding referenced `listlabel`, a property that does not exist on the component. The binding resolved to `undefined`, so the `aria-label` attribute was dropped from the rendered `<ul role="tree">`. The component does define a `listLabel` getter (backed by the ARIA translation key), but the template never referenced it. This PR points the binding at `listLabel`, matching the pattern already used in Select, MultiSelect, and AutoComplete.

## Steps to reproduce (before this fix)

1. Open the overlay on the CascadeSelect docs page.
2. Inspect `document.querySelector('p-cascadeselect ul[role="tree"]')`.
3. The element has no `aria-label` attribute, so screen readers announce the option tree with no accessible name.

## Change

- `packages/optimus-ui/src/cascadeselect/cascadeselect.ts`: `listlabel` -> `listLabel`.
- `packages/optimus-ui/src/cascadeselect/cascadeselect.test.ts`: added a test asserting the rendered option list gets `aria-label="Option List"`. Verified it fails without the fix and passes with it.

Fixes #1453