### PR TITLE
fix(optimus-ui-styled): avoid chained rest-destructuring in getCommon/getPreset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,9 @@ jobs:
               run: |
                   pnpm exec commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
-    # Formatting, the dependency audit and the schematics suite are all short and need no
-    # browser, so they share a job rather than each paying the setup cost.
+    # Formatting, the dependency audit, the schematics suite and the optimus-ui-styled unit
+    # tests are all short and need no browser, so they share a job rather than each paying
+    # the setup cost.
     checks:
         runs-on: ubuntu-latest
 
@@ -53,6 +54,10 @@ jobs:
             - name: Schematic Tests
               run: |
                   pnpm --filter @openng/optimus-ui test:schematics
+
+            - name: Styled Utils Tests
+              run: |
+                  pnpm run test:styled
 
     # The jasmine and vitest suites run as separate jobs so that each always runs, whatever
     # the other one does.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "lint:fix": "eslint --fix --ext \".js,.mjs,.ts,.mts\" --ignore-path .gitignore .",
         "test:unit": "pnpm run build:optimus-ui && pnpm --filter @openng/optimus-ui test:unit",
         "test:vitest": "pnpm run build:optimus-ui && pnpm --filter @openng/optimus-ui test:vitest",
-        "test:coverage": "pnpm run build:optimus-ui && pnpm --filter @openng/optimus-ui test:unit --code-coverage"
+        "test:coverage": "pnpm run build:optimus-ui && pnpm --filter @openng/optimus-ui test:unit --code-coverage",
+        "test:styled": "pnpm --filter @openng/optimus-ui-utils build && pnpm --filter @openng/optimus-ui-styled test"
     },
     "devDependencies": {
         "@angular-devkit/build-angular": "catalog:angular22",

--- a/packages/optimus-ui-styled/package.json
+++ b/packages/optimus-ui-styled/package.json
@@ -33,10 +33,15 @@
         "build:dev": "cross-env NODE_ENV=development INPUT_DIR=src/ OUTPUT_DIR=dist/ pnpm run build:dev:package",
         "build:package": "tsdown",
         "build:dev:package": "tsdown --watch",
-        "dev:link": "pnpm link --global && npm link"
+        "dev:link": "pnpm link --global && npm link",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "dependencies": {
         "@openng/optimus-ui-utils": "workspace:*"
+    },
+    "devDependencies": {
+        "vitest": "^4.0.8"
     },
     "engines": {
         "node": ">=12.11.0"

--- a/packages/optimus-ui-styled/src/utils/themeUtils.test.ts
+++ b/packages/optimus-ui-styled/src/utils/themeUtils.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import ThemeUtils from './themeUtils';
+
+const defaults = {
+    variable: {
+        prefix: 'p',
+        selector: ':root,:host',
+        excludedKeyRegex: /^(primitive|semantic|components|directives|variables|colorscheme|light|dark|common|root|states|extend|css)$/gi
+    },
+    options: { prefix: 'p', darkModeSelector: 'system', cssLayer: false }
+};
+
+const noopSet = { layerNames: () => {} };
+
+function callGetCommon(theme: any) {
+    return ThemeUtils.getCommon({ name: 'test', theme, params: undefined, set: noopSet, defaults });
+}
+
+function callGetPreset(preset: any, options: any = {}) {
+    return ThemeUtils.getPreset({ name: 'button', preset, options, params: undefined, set: noopSet, defaults, selector: undefined });
+}
+
+describe('ThemeUtils.getCommon', () => {
+    // Regression coverage for https://github.com/openng-org/optimus-ui/issues/1555:
+    // getCommon used to destructure `semantic`/`extend`/`colorScheme` via chained,
+    // rest-parameter destructuring assignments (`const { colorScheme, ...rest } = semantic || {}`)
+    // spread across a single statement. Any of those inputs being missing or null must
+    // never throw, regardless of how a downstream bundler transforms the statement.
+    describe('does not throw when preset branches are null/undefined (#1555 regression)', () => {
+        const primitive = { blue: { 500: '#3B82F6' } };
+
+        it.each([
+            ['semantic and extend both undefined', { primitive }],
+            ['semantic and extend both null', { primitive, semantic: null, extend: null }],
+            ['semantic present without colorScheme', { primitive, semantic: { primary: 'x' } }],
+            ['extend present without colorScheme', { primitive, extend: { foo: 'bar' } }],
+            ['colorScheme present without dark', { primitive, semantic: { colorScheme: { light: { s: 1 } } } }],
+            ['extend.colorScheme present without dark', { primitive, extend: { colorScheme: { light: { s: 1 } } } }],
+            ['semantic.colorScheme explicitly null', { primitive, semantic: { colorScheme: null } }],
+            ['extend.colorScheme explicitly null', { primitive, extend: { colorScheme: null } }]
+        ])('%s', (_label, preset) => {
+            expect(() => callGetCommon({ preset, options: {} })).not.toThrow();
+        });
+
+        it('empty preset object', () => {
+            expect(() => callGetCommon({ preset: {}, options: {} })).not.toThrow();
+        });
+
+        it('no preset at all', () => {
+            expect(() => callGetCommon({ options: {} })).not.toThrow();
+        });
+
+        it('no theme at all (defaults to {})', () => {
+            expect(() => callGetCommon(undefined)).not.toThrow();
+        });
+    });
+
+    it('skips the transform branch entirely when options.transform is "strict"', () => {
+        const result = callGetCommon({
+            preset: { primitive: { a: 1 }, semantic: { x: 1 } },
+            options: { transform: 'strict' }
+        });
+
+        expect(result.primitive.css).toBeUndefined();
+        expect(result.semantic.css).toBeUndefined();
+        expect(result.global.css).toBeUndefined();
+        expect(result.style).toBeUndefined();
+    });
+
+    it('returns an all-undefined shape when preset is empty', () => {
+        const result = callGetCommon({ preset: {}, options: {} });
+
+        expect(result).toEqual({
+            primitive: { css: undefined, tokens: undefined },
+            semantic: { css: undefined, tokens: undefined },
+            global: { css: undefined, tokens: undefined },
+            style: undefined
+        });
+    });
+
+    it('produces the expected primitive/semantic/global css and tokens for a full preset', () => {
+        const result = callGetCommon({
+            preset: {
+                primitive: { blue: { 500: '#3B82F6' } },
+                semantic: {
+                    primary: { color: '{blue.500}' },
+                    colorScheme: {
+                        light: { surface: { 0: '#ffffff' } },
+                        dark: { surface: { 0: '#000000' } }
+                    }
+                },
+                extend: {
+                    somekey: 'val',
+                    colorScheme: {
+                        light: { extra: 'e1' },
+                        dark: { extra: 'e2' }
+                    }
+                },
+                css: () => 'body{}'
+            },
+            options: {}
+        });
+
+        expect(result.primitive.css).toContain('--p-blue-500:#3B82F6');
+        expect(result.primitive.tokens).toEqual(['blue.500']);
+
+        expect(result.semantic.css).toContain('--p-primary-color:var(--p-blue-500)');
+        expect(result.semantic.css).toContain('--p-surface-0:#ffffff');
+        expect(result.semantic.css).toContain('@media (prefers-color-scheme: dark)');
+        expect(result.semantic.css).toContain('--p-surface-0:#000000');
+        expect(result.semantic.tokens).toEqual(expect.arrayContaining(['primary.color', 'surface.0']));
+
+        expect(result.global.css).toContain('--p-somekey:val');
+        expect(result.global.css).toContain('--p-extra:e1');
+        expect(result.global.css).toContain('color-scheme:light');
+        expect(result.global.css).toContain('--p-extra:e2');
+        expect(result.global.css).toContain('color-scheme:dark');
+        expect(result.global.tokens).toEqual(expect.arrayContaining(['somekey', 'extra']));
+
+        expect(result.style).toBe('body{}');
+    });
+
+    it('handles a preset with primitive only (no semantic/extend at all)', () => {
+        const result = callGetCommon({ preset: { primitive: { blue: { 500: '#3B82F6' } } }, options: {} });
+
+        expect(result.primitive.css).toContain('--p-blue-500:#3B82F6');
+        expect(result.primitive.tokens).toEqual(['blue.500']);
+        // No semantic/colorScheme tokens contributed since semantic/extend were absent.
+        expect(result.semantic.tokens).toEqual([]);
+        expect(result.global.tokens).toEqual([]);
+    });
+});
+
+describe('ThemeUtils.getPreset', () => {
+    // Same regression as getCommon: getPreset used a chained rest-destructure of
+    // preset/extend/colorScheme, each guarded only by `|| {}`.
+    describe('does not throw when preset branches are null/undefined (#1555 regression)', () => {
+        it.each([
+            ['minimal preset with no colorScheme/extend/css', { foo: 'bar' }],
+            ['empty preset', {}],
+            ['colorScheme null, extend undefined, css undefined', { colorScheme: null, extend: undefined, css: undefined, foo: 1 }],
+            ['extend present without colorScheme', { extend: { other: 1 }, foo: 1 }],
+            ['colorScheme present without dark', { colorScheme: { light: { s: 1 } }, foo: 1 }],
+            ['extend.colorScheme present without dark', { extend: { colorScheme: { light: { s: 1 } } }, foo: 1 }]
+        ])('%s', (_label, preset) => {
+            expect(() => callGetPreset(preset)).not.toThrow();
+        });
+
+        it('preset is undefined (uses the {} default parameter)', () => {
+            expect(() => callGetPreset(undefined)).not.toThrow();
+        });
+    });
+
+    it('skips the transform branch entirely when options.transform is "strict"', () => {
+        const result = callGetPreset({ foo: 'bar' }, { transform: 'strict' });
+
+        expect(result.css).toBeUndefined();
+        expect(result.tokens).toBeUndefined();
+        expect(result.style).toBeUndefined();
+    });
+
+    it('returns an all-undefined shape when preset is empty', () => {
+        const result = callGetPreset({});
+
+        expect(result).toEqual({ css: undefined, tokens: undefined, style: undefined });
+    });
+
+    it('produces the expected css and tokens for a full component preset, merging extend', () => {
+        const result = callGetPreset({
+            colorScheme: { light: { bg: '1' }, dark: { bg: '2' } },
+            extend: { colorScheme: { light: { x: '1' }, dark: { x: '2' } } },
+            css: () => '.p-button{}',
+            foo: 'bar'
+        });
+
+        expect(result.css).toContain('--p-button-foo:bar');
+        expect(result.css).toContain('--p-button-x:1');
+        expect(result.css).toContain('@media (prefers-color-scheme: dark)');
+        expect(result.css).toContain('--p-button-bg:2');
+        expect(result.css).toContain('--p-button-x:2');
+        expect(result.tokens).toEqual(expect.arrayContaining(['button.foo', 'button.x', 'button.bg']));
+
+        expect(result.style).toBe('.p-button{}');
+    });
+});

--- a/packages/optimus-ui-styled/src/utils/themeUtils.ts
+++ b/packages/optimus-ui-styled/src/utils/themeUtils.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isNotEmpty, isObject, matchRegex, minifyCSS, resolve } from '@openng/optimus-ui-utils/object';
+import { isEmpty, isNotEmpty, isObject, matchRegex, minifyCSS, omit, resolve } from '@openng/optimus-ui-utils/object';
 import { dt, toVariables } from '../helpers/index';
 import { CALC_REGEX, EXPR_REGEX, getRule, toTokenKey, VAR_REGEX } from './sharedUtils';
 
@@ -53,10 +53,14 @@ export default {
         // @todo - check if options is not empty
         if (isNotEmpty(preset) && options.transform !== 'strict') {
             const { primitive, semantic, extend } = preset;
-            const { colorScheme, ...sRest } = semantic || {};
-            const { colorScheme: eColorScheme, ...eRest } = extend || {};
-            const { dark, ...csRest } = colorScheme || {};
-            const { dark: eDark, ...ecsRest } = eColorScheme || {};
+            const colorScheme = semantic?.colorScheme;
+            const sRest: any = omit(semantic, 'colorScheme');
+            const eColorScheme = extend?.colorScheme;
+            const eRest: any = omit(extend, 'colorScheme');
+            const dark = colorScheme?.dark;
+            const csRest: any = omit(colorScheme, 'dark');
+            const eDark = eColorScheme?.dark;
+            const ecsRest: any = omit(eColorScheme, 'dark');
             const prim_var: any = isNotEmpty(primitive) ? this._toVariables({ primitive }, options) : {};
             const sRest_var: any = isNotEmpty(sRest) ? this._toVariables({ semantic: sRest }, options) : {};
             const csRest_var: any = isNotEmpty(csRest) ? this._toVariables({ light: csRest }, options) : {};
@@ -112,10 +116,14 @@ export default {
 
         if (isNotEmpty(preset) && options.transform !== 'strict') {
             const _name = name.replace('-directive', '');
-            const { colorScheme, extend, css, ...vRest } = preset;
-            const { colorScheme: eColorScheme, ...evRest } = extend || {};
-            const { dark, ...csRest } = colorScheme || {};
-            const { dark: ecsDark, ...ecsRest } = eColorScheme || {};
+            const { colorScheme, extend, css } = preset;
+            const vRest: any = omit(preset, 'colorScheme', 'extend', 'css');
+            const eColorScheme = extend?.colorScheme;
+            const evRest: any = omit(extend, 'colorScheme');
+            const dark = colorScheme?.dark;
+            const csRest: any = omit(colorScheme, 'dark');
+            const ecsDark = eColorScheme?.dark;
+            const ecsRest: any = omit(eColorScheme, 'dark');
             const vRest_var: any = isNotEmpty(vRest) ? this._toVariables({ [_name]: { ...vRest, ...evRest } }, options) : {};
             const csRest_var: any = isNotEmpty(csRest) ? this._toVariables({ [_name]: { ...csRest, ...ecsRest } }, options) : {};
             const csDark_var: any = isNotEmpty(dark) ? this._toVariables({ [_name]: { ...dark, ...ecsDark } }, options) : {};

--- a/packages/optimus-ui-styled/vitest.config.ts
+++ b/packages/optimus-ui-styled/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts']
+    }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,6 +403,10 @@ importers:
       '@openng/optimus-ui-utils':
         specifier: workspace:*
         version: link:../optimus-ui-utils
+    devDependencies:
+      vitest:
+        specifier: ^4.0.8
+        version: 4.1.10(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@8.1.5(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(less@4.6.7)(sass@1.101.0)(terser@5.49.0)(yaml@2.9.0))
 
   packages/optimus-ui-styles:
     dependencies:
@@ -659,6 +663,7 @@ packages:
   '@angular/animations@22.1.2':
     resolution: {integrity: sha512-SHvopFG8I92isKE6lgoWVVmmt6fSGKt76bfrBuJ9qvrKWYqWmWUh87Z5J3XRPUM8zdzuEkXjcTbn+GTGOGRiaA==}
     engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
+    deprecated: '@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.'
     peerDependencies:
       '@angular/core': 22.1.2
 
@@ -774,6 +779,7 @@ packages:
   '@angular/platform-browser-dynamic@22.1.2':
     resolution: {integrity: sha512-nNARbs9zXfoJL72zsTso6GHt1VuIGXWEpyZtzxcC32qQFG1YbzVqGkQTwZ0mZ2/Ctv8dAZ6PPiDo8sbYvAvUDw==}
     engines: {node: ^22.22.3 || ^24.15.0 || >=26.0.0}
+    deprecated: '@angular/platform-browser-dynamic is deprecated. Use `@angular/platform-browser` instead.'
     peerDependencies:
       '@angular/common': 22.1.2
       '@angular/compiler': 22.1.2


### PR DESCRIPTION
## Description

#1555 reports a runtime `TypeError: Cannot destructure 'null' as it is null` from `Theme.getCommon` when `@openng/optimus-ui-styled@2.0.0` is pre-bundled by Angular 22's Vite dev-server (`@angular/build:dev-server`).

`ThemeUtils.getCommon` and `ThemeUtils.getPreset` used a chain of destructuring assignments with rest parameters, each guarded only by `|| {}` (e.g. `const { colorScheme, ...sRest } = semantic || {}`). This is inherited unchanged from the vendored upstream `@primeuix/styled@0.7.4` code. tsdown's production minifier collapses these into a single multi-declarator `let` statement in the shipped dist, which is denser/more fragile input for any downstream tool that re-parses or re-transforms it.

This PR splits that pattern into discrete statements using optional chaining and the existing `omit()` utility instead of destructuring-with-rest, in both `getCommon` and `getPreset` (the issue only mentions `getCommon`, but `getPreset` has the identical pattern and the same risk).

**Important caveat:** I could not reproduce the reported crash. I cloned `openng-org/sparked` (same dependency versions as the reporter: Angular 22.1.2, `@angular/build` 22.1.3, `@openng/optimus-ui` 2.0.0) and ran a cold `ng serve` — Vite pre-bundled `optimus-ui-styled` and left the destructuring pattern completely intact (no downleveling), and the app rendered without error. I also couldn't reproduce it in isolation by forcing esbuild to downlevel the same pattern to `es2015`/`es2017` (transforms correctly) or `es5` (esbuild refuses outright rather than emitting broken code). So this is a defensive hardening of a genuinely fragile pattern rather than a confirmed fix for the reporter's specific crash — I'm using "Relates to" rather than "Fixes" below until we hear back from them. One remaining lead worth checking: an older resolved `esbuild` version in their toolchain (pre-0.28, before esbuild started erroring instead of silently mistransforming unsupported downlevels — see angular/angular-cli#33191 for the same class of issue surfacing in a different dependency).

## Related issues

Relates to #1555

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None. Verified behaviorally equivalent to the pre-change code by running the old and new built `dist/index.mjs` side-by-side against a dozen preset shapes (full preset, null/undefined `semantic`/`extend`/`colorScheme`, missing `dark`, empty/undefined preset, `strict` transform) for both `getCommon` and `getPreset` — identical output in every case.

## Test plan

- [x] `npm run build` — `pnpm --filter @openng/optimus-ui-styled build` is clean, and `tsc --noEmit` on the package passes
- [x] `npm test` — added `packages/optimus-ui-styled/src/utils/themeUtils.test.ts` (25 tests: null/undefined regression coverage for #1555, the `strict` transform short-circuit, and expected css/token output), wired into CI via a new `test:styled` root script in the `checks` job
- [ ] `npm run lint` — not run; this repo's lint pipeline is currently non-functional independent of this change
- [ ] Verified in the demo app — not run live against a demo app; see the dist-diff verification above instead

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed) — n/a, no public-facing docs affected
- [x] Public API changes documented; breaking changes called out — none
