### PR TITLE
fix(password): commit the cleared value under updateOn blur

### DIFF
--- a/packages/optimus-ui/src/password/password.test.ts
+++ b/packages/optimus-ui/src/password/password.test.ts
@@ -96,6 +96,24 @@ class TestFormPasswordComponent {
     toggleMask: boolean = true;
 }
 
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <form [formGroup]="form">
+            <p-password formControlName="password" [feedback]="false" [showClear]="true"> </p-password>
+        </form>
+    `
+})
+class TestUpdateOnBlurPasswordComponent {
+    form = new FormGroup({
+        password: new FormControl('', {
+            validators: [Validators.required, Validators.minLength(8)],
+            updateOn: 'blur' as const
+        })
+    });
+}
+
 // Comprehensive template test component with all ContentChild projections
 // Password pTemplate component
 @Component({
@@ -263,7 +281,7 @@ describe('Password', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             imports: [PasswordModule, FormsModule, ReactiveFormsModule, CommonModule, SharedModule],
-            declarations: [TestBasicPasswordComponent, TestFormPasswordComponent, TestPasswordPTemplateComponent, TestPasswordRefTemplateComponent, TestPTPasswordComponent],
+            declarations: [TestBasicPasswordComponent, TestFormPasswordComponent, TestUpdateOnBlurPasswordComponent, TestPasswordPTemplateComponent, TestPasswordRefTemplateComponent, TestPTPasswordComponent],
             providers: [provideZonelessChangeDetection()]
         }).compileComponents();
 
@@ -696,27 +714,76 @@ describe('Password', () => {
             expect(formTestComponent.form.pristine).toBe(true);
         });
 
-        it('should handle updateOn blur strategy', async () => {
-            // Create a new form with updateOn blur for testing
-            const blurForm = new FormGroup({
-                password: new FormControl('', {
-                    validators: [Validators.required, Validators.minLength(8)],
-                    updateOn: 'blur'
-                })
+        describe('updateOn blur strategy', () => {
+            let blurFixture: ComponentFixture<TestUpdateOnBlurPasswordComponent>;
+            let blurComponent: TestUpdateOnBlurPasswordComponent;
+            let blurInput: HTMLInputElement;
+
+            const control = () => blurComponent.form.controls.password;
+
+            const type = async (value: string) => {
+                blurInput.value = value;
+                blurInput.dispatchEvent(new Event('input'));
+                blurFixture.detectChanges();
+                await blurFixture.whenStable();
+            };
+
+            const blur = async () => {
+                blurInput.dispatchEvent(new Event('blur'));
+                blurFixture.detectChanges();
+                await blurFixture.whenStable();
+            };
+
+            beforeEach(async () => {
+                blurFixture = TestBed.createComponent(TestUpdateOnBlurPasswordComponent);
+                blurComponent = blurFixture.componentInstance;
+                blurFixture.detectChanges();
+                await blurFixture.whenStable();
+
+                blurInput = blurFixture.debugElement.query(By.css('input')).nativeElement;
             });
 
-            formTestFixture.detectChanges();
+            it('should not update the control while typing', async () => {
+                await type('secret12');
 
-            const inputEl = formTestFixture.debugElement.query(By.css('input'));
-            if (inputEl) {
-                inputEl.nativeElement.focus();
-                inputEl.nativeElement.blur();
-                formTestFixture.detectChanges();
-                await formTestFixture.whenStable();
+                expect(control().value).toBe('');
+                expect(control().touched).toBe(false);
+            });
 
-                // Check that blur triggered form update
-                expect(inputEl.nativeElement).toBeTruthy();
-            }
+            it('should commit the value and mark the control touched on blur', async () => {
+                await type('secret12');
+                await blur();
+
+                expect(control().value).toBe('secret12');
+                expect(control().touched).toBe(true);
+                expect(control().dirty).toBe(true);
+                expect(control().valid).toBe(true);
+            });
+
+            it('should run validators once the value is committed on blur', async () => {
+                await type('short');
+                await blur();
+
+                expect(control().value).toBe('short');
+                expect(control().hasError('minlength')).toBe(true);
+            });
+
+            it('should commit the cleared value when the clear icon is clicked', async () => {
+                await type('secret12');
+                await blur();
+                expect(control().value).toBe('secret12');
+
+                const clearIcon = blurFixture.debugElement.query(By.css('[data-pc-section="clearicon"]'));
+                expect(clearIcon).toBeTruthy();
+
+                clearIcon.nativeElement.dispatchEvent(new MouseEvent('click'));
+                blurFixture.detectChanges();
+                await blurFixture.whenStable();
+
+                expect(blurInput.value).toBe('');
+                expect(control().value).toBeNull();
+                expect(control().hasError('required')).toBe(true);
+            });
         });
 
         it('should handle nested form validation', async () => {

--- a/packages/optimus-ui/src/password/password.ts
+++ b/packages/optimus-ui/src/password/password.ts
@@ -947,6 +947,10 @@ export class Password extends BaseInput<PasswordPassThrough> {
     clear() {
         this.value = null;
         this.onModelChange(this.value);
+        // The clear icon is not part of the input, so no blur follows this interaction.
+        // Under updateOn: 'blur' onModelChange only stages the value, so mark the control
+        // as touched to commit it - otherwise the control keeps the previous password.
+        this.onModelTouched();
         this.writeValue(this.value);
         this.onClear.emit();
     }


### PR DESCRIPTION
## Description

Fixes #945.

With `updateOn: 'blur'`, Angular does **not** commit a value when the accessor calls `onModelChange` — it only stages it. The commit happens inside the callback registered through `registerOnTouched` ([`setUpBlurPipeline`](https://github.com/angular/angular/blob/main/packages/forms/src/directives/shared.ts)):

```ts
function setUpViewChangePipeline(control, dir) {
  dir.valueAccessor.registerOnChange(newValue => {
    control._pendingValue = newValue;
    control._pendingChange = true;
    control._pendingDirty = true;
    if (control.updateOn === 'change') updateControl(control, dir);
  });
}

function setUpBlurPipeline(control, dir) {
  dir.valueAccessor.registerOnTouched(() => {
    control._pendingTouched = true;
    if (control.updateOn === 'blur' && control._pendingChange) updateControl(control, dir);
    if (control.updateOn !== 'submit') control.markAsTouched();
  });
}
```

`Password.clear()` staged the cleared value and wrote it to the view, but never marked the control as touched:

```ts
clear() {
    this.value = null;
    this.onModelChange(this.value);   // stages null only
    this.writeValue(this.value);      // clears the visible input
    this.onClear.emit();
}
```

The clear icon sits outside the input, so clicking it produces no blur and nothing ever commits. **The field renders empty while the control still holds the previous password and still reports `VALID`** — a form submitted at that point sends the stale value, and `required` never fires.

### The fix

`clear()` now calls `onModelTouched()` after the model change, which is also what `Select.clear()` does. Under `updateOn: 'change'` the behaviour is unchanged (the value is already committed; the control is additionally marked touched, consistent with the other components).

### Note on the originally reported symptom

The keystroke half of the original report ("validation is triggered by the change event, blur does not take effect") no longer reproduces on this codebase: `onModelTouched()` is called only from `onInputBlur()` — upstream PrimeNG 15 also called it from `onInput()`, which committed the pending value on every keystroke. That part is already fixed here; I verified it in the browser and pinned it with tests so it cannot regress.

## Steps to reproduce

```ts
form = new FormGroup({
    value: new FormControl('', {
        validators: [Validators.required, Validators.minLength(8)],
        updateOn: 'blur'
    })
});
```

```html
<p-password formControlName="value" [feedback]="false" [showClear]="true" [toggleMask]="true" />
```

1. Type `secret12`
2. Blur the field — `control.value` becomes `"secret12"`, status `VALID` ✅
3. Click the clear icon

**Before** — the input is empty but the control still holds `"secret12"` and is `VALID`:

<img width="938" alt="before - cleared input, stale control value" src="https://raw.githubusercontent.com/rene-schakmann/optimus-ui/assets/issue-945-screenshots/945-before-bug.png" />

**After** — clearing commits, the control is empty and `INVALID` again (note the invalid styling on the field):

<img width="938" alt="after - cleared value committed to the control" src="https://raw.githubusercontent.com/rene-schakmann/optimus-ui/assets/issue-945-screenshots/945-after-fix.png" />

## Tests

The existing `'should handle updateOn blur strategy'` test was inert — it built a `FormGroup` that was never bound to the fixture and its only assertion was `expect(inputEl.nativeElement).toBeTruthy()`. It is replaced by a real bound host (`TestUpdateOnBlurPasswordComponent`) covering:

- typing does not update the control;
- blur commits the value, marks it touched/dirty and runs the validators;
- `minlength` errors surface once the value is committed;
- the clear icon commits the cleared value (the regression test for this fix — it fails without the one-line change).

The tests live in `password.test.ts` (Vitest) only — the Karma `password.spec.ts` changes were dropped after the rebase onto `main`, where Karma has been removed. `pnpm run test:unit` (7281 passing) and `pnpm run format:check` are both green. The clear-icon test fails without the one-line change in `password.ts` (`AssertionError: expected 'secret12' to be null`).

---

Co-authored by Claude.

