### PR TITLE
fix(migration): #1559 avoid full schematic tree scans during migration

### DIFF
--- a/packages/optimus-ui/schematics/migrate-from-primeng/index.ts
+++ b/packages/optimus-ui/schematics/migrate-from-primeng/index.ts
@@ -4,6 +4,7 @@ import { createIgnoreMatcher, IgnoreMatcher } from '../utils/gitignore';
 import { mapAssetReference, SPECIFIER_RENAMES } from '../utils/mappings';
 import { findPrimengMajor, hasPrimeflex, SKIP_DIRS, swapDependencies } from '../utils/package-json';
 import { renameStylesheetLayers, rewriteSource } from '../utils/rewrite';
+import { visitWorkspaceFiles } from '../utils/workspace-files';
 import { Schema } from './schema';
 
 const REPORT_EXTENSIONS = ['.ts', '.mts', '.js', '.mjs', '.html', '.scss', '.css', '.sass', '.less', '.json', '.md'];
@@ -28,27 +29,28 @@ const LOCKFILE_NAMES = new Set(['package-lock.json', 'npm-shrinkwrap.json', 'yar
 export function migrateFromPrimeng(options: Schema): Rule {
     return (tree: Tree, context: SchematicContext) => {
         checkVersionGate(tree, options);
-
-        // Coverage reports, build output and other git-ignored files are not the user's source:
-        // rewriting them is pointless and reporting them buries the leftovers that do matter.
         const isIgnored = createIgnoreMatcher(tree);
 
         const packageJsonPaths: string[] = [];
         const sourcePaths: string[] = [];
         const assetReferencePaths: string[] = [];
-        tree.visit((path) => {
-            if (SKIP_DIRS.test(path) || isIgnored(path)) {
-                return;
+        visitWorkspaceFiles(
+            tree,
+            (path) => {
+                const basename = path.slice(path.lastIndexOf('/') + 1);
+                if (basename === 'package.json') {
+                    packageJsonPaths.push(path);
+                } else if (path.endsWith('.ts') || path.endsWith('.mts') || TAILWIND_CONFIG_RE.test(path)) {
+                    sourcePaths.push(path);
+                } else if (STYLESHEET_EXTENSIONS.some((ext) => path.endsWith(ext)) || WORKSPACE_CONFIG_NAMES.has(basename)) {
+                    assetReferencePaths.push(path);
+                }
+            },
+            {
+                shouldDescend: (path) => !SKIP_DIRS.test(path) && !isIgnored(path),
+                shouldVisitFile: (path) => !SKIP_DIRS.test(path) && !isIgnored(path)
             }
-            const basename = path.slice(path.lastIndexOf('/') + 1);
-            if (basename === 'package.json') {
-                packageJsonPaths.push(path);
-            } else if (path.endsWith('.ts') || path.endsWith('.mts') || TAILWIND_CONFIG_RE.test(path)) {
-                sourcePaths.push(path);
-            } else if (STYLESHEET_EXTENSIONS.some((ext) => path.endsWith(ext)) || WORKSPACE_CONFIG_NAMES.has(basename)) {
-                assetReferencePaths.push(path);
-            }
-        });
+        );
 
         for (const path of packageJsonPaths) {
             migratePackageJson(tree, context, path);
@@ -165,20 +167,25 @@ const MIGRATION_GUIDE_URL = 'https://www.openng.org/migration/primeng';
 function reportLeftovers(tree: Tree, context: SchematicContext, isIgnored: IgnoreMatcher): void {
     const leftovers: string[] = [];
     const files = new Set<string>();
-    tree.visit((path, entry) => {
-        if (SKIP_DIRS.test(path) || !entry || isLockfile(path) || isIgnored(path) || !REPORT_EXTENSIONS.some((ext) => path.endsWith(ext))) {
-            return;
-        }
-        entry.content
-            .toString()
-            .split('\n')
-            .forEach((line, index) => {
+    visitWorkspaceFiles(
+        tree,
+        (path, read) => {
+            const content = read();
+            if (content === undefined) {
+                return;
+            }
+            content.split('\n').forEach((line, index) => {
                 if (/primeng|primeicons|@primeuix|tailwindcss-primeui|primelocale/i.test(line)) {
                     leftovers.push(`${path}:${index + 1}  ${line.trim()}`);
                     files.add(path);
                 }
             });
-    });
+        },
+        {
+            shouldDescend: (path) => !SKIP_DIRS.test(path) && !isIgnored(path),
+            shouldVisitFile: (path) => !SKIP_DIRS.test(path) && !isIgnored(path) && !isLockfile(path) && REPORT_EXTENSIONS.some((ext) => path.endsWith(ext))
+        }
+    );
     if (leftovers.length === 0) {
         context.logger.info('No leftover primeng/primeicons/@primeuix/tailwindcss-primeui/primelocale references found — nothing left to review.');
         return;

--- a/packages/optimus-ui/schematics/utils/gitignore.ts
+++ b/packages/optimus-ui/schematics/utils/gitignore.ts
@@ -1,5 +1,6 @@
 import { Tree } from '@angular-devkit/schematics';
 import { SKIP_DIRS } from './package-json';
+import { visitWorkspaceFiles } from './workspace-files';
 
 /**
  * Minimal `.gitignore` matcher.
@@ -32,15 +33,23 @@ const REGEXP_SPECIALS = /[.+^${}()|[\]\\]/g;
 
 export function createIgnoreMatcher(tree: Tree): IgnoreMatcher {
     const files: IgnoreFile[] = [];
-    tree.visit((path, entry) => {
-        if (SKIP_DIRS.test(path) || !entry || path.slice(path.lastIndexOf('/') + 1) !== GITIGNORE_NAME) {
-            return;
+    visitWorkspaceFiles(
+        tree,
+        (path, read) => {
+            const content = read();
+            if (content === undefined) {
+                return;
+            }
+            const rules = parseGitignore(content);
+            if (rules.length > 0) {
+                files.push({ base: path.slice(0, path.lastIndexOf('/') + 1), rules });
+            }
+        },
+        {
+            shouldDescend: (path) => !SKIP_DIRS.test(path),
+            shouldVisitFile: (path) => path.slice(path.lastIndexOf('/') + 1) === GITIGNORE_NAME
         }
-        const rules = parseGitignore(entry.content.toString());
-        if (rules.length > 0) {
-            files.push({ base: path.slice(0, path.lastIndexOf('/') + 1), rules });
-        }
-    });
+    );
     if (files.length === 0) {
         return () => false;
     }

--- a/packages/optimus-ui/schematics/utils/package-json.ts
+++ b/packages/optimus-ui/schematics/utils/package-json.ts
@@ -1,7 +1,8 @@
 import { Tree } from '@angular-devkit/schematics';
 import { MODULE_MAP, VERSIONS } from './mappings';
+import { visitWorkspaceFiles } from './workspace-files';
 
-export const SKIP_DIRS = /(^|\/)(node_modules|dist|\.angular|\.git|out-tsc)\//;
+export const SKIP_DIRS = /(^|\/)(node_modules|dist|\.angular|\.git|out-tsc)(\/|$)/;
 
 // Sections where a package can be declared as a direct dependency of some kind.
 const DIRECT_DEPENDENCY_SECTIONS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const;
@@ -198,20 +199,24 @@ export function hasPrimeflex(tree: Tree): boolean {
  * invoking `visitor` with each successfully-parsed package.json contents.
  */
 function visitWorkspacePackageJsons(tree: Tree, visitor: (pkg: Record<string, any>) => void): void {
-    tree.visit((path) => {
-        if (SKIP_DIRS.test(path) || !path.endsWith('/package.json')) {
-            return;
+    visitWorkspaceFiles(
+        tree,
+        (path, read) => {
+            const content = read();
+            if (content === undefined) {
+                return;
+            }
+            let pkg: Record<string, any>;
+            try {
+                pkg = JSON.parse(content);
+            } catch {
+                return;
+            }
+            visitor(pkg);
+        },
+        {
+            shouldDescend: (path) => !SKIP_DIRS.test(path),
+            shouldVisitFile: (path) => !SKIP_DIRS.test(path) && path.endsWith('/package.json')
         }
-        const buffer = tree.read(path);
-        if (!buffer) {
-            return;
-        }
-        let pkg: Record<string, any>;
-        try {
-            pkg = JSON.parse(buffer.toString());
-        } catch {
-            return;
-        }
-        visitor(pkg);
-    });
+    );
 }

--- a/packages/optimus-ui/schematics/utils/workspace-files.spec.ts
+++ b/packages/optimus-ui/schematics/utils/workspace-files.spec.ts
@@ -1,0 +1,55 @@
+import { HostTree } from '@angular-devkit/schematics';
+import { UnitTestTree } from '@angular-devkit/schematics/testing';
+import { describe, expect, it, vi } from 'vitest';
+import { SKIP_DIRS } from './package-json';
+import { visitWorkspaceFiles } from './workspace-files';
+
+function tree(files: Record<string, string>): UnitTestTree {
+    const result = new UnitTestTree(new HostTree());
+    for (const [path, content] of Object.entries(files)) {
+        result.create(path, content);
+    }
+    return result;
+}
+
+describe('visitWorkspaceFiles', () => {
+    it('does not descend into pruned directories', () => {
+        const visited: string[] = [];
+        visitWorkspaceFiles(
+            tree({
+                '/src/app.ts': '',
+                '/src/nested/component.ts': '',
+                '/dist/main.js': '',
+                '/node_modules/pkg/index.ts': '',
+                '/libs/ui/package.json': '{}\n'
+            }),
+            (path) => visited.push(path),
+            {
+                shouldDescend: (path) => !SKIP_DIRS.test(path),
+                // Keep the file filter aligned with production callers: skipped paths must not be read.
+                shouldVisitFile: (path) => !SKIP_DIRS.test(path) && (path.endsWith('.ts') || path.endsWith('/package.json'))
+            }
+        );
+
+        expect(visited).toContain('/src/app.ts');
+        expect(visited).toContain('/src/nested/component.ts');
+        expect(visited).toContain('/libs/ui/package.json');
+        expect(visited).not.toContain('/dist/main.js');
+        expect(visited).not.toContain('/node_modules/pkg/index.ts');
+    });
+
+    it('does not read files until the visitor requests their contents', () => {
+        const workspace = tree({ '/src/app.ts': 'const app = true;' });
+        const readFile = vi.spyOn(workspace, 'read');
+        let read: (() => string | undefined) | undefined;
+
+        visitWorkspaceFiles(workspace, (_path, fileRead) => {
+            read = fileRead;
+        });
+
+        expect(read).toBeDefined();
+        expect(readFile).not.toHaveBeenCalled();
+        expect(read!()).toBe('const app = true;');
+        expect(readFile).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/optimus-ui/schematics/utils/workspace-files.ts
+++ b/packages/optimus-ui/schematics/utils/workspace-files.ts
@@ -1,0 +1,34 @@
+import { Tree } from '@angular-devkit/schematics';
+
+export interface WorkspaceFileVisitOptions {
+    shouldDescend?: (path: string) => boolean;
+    shouldVisitFile?: (path: string) => boolean;
+}
+
+export type WorkspaceFileReader = () => string | undefined;
+
+export function visitWorkspaceFiles(tree: Tree, visitor: (path: string, read: WorkspaceFileReader) => void, options: WorkspaceFileVisitOptions = {}): void {
+    visitDirectory(tree, '/', visitor, options);
+}
+
+function visitDirectory(tree: Tree, dirPath: string, visitor: (path: string, read: WorkspaceFileReader) => void, options: WorkspaceFileVisitOptions): void {
+    const dir = tree.getDir(dirPath);
+    for (const name of dir.subdirs) {
+        const path = joinWorkspacePath(dirPath, name);
+        if (options.shouldDescend && !options.shouldDescend(path)) {
+            continue;
+        }
+        visitDirectory(tree, path, visitor, options);
+    }
+    for (const name of dir.subfiles) {
+        const path = joinWorkspacePath(dirPath, name);
+        if (options.shouldVisitFile && !options.shouldVisitFile(path)) {
+            continue;
+        }
+        visitor(path, () => tree.read(path)?.toString());
+    }
+}
+
+function joinWorkspacePath(parent: string, name: string): string {
+    return parent === '/' ? `/${name}` : `${parent}/${name}`;
+}


### PR DESCRIPTION
## Description

File scan modified to prune SKIP_DIRS

## Related issues

Fixes #1559 

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

Validated against repo that was hanging.
Added coverage to ensure SKIP_DIRS wasn't entered during scan.

` pnpm --filter @openng/optimus-ui build:schematics && pnpm --filter @openng/optimus-ui test:schematics `

## Checklist

- [X] Issue discussed or bug clearly described (link issue when applicable)
- [X] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [X] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

N/A
