### PR TITLE
fix(#624): p-tree-node-toggle-button missing aria-label

### DIFF
--- a/apps/docs/doc/apidoc/index.json
+++ b/apps/docs/doc/apidoc/index.json
@@ -47187,6 +47187,13 @@
                             "description": "Establishes relationships between the component and label(s) where its value should be one or more element IDs."
                         },
                         {
+                            "name": "togglerAriaLabel",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "string",
+                            "description": "Defines a string that labels the toggler icon for accessibility."
+                        },
+                        {
                             "name": "placeholder",
                             "optional": false,
                             "readonly": false,

--- a/packages/optimus-ui/src/tree/tree.test.ts
+++ b/packages/optimus-ui/src/tree/tree.test.ts
@@ -1961,12 +1961,28 @@ describe('Tree', () => {
         });
 
         it('should handle togglerAriaLabel property', async () => {
+            const testNodes: TreeNode[] = [
+                {
+                    label: 'Root',
+                    key: 'root',
+                    expanded: false,
+                    children: [{ label: 'Child 1', key: 'child1' }]
+                }
+            ];
+            component.nodes = testNodes;
             component.togglerAriaLabel = 'Toggle node';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
 
             expect(tree.togglerAriaLabel).toBe('Toggle node');
+
+            // Verify togglerAriaLabel is applied to toggle button
+            const toggleButtons = fixture.debugElement.queryAll(By.css('[role="treeitem"] button[type="button"]'));
+            if (toggleButtons.length > 0) {
+                const toggleButton = toggleButtons[0];
+                expect(toggleButton.nativeElement.getAttribute('aria-label')).toBe('Toggle node');
+            }
         });
 
         it('should handle ariaLabelledBy property', async () => {

--- a/packages/optimus-ui/src/tree/tree.ts
+++ b/packages/optimus-ui/src/tree/tree.ts
@@ -105,7 +105,7 @@ const TREENODE_INSTANCE = new InjectionToken<UITreeNode>('TREENODE_INSTANCE');
                     [draggable]="tree.draggableNodes"
                     [pBind]="getPTOptions('nodeContent')"
                 >
-                    <button type="button" [class]="cx('nodeToggleButton')" (click)="toggle($event)" pRipple tabindex="-1" [pBind]="getPTOptions('nodeToggleButton')">
+                    <button type="button" [attr.aria-label]="togglerAriaLabel" [class]="cx('nodeToggleButton')" (click)="toggle($event)" pRipple tabindex="-1" [pBind]="getPTOptions('nodeToggleButton')">
                         <ng-container *ngIf="!tree.togglerIconTemplate && !tree._togglerIconTemplate">
                             <ng-container *ngIf="!node.loading">
                                 <svg data-p-icon="chevron-right" *ngIf="!node.expanded" [class]="cx('nodeToggleIcon')" [pBind]="getPTOptions('nodeToggleIcon')" />
@@ -172,6 +172,8 @@ const TREENODE_INSTANCE = new InjectionToken<UITreeNode>('TREENODE_INSTANCE');
                         [itemSize]="itemSize"
                         [level]="level + 1"
                         [loadingMode]="loadingMode"
+                        +
+                        [togglerAriaLabel]="togglerAriaLabel"
                         [pt]="pt"
                         [unstyled]="unstyled()"
                     ></p-treeNode>
@@ -208,6 +210,8 @@ export class UITreeNode extends BaseComponent<TreePassThrough> {
     @Input({ transform: numberAttribute }) itemSize: number | undefined;
 
     @Input() loadingMode: string;
+
+    @Input() togglerAriaLabel: string;
 
     tree: Tree = inject(forwardRef(() => Tree));
 
@@ -818,6 +822,7 @@ export class UITreeNode extends BaseComponent<TreePassThrough> {
                             [itemSize]="scrollerOptions.itemSize"
                             [indentation]="indentation"
                             [loadingMode]="loadingMode"
+                            [togglerAriaLabel]="togglerAriaLabel"
                             [pt]="pt"
                             [unstyled]="unstyled()"
                         ></p-treeNode>
@@ -840,6 +845,8 @@ export class UITreeNode extends BaseComponent<TreePassThrough> {
                             [index]="index"
                             [level]="0"
                             [loadingMode]="loadingMode"
+                            +
+                            [togglerAriaLabel]="togglerAriaLabel"
                             [pt]="pt"
                             [unstyled]="unstyled()"
                         ></p-treeNode>

--- a/packages/optimus-ui/src/treeselect/treeselect.test.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.test.ts
@@ -6,6 +6,7 @@ import { SharedModule, TreeNode } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { TreeSelectNodeCollapseEvent, TreeSelectNodeExpandEvent } from '@openng/optimus-ui/types/treeselect';
 import { BehaviorSubject } from 'rxjs';
+import { Tree } from '../tree/tree';
 import { TreeSelect, TreeSelectModule } from './treeselect';
 
 const mockTreeNodes: TreeNode[] = [
@@ -76,6 +77,7 @@ const mockTreeNodes: TreeNode[] = [
             [tabindex]="tabindex"
             [inputId]="inputId"
             [ariaLabel]="ariaLabel"
+            [togglerAriaLabel]="togglerAriaLabel"
             [ariaLabelledBy]="ariaLabelledBy"
             [panelClass]="panelClass"
             [panelStyle]="panelStyle"
@@ -200,6 +202,7 @@ class TestTreeSelectComponent {
     tabindex: number = 0;
     inputId: string | undefined;
     ariaLabel: string = 'Test tree select';
+    togglerAriaLabel: string | undefined;
     ariaLabelledBy: string | undefined;
 
     // Styling
@@ -1216,6 +1219,23 @@ describe('TreeSelect', () => {
             expect(hiddenInput.nativeElement.getAttribute('id')).toBe('tree-input');
             expect(hiddenInput.nativeElement.getAttribute('role')).toBe('combobox');
             expect(hiddenInput.nativeElement.getAttribute('aria-haspopup')).toBe('tree');
+        });
+
+        it('should handle togglerAriaLabel property', async () => {
+            testComponent.togglerAriaLabel = 'Expand node';
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const treeSelectInstance = testFixture.debugElement.query(By.directive(TreeSelect)).componentInstance;
+            expect(treeSelectInstance.togglerAriaLabel).toBe('Expand node');
+
+            // Verify togglerAriaLabel is passed to the internal Tree component
+            const treeComponent = testFixture.debugElement.query(By.directive(Tree));
+            if (treeComponent) {
+                const tree = treeComponent.componentInstance;
+                expect(tree.togglerAriaLabel).toBe('Expand node');
+            }
         });
 
         it('should handle keyboard navigation', async () => {

--- a/packages/optimus-ui/src/treeselect/treeselect.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.ts
@@ -171,6 +171,7 @@ const TREESELECT_INSTANCE = new InjectionToken<TreeSelect>('TREESELECT_INSTANCE'
                             [_templateMap]="templateMap"
                             [loading]="loading"
                             [filterInputAutoFocus]="filterInputAutoFocus"
+                            [togglerAriaLabel]="togglerAriaLabel"
                             [loadingMode]="loadingMode"
                             [pt]="ptm('pcTree')"
                             [unstyled]="unstyled()"
@@ -281,6 +282,11 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
      * @group Props
      */
     @Input() ariaLabelledBy: string | undefined;
+    /**
+     * Defines a string that labels the toggler icon for accessibility.
+     * @group Props
+     */
+    @Input() togglerAriaLabel: string | undefined;
     /**
      * Label to display when there are no selections.
      * @group Props


### PR DESCRIPTION
## Description

Added the `togglerAriaLabel` input to the missing locations in the `treeselect` and `tree` components.

## Related issues
Fixes #624 
