### PR TITLE
docs(theming): remove architecture image with prime ng reference

### DIFF
--- a/apps/docs/doc/theming/styled/architecture-doc.ts
+++ b/apps/docs/doc/theming/styled/architecture-doc.ts
@@ -12,7 +12,6 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
                 <i>base</i> and <i>preset</i>. The base is the style rules with CSS variables as placeholders whereas the preset is a set of design tokens to feed a base by mapping the tokens to CSS variables. A base may be configured with different
                 presets, currently Aura, Material, Lara and Nora are the available built-in options.
             </p>
-            <img alt="Architecture" src="https://optimus.openng.org/demo/primevue-v4-styled-architecture.png" class="w-full mb-4" />
             <p>The core of the styled mode architecture is based on a concept named <i>design token</i>, a preset defines the token configuration in 3 tiers; <i>primitive</i>, <i>semantic</i> and <i>component</i>.</p>
             <h3>Primitive Tokens</h3>
             <p>


### PR DESCRIPTION
Fixes #1400

## Description

removed image with PrimeOne reference from documentation

## Related issues

Fixes #1400 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [x] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [x] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [X] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->
