### PR TITLE
fix(cascadeselect): bind role="group" on nested option lists

### DIFF
--- a/packages/optimus-ui/src/cascadeselect/cascadeselect.test.ts
+++ b/packages/optimus-ui/src/cascadeselect/cascadeselect.test.ts
@@ -854,6 +854,32 @@ describe('CascadeSelect', () => {
             expect(ariaRequired === null || ariaRequired === 'false').toBe(true);
             expect(hiddenInput.nativeElement.getAttribute('aria-label')).toBeTruthy();
         });
+
+        it('should render nested option lists with role="group"', async () => {
+            testComponent.options = mockCountries;
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const trigger = testFixture.debugElement.query(By.css('.p-cascadeselect-dropdown'));
+            trigger.nativeElement.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+            testFixture.changeDetectorRef.markForCheck();
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            const rootList = testFixture.debugElement.query(By.css('ul[role="tree"]'));
+            expect(rootList).toBeTruthy();
+
+            const groupOption = testFixture.debugElement.query(By.css('li[role="treeitem"]'));
+            groupOption.nativeElement.querySelector('.p-cascadeselect-option-content').click();
+            testFixture.changeDetectorRef.markForCheck();
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+
+            const nestedList = rootList.nativeElement.querySelector('ul');
+            expect(nestedList).toBeTruthy();
+            expect(nestedList.getAttribute('role')).toBe('group');
+        });
     });
 
     describe('Complex Situations and Edge Cases', () => {

--- a/packages/optimus-ui/src/cascadeselect/cascadeselect.ts
+++ b/packages/optimus-ui/src/cascadeselect/cascadeselect.ts
@@ -97,7 +97,7 @@ export const CASCADESELECT_VALUE_ACCESSOR: any = {
                 <ul
                     pCascadeSelectSub
                     *ngIf="isOptionGroup(processedOption) && isOptionActive(processedOption)"
-                    [attrrole]="'group'"
+                    [attr.role]="'group'"
                     [class]="cx('optionList')"
                     [selectId]="selectId"
                     [focusedOptionId]="focusedOptionId"


### PR DESCRIPTION
Closes #1553

## What

The nested `<ul>` rendered for an expanded option group in `CascadeSelectSub` bound `[attrrole]="'group'"` instead of `[attr.role]="'group'"`. That is neither an attribute binding nor an input of `pCascadeSelectSub`, so the binding was silently dropped and nested lists rendered with no `role` at all inside the `role="tree"` root list — breaking the WAI-ARIA tree/group semantics the template intends.

Same bug class as the `listlabel` → `listLabel` fix in #1454, in the same file.

## Changes

- `packages/optimus-ui/src/cascadeselect/cascadeselect.ts`: `[attrrole]` → `[attr.role]`.
- `packages/optimus-ui/src/cascadeselect/cascadeselect.test.ts`: regression test that opens the overlay, activates an option group, and asserts the nested `<ul>` carries `role="group"`.

## Verification

Ran `ng run optimus-ui:test-vitest --include='**/cascadeselect/*.test.ts'`: 111/111 pass. With the typo restored the new test fails with `NG0303: Can't bind to 'attrrole' since it isn't a known property of 'ul'`, so it genuinely covers the regression.

Test added to `cascadeselect.test.ts` (vitest) only, not the identical Karma `cascadeselect.spec.ts`.

## Note

This compiled silently because `strictTemplates` and `fullTemplateTypeCheck` are `false` in `tsconfig.vitest.json`. Enabling `strictTemplates` for `packages/optimus-ui` would catch this whole class of template typo at build time — out of scope here, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xBTEbSbBHZJ8zXFw5YgsL