### PR TITLE
fix(togglebutton): allow size to be undefined

### DIFF
--- a/packages/optimus-ui/src/togglebutton/togglebutton.test.ts
+++ b/packages/optimus-ui/src/togglebutton/togglebutton.test.ts
@@ -392,6 +392,24 @@ describe('ToggleButton', () => {
 
             expect(toggleButtonInstance.size).toBe('large');
         });
+
+        it('should allow size to be reset to undefined', async () => {
+            component.size = 'large';
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(toggleButtonInstance.size).toBe('large');
+            expect(toggleButtonElement.nativeElement.getAttribute('data-p')).toContain('large');
+
+            toggleButtonInstance.size = undefined;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(toggleButtonInstance.size).toBeUndefined();
+            expect(toggleButtonElement.nativeElement.getAttribute('data-p')).not.toContain('large');
+        });
     });
 
     describe('Reactive Forms Integration', () => {

--- a/packages/optimus-ui/src/togglebutton/togglebutton.ts
+++ b/packages/optimus-ui/src/togglebutton/togglebutton.ts
@@ -173,7 +173,7 @@ export class ToggleButton extends BaseEditableHolder<ToggleButtonPassThrough> {
      * Defines the size of the component.
      * @group Props
      */
-    @Input() size: 'large' | 'small';
+    @Input() size: 'large' | 'small' | undefined;
     /**
      * Whether selection can not be cleared.
      * @group Props


### PR DESCRIPTION
## Summary

`ToggleButton.size` was typed as `'large' | 'small'` (no `undefined`), unlike every other component in the library with a `size` input — `Button`, `Message`, and `Table` all type it `'large' | 'small' | undefined`. That makes it impossible to reset the input programmatically (`toggleButton.size = undefined` fails to compile with `TS2322`), which is awkward for anything binding size from a variable that can be cleared.

I checked the one place `size` is read at runtime, the `dataP` getter:

```ts
get dataP() {
    return this.cn({
        checked: this.active,
        invalid: this.invalid(),
        [this.size as string]: this.size
    });
}
```

`cn()` (in `@openng/optimus-ui-utils`) drops any object entry whose value is falsy, so an `undefined` `size` already produces no `data-p` token today — the getter is already `undefined`-safe. Widening the type is a pure type-level fix with no behavior change.

## Change

- `packages/optimus-ui/src/togglebutton/togglebutton.ts`: `size: 'large' | 'small'` → `size: 'large' | 'small' | undefined`.
- `packages/optimus-ui/src/togglebutton/togglebutton.test.ts`: added a test that sets `size` then resets it to `undefined`, asserting the `data-p` attribute drops the `large` token. Verified it fails to type-check (`TS2322`) without the fix and passes with it.

Fixes #19