### PR TITLE
fix(scroller): initialize virtual scroll when the viewport becomes measurable

### DIFF
--- a/packages/optimus-ui/src/multiselect/multiselect.spec.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.spec.ts
@@ -5,10 +5,10 @@ import { FormControl, FormGroup, FormsModule, NgForm, NgModel, ReactiveFormsModu
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideOptimus } from '@openng/optimus-ui/config';
+import type { MultiSelectBlurEvent, MultiSelectChangeEvent, MultiSelectFilterEvent, MultiSelectFocusEvent } from '@openng/optimus-ui/types/multiselect';
 import { BehaviorSubject, of } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { MultiSelect, MultiSelectModule } from './multiselect';
-import type { MultiSelectBlurEvent, MultiSelectChangeEvent, MultiSelectFilterEvent, MultiSelectFocusEvent } from '@openng/optimus-ui/types/multiselect';
 interface City {
     name: string;
     code: string;
@@ -1832,6 +1832,21 @@ describe('MultiSelect Virtual Scrolling', () => {
         expect(multiSelect.virtualScrollItemSize).toBe(40);
         expect(multiSelect.scrollHeight).toBe('200px');
         expect(multiSelect.virtualScrollerDisabled).toBe(false);
+    });
+
+    it('should initialize the scroller on overlay enter with no value selected', async () => {
+        multiSelect.show();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(multiSelect.scroller).toBeTruthy();
+        expect(multiSelect.modelValue()?.length).toBeFalsy();
+
+        multiSelect.scroller!.initialized = false;
+        multiSelect.onOverlayBeforeEnter({});
+
+        expect(multiSelect.scroller!.initialized).toBe(true);
     });
 
     it('should handle large datasets', async () => {

--- a/packages/optimus-ui/src/multiselect/multiselect.test.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.test.ts
@@ -5,10 +5,10 @@ import { FormControl, FormGroup, FormsModule, NgForm, NgModel, ReactiveFormsModu
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideOptimus } from '@openng/optimus-ui/config';
+import type { MultiSelectBlurEvent, MultiSelectChangeEvent, MultiSelectFilterEvent, MultiSelectFocusEvent } from '@openng/optimus-ui/types/multiselect';
 import { BehaviorSubject, of } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { MultiSelect, MultiSelectModule } from './multiselect';
-import type { MultiSelectBlurEvent, MultiSelectChangeEvent, MultiSelectFilterEvent, MultiSelectFocusEvent } from '@openng/optimus-ui/types/multiselect';
 interface City {
     name: string;
     code: string;
@@ -1675,6 +1675,21 @@ describe('MultiSelect Virtual Scrolling', () => {
         expect(multiSelect.virtualScrollItemSize).toBe(40);
         expect(multiSelect.scrollHeight).toBe('200px');
         expect(multiSelect.virtualScrollerDisabled).toBe(false);
+    });
+
+    it('should initialize the scroller on overlay enter with no value selected', async () => {
+        multiSelect.show();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(multiSelect.scroller).toBeTruthy();
+        expect(multiSelect.modelValue()?.length).toBeFalsy();
+
+        multiSelect.scroller!.initialized = false;
+        multiSelect.onOverlayBeforeEnter({});
+
+        expect(multiSelect.scroller!.initialized).toBe(true);
     });
 
     it('should handle large datasets', async () => {

--- a/packages/optimus-ui/src/multiselect/multiselect.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.ts
@@ -2043,7 +2043,11 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     onOverlayBeforeEnter(event: any) {
         this.itemsWrapper = <any>findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
-        this.virtualScroll && this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
+
+        if (this.virtualScroll) {
+            this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
+            this.scroller?.viewInit();
+        }
 
         if (this.options && this.options.length) {
             if (this.virtualScroll) {

--- a/packages/optimus-ui/src/scroller/scroller.spec.ts
+++ b/packages/optimus-ui/src/scroller/scroller.spec.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DebugElement, input, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, ElementRef, input, provideZonelessChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -246,6 +246,24 @@ class TestDynamicPropertiesComponent {
     updateDisabled(disabled: boolean) {
         this.dynamicDisabled = disabled;
     }
+}
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <div #host style="display: none">
+            <p-scroller [items]="items" [itemSize]="38" scrollHeight="200px">
+                <ng-template #item let-item>
+                    <div class="deferred-item">{{ item }}</div>
+                </ng-template>
+            </p-scroller>
+        </div>
+    `
+})
+class TestDeferredVisibilityComponent {
+    @ViewChild('host', { static: true }) host: ElementRef<HTMLElement>;
+    items = Array.from({ length: 50 }, (_, i) => `Item ${i}`);
 }
 
 describe('Scroller', () => {
@@ -4341,6 +4359,58 @@ describe('Scroller', () => {
                     expect(loadingIcon.nativeElement.classList.contains('PT_LOADING_ICON')).toBeTruthy();
                 }
             });
+        });
+    });
+
+    describe('Deferred Visibility Initialization', () => {
+        let fixture: ComponentFixture<TestDeferredVisibilityComponent>;
+        let scroller: Scroller;
+
+        beforeEach(async () => {
+            await TestBed.configureTestingModule({
+                imports: [Scroller],
+                providers: [provideZonelessChangeDetection()],
+                declarations: [TestDeferredVisibilityComponent]
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(TestDeferredVisibilityComponent);
+            scroller = fixture.debugElement.query(By.directive(Scroller)).componentInstance;
+            fixture.detectChanges();
+            await fixture.whenStable();
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        });
+
+        it('should not initialize while the host has no box', () => {
+            expect(scroller.initialized).toBe(false);
+            expect(fixture.nativeElement.querySelectorAll('.deferred-item').length).toBe(0);
+        });
+
+        it('should observe the element while it has no box', () => {
+            expect(scroller.visibilityObserver).toBeTruthy();
+        });
+
+        it('should render items once the host becomes visible, without any change detection cycle', async () => {
+            fixture.componentInstance.host.nativeElement.style.display = 'block';
+
+            await new Promise((resolve) => setTimeout(resolve, 300));
+
+            expect(scroller.initialized).toBe(true);
+            expect(scroller.last).toBeGreaterThan(0);
+            expect(fixture.nativeElement.querySelectorAll('.deferred-item').length).toBeGreaterThan(0);
+        });
+
+        it('should stop observing the element once initialized', async () => {
+            fixture.componentInstance.host.nativeElement.style.display = 'block';
+
+            await new Promise((resolve) => setTimeout(resolve, 300));
+
+            expect(scroller.visibilityObserver).toBeUndefined();
+        });
+
+        it('should disconnect the observer on destroy', () => {
+            fixture.destroy();
+
+            expect(scroller.visibilityObserver).toBeUndefined();
         });
     });
 });

--- a/packages/optimus-ui/src/scroller/scroller.test.ts
+++ b/packages/optimus-ui/src/scroller/scroller.test.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DebugElement, input, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, ElementRef, input, provideZonelessChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -246,6 +246,24 @@ class TestDynamicPropertiesComponent {
     updateDisabled(disabled: boolean) {
         this.dynamicDisabled = disabled;
     }
+}
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <div #host style="display: none">
+            <p-scroller [items]="items" [itemSize]="38" scrollHeight="200px">
+                <ng-template #item let-item>
+                    <div class="deferred-item">{{ item }}</div>
+                </ng-template>
+            </p-scroller>
+        </div>
+    `
+})
+class TestDeferredVisibilityComponent {
+    @ViewChild('host', { static: true }) host: ElementRef<HTMLElement>;
+    items = Array.from({ length: 50 }, (_, i) => `Item ${i}`);
 }
 
 describe('Scroller', () => {
@@ -4341,6 +4359,58 @@ describe('Scroller', () => {
                     expect(loadingIcon.nativeElement.classList.contains('PT_LOADING_ICON')).toBeTruthy();
                 }
             });
+        });
+    });
+
+    describe('Deferred Visibility Initialization', () => {
+        let fixture: ComponentFixture<TestDeferredVisibilityComponent>;
+        let scroller: Scroller;
+
+        beforeEach(async () => {
+            await TestBed.configureTestingModule({
+                imports: [Scroller],
+                providers: [provideZonelessChangeDetection()],
+                declarations: [TestDeferredVisibilityComponent]
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(TestDeferredVisibilityComponent);
+            scroller = fixture.debugElement.query(By.directive(Scroller)).componentInstance;
+            fixture.detectChanges();
+            await fixture.whenStable();
+            await new Promise((resolve) => setTimeout(resolve, 50));
+        });
+
+        it('should not initialize while the host has no box', () => {
+            expect(scroller.initialized).toBe(false);
+            expect(fixture.nativeElement.querySelectorAll('.deferred-item').length).toBe(0);
+        });
+
+        it('should observe the element while it has no box', () => {
+            expect(scroller.visibilityObserver).toBeTruthy();
+        });
+
+        it('should render items once the host becomes visible, without any change detection cycle', async () => {
+            fixture.componentInstance.host.nativeElement.style.display = 'block';
+
+            await new Promise((resolve) => setTimeout(resolve, 300));
+
+            expect(scroller.initialized).toBe(true);
+            expect(scroller.last).toBeGreaterThan(0);
+            expect(fixture.nativeElement.querySelectorAll('.deferred-item').length).toBeGreaterThan(0);
+        });
+
+        it('should stop observing the element once initialized', async () => {
+            fixture.componentInstance.host.nativeElement.style.display = 'block';
+
+            await new Promise((resolve) => setTimeout(resolve, 300));
+
+            expect(scroller.visibilityObserver).toBeUndefined();
+        });
+
+        it('should disconnect the observer on destroy', () => {
+            fixture.destroy();
+
+            expect(scroller.visibilityObserver).toBeUndefined();
         });
     });
 });

--- a/packages/optimus-ui/src/scroller/scroller.ts
+++ b/packages/optimus-ui/src/scroller/scroller.ts
@@ -511,6 +511,8 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
 
     windowResizeListener: VoidListener;
 
+    visibilityObserver: ResizeObserver | undefined;
+
     defaultWidth: number | undefined;
 
     defaultHeight: number | undefined;
@@ -671,6 +673,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
 
     onDestroy() {
         this.unbindResizeListener();
+        this.unbindVisibilityObserver();
 
         this.contentEl = null;
         this.initialized = false;
@@ -679,6 +682,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
     viewInit() {
         if (isPlatformBrowser(this.platformId) && !this.initialized) {
             if (isVisible(this.elementViewChild?.nativeElement)) {
+                this.unbindVisibilityObserver();
                 this.setInitialState();
                 this.setContentEl(this.contentEl);
                 this.init();
@@ -688,6 +692,8 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
                 this.defaultContentWidth = getWidth(this.contentEl);
                 this.defaultContentHeight = getHeight(this.contentEl);
                 this.initialized = true;
+            } else {
+                this.bindVisibilityObserver();
             }
         }
     }
@@ -1155,6 +1161,37 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
         if (this.windowResizeListener) {
             this.windowResizeListener();
             this.windowResizeListener = null;
+        }
+    }
+
+    bindVisibilityObserver() {
+        if (this.visibilityObserver || typeof ResizeObserver === 'undefined') {
+            return;
+        }
+
+        const element = this.elementViewChild?.nativeElement;
+
+        if (!element) {
+            return;
+        }
+
+        this.zone.runOutsideAngular(() => {
+            this.visibilityObserver = new ResizeObserver(() => {
+                // `viewInit` disconnects this observer as soon as it initializes, so there is
+                // nothing to guard against here: the callback cannot run once initialized.
+                if (isVisible(element)) {
+                    this.zone.run(() => this.viewInit());
+                }
+            });
+
+            this.visibilityObserver.observe(element);
+        });
+    }
+
+    unbindVisibilityObserver() {
+        if (this.visibilityObserver) {
+            this.visibilityObserver.disconnect();
+            this.visibilityObserver = undefined;
         }
     }
 

--- a/packages/optimus-ui/src/select/select.spec.ts
+++ b/packages/optimus-ui/src/select/select.spec.ts
@@ -2733,6 +2733,23 @@ describe('Select ViewChild Properties', () => {
             expect(selectInstance.lastHiddenFocusableElementOnOverlay.nativeElement).toBeTruthy();
         }
     });
+
+    it('should initialize the scroller on overlay enter with no value selected', async () => {
+        const virtualSelect = viewChildFixture.debugElement.query(By.css('p-select[placeholder="Virtual scroll select"]')).componentInstance;
+
+        virtualSelect.show();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await viewChildFixture.whenStable();
+        viewChildFixture.detectChanges();
+
+        expect(virtualSelect.scroller).toBeTruthy();
+        expect(virtualSelect.modelValue()).toBeFalsy();
+
+        virtualSelect.scroller.initialized = false;
+        virtualSelect.onOverlayBeforeEnter({});
+
+        expect(virtualSelect.scroller.initialized).toBe(true);
+    });
 });
 
 // Complex Edge Cases Tests

--- a/packages/optimus-ui/src/select/select.test.ts
+++ b/packages/optimus-ui/src/select/select.test.ts
@@ -2733,6 +2733,23 @@ describe('Select ViewChild Properties', () => {
             expect(selectInstance.lastHiddenFocusableElementOnOverlay.nativeElement).toBeTruthy();
         }
     });
+
+    it('should initialize the scroller on overlay enter with no value selected', async () => {
+        const virtualSelect = viewChildFixture.debugElement.query(By.css('p-select[placeholder="Virtual scroll select"]')).componentInstance;
+
+        virtualSelect.show();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await viewChildFixture.whenStable();
+        viewChildFixture.detectChanges();
+
+        expect(virtualSelect.scroller).toBeTruthy();
+        expect(virtualSelect.modelValue()).toBeFalsy();
+
+        virtualSelect.scroller.initialized = false;
+        virtualSelect.onOverlayBeforeEnter({});
+
+        expect(virtualSelect.scroller.initialized).toBe(true);
+    });
 });
 
 // Complex Edge Cases Tests

--- a/packages/optimus-ui/src/select/select.ts
+++ b/packages/optimus-ui/src/select/select.ts
@@ -1416,7 +1416,11 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
     onOverlayBeforeEnter(event: any) {
         this.itemsWrapper = <any>findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
-        this.virtualScroll && this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
+
+        if (this.virtualScroll) {
+            this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
+            this.scroller?.viewInit();
+        }
 
         if (this.options && this.options.length) {
             if (this.virtualScroll) {


### PR DESCRIPTION
## Description

Open a `p-select` with `[virtualScroll]="true"` and don't move the mouse: the panel comes up empty. Wiggle the mouse and the options appear!

The overlay is still `display: none` when the scroller gets created (that's `p-motion` hiding the panel before it animates it in), so `isVisible()` is false when `viewInit()` runs and it gives up early. `last` stays at 0, so the rendered slice is empty. The only thing that retries is `onAfterViewChecked`, which needs a change detection cycle, and showing the panel doesn't schedule one. A mousemove over the panel does, hence the "move the mouse and it works" behaviour.

The reason it looks flaky rather than broken: `onOverlayBeforeEnter` does wake the scroller, but only through the `scrollToIndex` call that's guarded by "is something selected". So reopening a select that already has a value is usually fine, and the case that actually breaks is the first open on a placeholder.

This one is unrecoverable under `provideZonelessChangeDetection()`. No mousemove, no change detection, panel stays empty for good.

Fix is in two parts:

- `Scroller.viewInit()` now sets up a `ResizeObserver` when the element has no box yet, and initializes as soon as it gets one. Disconnects on init and on destroy. I left `onAfterViewChecked` in place because it's what arms the observer when the scroller starts out disabled and there's no element to observe yet.
- `p-select` and `p-multiselect` also call `scroller.viewInit()` from `onOverlayBeforeEnter`, where the panel is already laid out. `p-autocomplete` was already doing this, so it just brings the other two in line.

The scroller change also covers `p-listbox`, `p-table`, `p-treetable` and `p-tree`, which have no overlay hook and were relying on the same retry.

## Related issues

None found

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None, it is just a bugfix.

## Test plan

- [x] `pnpm run build:lib`
- [x] `pnpm run test:vitest` and `pnpm run test:unit`, both green
- [x] `pnpm run format:check`
- [x] `pnpm run lint`
- [ ] Demo app: didn't go through it. The new tests run in a real browser (Chromium for vitest, Chrome for karma) and cover the unmeasurable-viewport case directly.

Added 7 tests, mirrored in both the `.spec.ts` and `.test.ts` files so the jasmine and vitest jobs both pick them up. The scroller ones is in a new `Deferred Visibility Initialization` block.

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [x] Documentation updated (README, JSDoc, migration notes as needed)
- [x] Public API changes documented; breaking changes called out
- [x] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)