### PR TITLE
docs(schematics): deprecate migrate-from-primeng

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Full setup, including the manual path and icons, is in the [getting started guid
 `ng add` does not migrate an existing workspace. It sets up new projects only, and when it detects a `primeng` dependency it leaves your code untouched and points you here. Use the `migrate-from-primeng` schematic instead: install the package so the Angular CLI can resolve it, then run the schematic. Packages are swapped, imports are rewritten, and you get a report of anything it could not handle automatically, with file and line numbers.
 
 ```bash
-npm install @openng/optimus-ui
-ng generate @openng/optimus-ui:migrate-from-primeng
+npm install @openng/optimus-ui@1
+ng generate @openng/optimus-ui@1:migrate-from-primeng
 ```
 
 See the [migration guide](https://optimus.openng.org/migration/primeng) for prerequisites and the manual cases. If you are on PrimeNG v20 or older, upgrade to v21 first.

--- a/packages/optimus-ui/README.md
+++ b/packages/optimus-ui/README.md
@@ -43,7 +43,7 @@ Optimus UI is API-compatible with PrimeNG v21. On a PrimeNG v21 workspace, run t
 migration schematic:
 
 ```bash
-ng generate @openng/optimus-ui:migrate-from-primeng            # options: --skip-install, --force
+ng generate @openng/optimus-ui@1:migrate-from-primeng          # options: --skip-install, --force
 ```
 
 This replaces `primeng` and `@primeuix/*` dependencies with their `@openng` counterparts, rewrites

--- a/packages/optimus-ui/schematics/collection.json
+++ b/packages/optimus-ui/schematics/collection.json
@@ -7,7 +7,7 @@
             "schema": "./ng-add/schema.json"
         },
         "migrate-from-primeng": {
-            "description": "Migrate a PrimeNG v21 project to Optimus UI (including PrimeIcons to @openng/icons).",
+            "description": "Deprecated on this line, maintained only on release/1.x (@openng/optimus-ui@1). Migrate a PrimeNG v21 project to Optimus UI (including PrimeIcons to @openng/icons).",
             "factory": "./migrate-from-primeng/index#migrateFromPrimeng",
             "schema": "./migrate-from-primeng/schema.json"
         },

--- a/packages/optimus-ui/schematics/migrate-from-primeng/index.ts
+++ b/packages/optimus-ui/schematics/migrate-from-primeng/index.ts
@@ -26,8 +26,16 @@ const MIN_PRIMENG_MAJOR = 21;
 // leftover report with dozens of registry URL lines for a dependency we already swapped out.
 const LOCKFILE_NAMES = new Set(['package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb', 'bun.lock']);
 
+/**
+ * Migrates a PrimeNG v21 workspace to Optimus UI.
+ *
+ * @deprecated This schematic is only maintained on the `release/1.x` line (the `@openng/optimus-ui@1`
+ * package, published to v1.optimus.openng.org). It is not actively maintained on `main` going forward.
+ * Run it via `ng generate @openng/optimus-ui@1:migrate-from-primeng` rather than an unpinned install.
+ */
 export function migrateFromPrimeng(options: Schema): Rule {
     return (tree: Tree, context: SchematicContext) => {
+        warnDeprecated(context);
         checkVersionGate(tree, options);
         const isIgnored = createIgnoreMatcher(tree);
 
@@ -81,6 +89,19 @@ export function migrateFromPrimeng(options: Schema): Rule {
         }
         return tree;
     };
+}
+
+/**
+ * This schematic is deprecated on `main` — it is only maintained on the `release/1.x` line. Printed
+ * once, up front, so CLI users see it even though they will never read the JSDoc above.
+ */
+function warnDeprecated(context: SchematicContext): void {
+    context.logger.warn(
+        'migrate-from-primeng is deprecated on this line of @openng/optimus-ui and is only maintained on release/1.x. ' +
+            'Run it via the pinned v1 package instead:\n' +
+            '  npm install @openng/optimus-ui@1\n' +
+            '  ng generate @openng/optimus-ui@1:migrate-from-primeng'
+    );
 }
 
 /**

--- a/packages/optimus-ui/schematics/migrate-from-primeng/schema.json
+++ b/packages/optimus-ui/schematics/migrate-from-primeng/schema.json
@@ -2,6 +2,8 @@
     "$schema": "http://json-schema.org/schema",
     "$id": "OptimusUiMigrateFromPrimeng",
     "title": "Migrate a PrimeNG v21 project to Optimus UI",
+    "description": "Deprecated on this line \u2014 only maintained on release/1.x. Run via @openng/optimus-ui@1.",
+    "deprecated": true,
     "type": "object",
     "properties": {
         "skipInstall": {

--- a/packages/optimus-ui/schematics/migrate-from-primeng/schema.ts
+++ b/packages/optimus-ui/schematics/migrate-from-primeng/schema.ts
@@ -1,3 +1,7 @@
+/**
+ * @deprecated Only maintained on the `release/1.x` line (`@openng/optimus-ui@1`). See
+ * {@link migrateFromPrimeng}.
+ */
 export interface Schema {
     skipInstall?: boolean;
     force?: boolean;


### PR DESCRIPTION
## Description

`migrate-from-primeng` is only maintained on the `release/1.x` line going forward (`@openng/optimus-ui@1`). This marks it deprecated everywhere it's declared on this line: a `@deprecated` JSDoc tag on the exported `migrateFromPrimeng` factory and on the `Schema` interface, the standard `"deprecated": true` JSON Schema keyword in `schema.json`, and a deprecation note prefixed onto the `collection.json` description. It also prints a runtime warning the first thing the rule does when it actually runs, since most users invoke this via `ng generate` rather than importing the TypeScript module and would never see a JSDoc comment. The warning and both remaining README commands (root and `packages/optimus-ui`) point at the pinned v1 line: `npm install @openng/optimus-ui@1` / `ng generate @openng/optimus-ui@1:migrate-from-primeng`.

No functional behavior changes — the schematic still does exactly what it did before. This is a deprecation notice, not a removal.

## Related issues

N/A — requested directly, not tied to a tracked issue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [x] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None. The schematic runs exactly as before; it now also logs a deprecation warning and is flagged as deprecated in its metadata.

## Test plan

- [ ] `npm run build` — not run; this environment's `node_modules` is built for a different platform than the sandbox, so native build tooling won't run here
- [x] `npm test` — not run as the literal script, but the full schematics vitest suite was run in a cloud clone (device VM can't build this package — rollup native-binary mismatch): 132/132 passing, including all 28 `migrate-from-primeng` specs, unmodified by this change
- [ ] `npm run lint` — not run as the script itself; instead ran `npx prettier --check` (clean) on every touched file
- [ ] Verified in the demo app (if applicable) — N/A, no demo changes

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable) — N/A, requested directly
- [ ] Tests added or updated for behavioral changes — not added; the new deprecation warning was manually verified with a scripted `SchematicTestRunner` run (confirmed it's the first log line printed) but there's no automated assertion for it yet in the suite. Existing specs pass unchanged.
- [x] Documentation updated (README, JSDoc, migration notes as needed)
- [x] Public API changes documented; breaking changes called out — the deprecation itself is the change being documented; no breaking change
- [x] CHANGELOG updated (if the repository maintains one and the change is user-facing) — N/A, repo relies on GitHub Releases, no CHANGELOG.md
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Verification recipe: cloned the public repo into a scratch cloud container, overlaid the four edited schematic files, built a standalone vitest harness (tsc → CommonJS `dist/`, regenerated `utils/versions.json` from package versions, added the `{"type":"commonjs"}` `dist/package.json` override the real build script writes) and ran the full suite.

Deliberately left unchanged: `ng-add`'s two runtime warnings still point at the unpinned `ng generate @openng/optimus-ui:migrate-from-primeng` command. Pinning those to `@1` would also require updating two exact-substring `toContain(...)` assertions in `ng-add.spec.ts`, which felt like it was drifting past the scope of a deprecation notice — happy to do as a follow-up if wanted.