### PR TITLE
fix(inputnumber): Hitting enter when text is selected deletes text

### DIFF
--- a/packages/optimus-ui/src/inputnumber/inputnumber.ts
+++ b/packages/optimus-ui/src/inputnumber/inputnumber.ts
@@ -986,13 +986,15 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
         }
 
         let code = event.which || event.keyCode;
+        if (code == 13) {
+            return;
+        }
+        event.preventDefault();
+
         let char = String.fromCharCode(code);
         let isDecimalSign = this.isDecimalSign(char);
         const isMinusSign = this.isMinusSign(char);
 
-        if (code != 13) {
-            event.preventDefault();
-        }
         if (!isDecimalSign && event.code === 'NumpadDecimal') {
             isDecimalSign = true;
             char = this._decimalChar;


### PR DESCRIPTION
## Description

Hitting enter was replacing the selected text with "". A simple return is enough - nothing is to be inserted in onInputKeyPress and the enter itself gets handled elsewhere - in onInputKeyDown. This solution was also suggested in the original bug description.

## Related issues

Fixes #98

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context
