### PR TITLE
fix(confirmdialog): add draggable to the Confirmation interface

### DIFF
--- a/packages/optimus-ui/src/api/confirmation.ts
+++ b/packages/optimus-ui/src/api/confirmation.ts
@@ -114,4 +114,9 @@ export interface Confirmation {
      * @defaultValue true
      */
     modal?: boolean;
+    /**
+     * Enables dragging to change the position of the dialog using its header.
+     * @defaultValue true
+     */
+    draggable?: boolean;
 }

--- a/packages/optimus-ui/src/confirmdialog/confirmdialog.test.ts
+++ b/packages/optimus-ui/src/confirmdialog/confirmdialog.test.ts
@@ -233,6 +233,24 @@ class TestConfirmationServiceComponent {
     }
 }
 
+// ConfirmDialog with a Confirmation-level draggable override
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: ` <p-confirmdialog></p-confirmdialog> `,
+    providers: [ConfirmationService]
+})
+class TestConfirmationDraggableComponent {
+    constructor(private confirmationService: ConfirmationService) {}
+
+    confirm() {
+        this.confirmationService.confirm({
+            message: 'Are you sure you want to delete this record?',
+            draggable: false
+        });
+    }
+}
+
 // ConfirmDialog Accessibility Test
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -300,6 +318,7 @@ describe('ConfirmDialog', () => {
                 TestContentTemplateConfirmDialogComponent,
                 TestPositionConfirmDialogComponent,
                 TestConfirmationServiceComponent,
+                TestConfirmationDraggableComponent,
                 TestAccessibilityConfirmDialogComponent,
                 TestButtonPropertiesComponent,
                 TestEventsConfirmDialogComponent
@@ -845,6 +864,24 @@ describe('ConfirmDialog', () => {
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             expect(serviceComponent.rejectClicked).toBe(true);
+        });
+
+        it('should apply the draggable option from the Confirmation object', async () => {
+            const serviceFixture = TestBed.createComponent(TestConfirmationDraggableComponent);
+            const serviceComponent = serviceFixture.componentInstance;
+            serviceFixture.changeDetectorRef.markForCheck();
+            await serviceFixture.whenStable();
+
+            serviceComponent.confirm();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            serviceFixture.changeDetectorRef.markForCheck();
+            await serviceFixture.whenStable();
+
+            const confirmDialogInstance = serviceFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
+            expect(confirmDialogInstance.draggable).toBe(false);
+
+            const dialogInstance = serviceFixture.debugElement.query(By.directive(Dialog)).componentInstance;
+            expect(dialogInstance.draggable).toBe(false);
         });
     });
 


### PR DESCRIPTION
## Summary

`ConfirmationService.confirm()` already supports a `draggable` option at runtime: `ConfirmDialog`'s constructor copies every own key of the `Confirmation` object onto the component instance (`keys.forEach((key) => { this[key] = confirmation[key]; })`), and `draggable` is one of the component's own `@Input()`s, bound straight through to the underlying `p-dialog`. The `Confirmation` interface, however, never declared the field, so any typed caller doing `confirm({ draggable: false })` hits:

```
Object literal may only specify known properties, and 'draggable' does not exist in type 'Confirmation'.
```

This PR adds `draggable?: boolean` to the interface, next to the other dialog-behavior flags (`closable`, `modal`). No runtime code changes — the propagation path already existed.

## Change

- `packages/optimus-ui/src/api/confirmation.ts`: add `draggable?: boolean` to `Confirmation`.
- `packages/optimus-ui/src/confirmdialog/confirmdialog.test.ts`: added a test that calls `confirmationService.confirm({ draggable: false, ... })` and asserts it propagates to both the `ConfirmDialog` instance and the underlying `Dialog` instance. Verified it fails to type-check (`TS2353`) without the interface change and passes with it.

Fixes #60