### PR TITLE
fix(toast): return null instead of false in inline position styles

### DIFF
--- a/packages/optimus-ui/src/chip/style/chipstyle.ts
+++ b/packages/optimus-ui/src/chip/style/chipstyle.ts
@@ -4,7 +4,7 @@ import { BaseStyle } from '@openng/optimus-ui/base';
 
 const inlineStyles = {
     root: ({ instance }) => ({
-        display: !instance.visible && 'none'
+        display: !instance.visible ? 'none' : null
     })
 };
 

--- a/packages/optimus-ui/src/speeddial/style/speeddialstyle.ts
+++ b/packages/optimus-ui/src/speeddial/style/speeddialstyle.ts
@@ -5,8 +5,8 @@ import { BaseStyle } from '@openng/optimus-ui/base';
 /* Direction */
 const inlineStyles = {
     root: ({ instance }) => ({
-        alignItems: (instance.direction === 'up' || instance.direction === 'down') && 'center',
-        justifyContent: (instance.direction === 'left' || instance.direction === 'right') && 'center',
+        alignItems: instance.direction === 'up' || instance.direction === 'down' ? 'center' : null,
+        justifyContent: instance.direction === 'left' || instance.direction === 'right' ? 'center' : null,
         flexDirection: instance.direction === 'up' ? 'column-reverse' : instance.direction === 'down' ? 'column' : instance.direction === 'left' ? 'row-reverse' : instance.direction === 'right' ? 'row' : null
     }),
     list: ({ instance }) => ({

--- a/packages/optimus-ui/src/toast/style/toaststyle.ts
+++ b/packages/optimus-ui/src/toast/style/toaststyle.ts
@@ -10,8 +10,8 @@ const inlineStyles = {
         return {
             position: 'fixed',
             top: _position === 'top-right' || _position === 'top-left' || _position === 'top-center' ? '20px' : _position === 'center' ? '50%' : null,
-            right: (_position === 'top-right' || _position === 'bottom-right') && '20px',
-            bottom: (_position === 'bottom-left' || _position === 'bottom-right' || _position === 'bottom-center') && '20px',
+            right: _position === 'top-right' || _position === 'bottom-right' ? '20px' : null,
+            bottom: _position === 'bottom-left' || _position === 'bottom-right' || _position === 'bottom-center' ? '20px' : null,
             left: _position === 'top-left' || _position === 'bottom-left' ? '20px' : _position === 'center' || _position === 'top-center' || _position === 'bottom-center' ? '50%' : null
         };
     }


### PR DESCRIPTION
## Description

Angular 22.1.1 added a dev-mode `NG0318` console warning when a style binding receives a value that is not a string, number, SafeValue, `null`, or `undefined` (angular/angular@deecb301c8). Several `inlineStyles` objects used short-circuit `&&` expressions that yield boolean `false`, which triggers the warning through the components' `[style]` host bindings:

- **Toast** — `right`/`bottom` used `(cond) && '20px'`: warns for the sides that don't match the current `position`, as reported in #1556
- **Chip** — `display` used `!instance.visible && 'none'`: warns for every visible chip (the default state)
- **SpeedDial** — `alignItems`/`justifyContent`: bound via `[ngStyle]` so it does not warn today; fixed in the same pass for consistency

**Before:** `NG0318: '[style.bottom]' was bound to an invalid value. Expected a string, number, SafeValue, null, or undefined, but received 'boolean' ('false')` logged in dev mode when using `p-toast`.
**After:** no warning. Rendered output is unchanged — `false` and `null` both result in the property not being set.

The `&&` expressions are replaced with ternaries returning `null`, matching the existing `top`/`left` properties in the same style objects.

## Related issues

Fixes #1556

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [x] `ng test optimus-ui` for the affected components (toast, chip, speeddial specs): 309/309 pass
- [x] Prettier check clean on the touched files
- [ ] `npm run build`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes — no behavioral change (`false` and `null` render identically); existing specs cover the components
- [ ] Documentation updated (README, JSDoc, migration notes as needed) — not needed
- [ ] Public API changes documented; breaking changes called out — no API change
- [ ] CHANGELOG updated — repository relies on GitHub releases
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

- The warning is dev-mode only (`ngDevMode`); production builds are unaffected.
- Upstream PrimeNG `master` still has the identical `&&` pattern in `toaststyle.ts`, so this is a fork-original fix and a candidate to contribute upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gW5jUwcp3AFVWobB7ZZck