### PR TITLE
fix(password): password directive with strength bar and documation update

### DIFF
--- a/apps/docs/doc/password/directive-doc.ts
+++ b/apps/docs/doc/password/directive-doc.ts
@@ -1,0 +1,26 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { PasswordModule } from '@openng/optimus-ui/password';
+
+@Component({
+    selector: 'directive-doc',
+    standalone: true,
+    imports: [FormsModule, PasswordModule, AppCode, AppDocSectionText],
+    template: `
+        <app-docsectiontext>
+            <p>
+                The <i>pPassword</i> directive adds strength meter feedback to any native <i>input</i> element. Applying it directly to an <i>input</i> is useful when you need full control over native attributes such as <i>autocomplete</i>. Setting
+                <i>autocomplete</i> to <i>"new-password"</i> tells the browser this field expects a new password, preventing it from autofilling with saved credentials.
+            </p>
+        </app-docsectiontext>
+        <div class="card flex justify-center">
+            <input type="password" pPassword [(ngModel)]="value" autocomplete="new-password" placeholder="New password" />
+        </div>
+        <app-code></app-code>
+    `
+})
+export class DirectiveDoc {
+    value!: string;
+}

--- a/apps/docs/pages/password/index.ts
+++ b/apps/docs/pages/password/index.ts
@@ -1,23 +1,24 @@
+import { AppDoc } from '@/components/doc/app.doc';
 import { AccessibilityDoc } from '@/doc/password/accessibility-doc';
 import { BasicDoc } from '@/doc/password/basic-doc';
+import { ClearIconDoc } from '@/doc/password/clearicon-doc';
+import { DirectiveDoc } from '@/doc/password/directive-doc';
 import { DisabledDoc } from '@/doc/password/disabled-doc';
 import { FilledDoc } from '@/doc/password/filled-doc';
 import { FloatLabelDoc } from '@/doc/password/floatlabel-doc';
+import { FluidDoc } from '@/doc/password/fluid-doc';
 import { IftaLabelDoc } from '@/doc/password/iftalabel-doc';
 import { ImportDoc } from '@/doc/password/import-doc';
 import { InvalidDoc } from '@/doc/password/invalid-doc';
 import { LocaleDoc } from '@/doc/password/locale-doc';
 import { MeterDoc } from '@/doc/password/meter-doc';
+import { PTComponent } from '@/doc/password/pt/PTComponent';
 import { ReactiveFormsDoc } from '@/doc/password/reactiveforms-doc';
 import { SizesDoc } from '@/doc/password/sizes-doc';
 import { TemplateDoc } from '@/doc/password/template-doc';
 import { TemplateDrivenFormsDoc } from '@/doc/password/templatedrivenforms-doc';
 import { ToggleMaskDoc } from '@/doc/password/togglemask-doc';
-import { FluidDoc } from '@/doc/password/fluid-doc';
-import { ClearIconDoc } from '@/doc/password/clearicon-doc';
-import { PTComponent } from '@/doc/password/pt/PTComponent';
 import { Component } from '@angular/core';
-import { AppDoc } from '@/components/doc/app.doc';
 
 @Component({
     template: `<app-doc
@@ -44,6 +45,11 @@ export class PasswordDemo {
             id: 'basic',
             label: 'Basic',
             component: BasicDoc
+        },
+        {
+            id: 'directive',
+            label: 'Directive',
+            component: DirectiveDoc
         },
 
         {

--- a/apps/docs/public/demos.json
+++ b/apps/docs/public/demos.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "generatedAt": "2026-08-20T21:26:44.471Z",
-  "totalDemos": 803,
+  "generatedAt": "2026-08-21T04:32:36.054Z",
+  "totalDemos": 804,
   "demos": {
     "Image-template-demo": {
       "key": "Image-template-demo",
@@ -8744,6 +8744,23 @@
         "extFiles": [],
         "imports": [
           "PasswordModule",
+          "FormsModule"
+        ]
+      }
+    },
+    "password-directive-demo": {
+      "key": "password-directive-demo",
+      "selector": "password-directive-demo",
+      "component": "password",
+      "section": "directive",
+      "code": {
+        "typescript": "import { Component } from '@angular/core';\nimport { FormsModule } from '@angular/forms';\n\n@Component({\n    template: `\n        <div class=\"card flex justify-center\">\n            <input type=\"password\" pPassword [(ngModel)]=\"value\" autocomplete=\"new-password\" placeholder=\"New password\" />\n        </div>\n    `,\n    standalone: true,\n    imports: [FormsModule]\n})\nexport class PasswordDirectiveDemo {\n    value!: string;\n}"
+      },
+      "metadata": {
+        "services": [],
+        "optimusServices": [],
+        "extFiles": [],
+        "imports": [
           "FormsModule"
         ]
       }

--- a/packages/optimus-ui/src/password/password.spec.ts
+++ b/packages/optimus-ui/src/password/password.spec.ts
@@ -1327,7 +1327,7 @@ describe('PasswordDirective', () => {
             expect(directive.meter).toBeTruthy();
             expect(directive.info).toBeTruthy();
             expect(directive.content).toBeTruthy();
-            expect(directive.label).toBeTruthy();
+            expect(directive.meterLabel).toBeTruthy();
         });
 
         it('should show overlay on focus', async () => {

--- a/packages/optimus-ui/src/password/password.test.ts
+++ b/packages/optimus-ui/src/password/password.test.ts
@@ -1,8 +1,8 @@
-import type { Mock } from 'vitest';
 import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 import { CommonModule } from '@angular/common';
 import { SharedModule } from '@openng/optimus-ui/api';
@@ -1328,7 +1328,7 @@ describe('PasswordDirective', () => {
             expect(directive.meter).toBeTruthy();
             expect(directive.info).toBeTruthy();
             expect(directive.content).toBeTruthy();
-            expect(directive.label).toBeTruthy();
+            expect(directive.meterLabel).toBeTruthy();
         });
 
         it('should show overlay on focus', async () => {

--- a/packages/optimus-ui/src/password/password.ts
+++ b/packages/optimus-ui/src/password/password.ts
@@ -30,7 +30,7 @@ import {
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionOptions } from '@openng/optimus-ui-motion';
-import { absolutePosition, addClass, hasClass, isTouchDevice, removeClass } from '@openng/optimus-ui-utils';
+import { absolutePosition, addClass, isTouchDevice, removeClass } from '@openng/optimus-ui-utils';
 import { OverlayOptions, OverlayService, PrimeTemplate, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { AutoFocus } from '@openng/optimus-ui/autofocus';
 import { PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -160,7 +160,7 @@ export class PasswordDirective extends BaseEditableHolder {
 
     content: Nullable<HTMLDivElement>;
 
-    label: Nullable<HTMLLabelElement>;
+    meterLabel: Nullable<HTMLDivElement>;
 
     scrollHandler: Nullable<ConnectedOverlayScrollHandler>;
 
@@ -200,18 +200,18 @@ export class PasswordDirective extends BaseEditableHolder {
             this.renderer.addClass(this.meter, 'p-password-meter');
             this.renderer.appendChild(this.content, this.meter);
 
-            this.label = this.renderer.createElement('div');
-            this.renderer.addClass(this.label, 'p-password-meter-label');
-            this.renderer.appendChild(this.meter, this.label);
+            this.meterLabel = this.renderer.createElement('div');
+            this.renderer.addClass(this.meterLabel, 'p-password-meter-label');
+            this.renderer.appendChild(this.meter, this.meterLabel);
 
             this.info = this.renderer.createElement('div');
             this.renderer.addClass(this.info, 'p-password-meter-text');
             this.renderer.setProperty(this.info, 'textContent', this.promptLabel);
             this.renderer.appendChild(this.content, this.info);
 
+            this.renderer.setStyle(this.panel, 'position', 'absolute');
             this.renderer.setStyle(this.panel, 'minWidth', `${this.el.nativeElement.offsetWidth}px`);
-            this.renderer.appendChild(document.body, this.panel);
-            this.updateMeter();
+            this.renderer.appendChild(this.document.body, this.panel);
         }
     }
 
@@ -223,28 +223,37 @@ export class PasswordDirective extends BaseEditableHolder {
 
             this.renderer.setStyle(this.panel, 'zIndex', String(++DomHandler.zindex));
             this.renderer.setStyle(this.panel, 'display', 'block');
-            this.zone.runOutsideAngular(() => {
-                setTimeout(() => {
-                    addClass(this.panel!, 'p-connected-overlay-visible');
-                    this.bindScrollListener();
-                    this.bindDocumentResizeListener();
-                }, 1);
-            });
             absolutePosition(this.panel!, this.el.nativeElement);
+            removeClass(this.panel!, 'p-password-leave');
+            addClass(this.panel!, 'p-password-enter');
+            this.bindScrollListener();
+            this.bindDocumentResizeListener();
+            this.updateMeter(false);
         }
     }
 
     hideOverlay() {
         if (this.feedback && this.panel) {
-            addClass(this.panel, 'p-connected-overlay-hidden');
-            removeClass(this.panel, 'p-connected-overlay-visible');
+            const panelRef = this.panel;
+
+            removeClass(panelRef, 'p-password-enter');
+            addClass(panelRef, 'p-password-leave');
             this.unbindScrollListener();
             this.unbindDocumentResizeListener();
 
+            // Nullify immediately so a re-focus within the animation window creates a fresh panel
+            this.panel = null;
+            this.meter = null;
+            this.meterLabel = null;
+            this.info = null;
+            this.content = null;
+
             this.zone.runOutsideAngular(() => {
                 setTimeout(() => {
-                    this.onDestroy();
-                }, 150);
+                    if (panelRef.parentNode) {
+                        panelRef.parentNode.removeChild(panelRef);
+                    }
+                }, 300);
             });
         }
     }
@@ -271,6 +280,8 @@ export class PasswordDirective extends BaseEditableHolder {
             if (value.length === 0) {
                 label = this.promptLabel;
                 meterPos = '0px 0px';
+                this.labelSignal.set('');
+                this.updateMeter();
             } else {
                 var score = this.testStrength(value);
 
@@ -289,7 +300,7 @@ export class PasswordDirective extends BaseEditableHolder {
                 this.updateMeter();
             }
 
-            if (!this.panel || !hasClass(this.panel, 'p-connected-overlay-visible')) {
+            if (!this.panel) {
                 this.showOverlay();
             }
 
@@ -303,15 +314,37 @@ export class PasswordDirective extends BaseEditableHolder {
         }
     }
 
-    updateMeter() {
-        if (this.labelSignal() && this.meter && this.info) {
+    updateMeter(animate = true) {
+        if (this.meterLabel) {
+            ['weak', 'medium', 'strong'].forEach((strength) => {
+                this.renderer.removeClass(this.meterLabel, this.strengthClass(strength));
+            });
+        }
+
+        if (this.labelSignal() && this.meter && this.meterLabel && this.info) {
             const label = this.labelSignal();
             const strengthClass = this.strengthClass(label.toLowerCase());
             const width = this.getWidth(label.toLowerCase());
 
-            this.renderer.addClass(this.meter, strengthClass);
-            this.renderer.setStyle(this.meter, 'width', width);
+            if (!animate) {
+                this.renderer.setStyle(this.meterLabel, 'transition', 'none');
+            }
+
+            this.renderer.addClass(this.meterLabel, strengthClass);
+            this.renderer.setStyle(this.meterLabel, 'width', width);
             (this.info as HTMLDivElement).textContent = label;
+
+            if (!animate) {
+                this.zone.runOutsideAngular(() => {
+                    setTimeout(() => {
+                        if (this.meterLabel) {
+                            this.renderer.removeStyle(this.meterLabel, 'transition');
+                        }
+                    }, 0);
+                });
+            }
+        } else if (this.meterLabel) {
+            this.renderer.setStyle(this.meterLabel, 'width', '');
         }
     }
 
@@ -354,7 +387,7 @@ export class PasswordDirective extends BaseEditableHolder {
     bindScrollListener() {
         if (!this.scrollHandler) {
             this.scrollHandler = new ConnectedOverlayScrollHandler(this.el.nativeElement, () => {
-                if (hasClass(this.panel!, 'p-connected-overlay-visible')) {
+                if (this.panel) {
                     this.hideOverlay();
                 }
             });
@@ -403,7 +436,9 @@ export class PasswordDirective extends BaseEditableHolder {
             this.renderer.removeChild(this.document.body, this.panel);
             this.panel = null;
             this.meter = null;
+            this.meterLabel = null;
             this.info = null;
+            this.content = null;
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes the strength-meter overlay for the `pPassword` directive (used on a plain `<input pPassword>` instead of the `<p-password>` component). Previously:

- The overlay panel never appeared, because it was missing `position: absolute`, so `absolutePosition()` had no effect and the panel rendered off-screen at the bottom of `<body>`.
- The overlay show/hide logic toggled `p-connected-overlay-visible` / `p-connected-overlay-hidden`, classes that don't exist in the password stylesheet. The real animation classes are `p-password-enter` / `p-password-leave`.
- The strength class (`p-password-meter-weak/medium/strong`) and the fill `width` were applied to the outer `.p-password-meter` track instead of the inner `.p-password-meter-label` bar, so the bar always rendered fully filled/red regardless of actual strength.
- Re-focusing the input after a completed strength check replayed the CSS width transition from `0%` even though the strength (and thus the target width) hadn't changed.
- The scroll handler and keyup logic depended on the now-unused `hasClass(panel, 'p-connected-overlay-visible')` check.

**Before:** typing in a `pPassword`-directive input showed no popover, or showed a meter bar that jumped straight to 100% red fill regardless of password strength, and re-focusing caused the bar to visibly re-animate from empty.

**After:** the popover now appears correctly positioned below the input, the meter bar fills to 33/66/100% with the correct weak/medium/strong color, and re-focusing an input with an already-typed password shows the bar at the correct width instantly (no transition flash).

Also added a "Directive" usage example to the Password docs demonstrating `pPassword` with `autocomplete="new-password"`, for cases where consumers need native attribute control (e.g. preventing browser autofill) that isn't otherwise exposed via `<p-password>`.

## Related issues

Fixes #954 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (manually confirmed overlay positioning, meter fill/color per strength level, and no re-animation flash on re-focus)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [x] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Changes are in `packages/optimus-ui/src/password/password.ts` (`PasswordDirective` only — the `Password` component was already unaffected). Added a new "Directive" doc example at `apps/docs/doc/password/directive-doc.ts`, registered in `apps/docs/pages/password/index.ts`, and regenerated `apps/docs/public/demos.json` via `node scripts/build-demo-code.mjs`.

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->
### Working Demo


https://github.com/user-attachments/assets/d331080f-1db1-4f21-b9c1-da7abf5e2fbc


