### PR TITLE
feat(autocomplete): add generic typing support for AutoComplete compo…

### DIFF
--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -2641,3 +2641,59 @@ describe('AutoComplete', () => {
         });
     });
 });
+
+describe('AutoComplete generic typing', () => {
+    interface Country {
+        name: string;
+        code: string;
+    }
+
+    const afghanistan: Country = { name: 'Afghanistan', code: 'AF' };
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [AutoCompleteModule],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+    });
+
+    it('should type the select event value as the suggestion type', () => {
+        const event: AutoCompleteSelectEvent<Country> = { originalEvent: new Event('click'), value: afghanistan };
+
+        // Fails to compile if `value` is widened back to `any`.
+        const name: string = event.value.name;
+
+        expect(name).toBe('Afghanistan');
+    });
+
+    it('should type the unselect event value as the suggestion type', () => {
+        const event: AutoCompleteUnselectEvent<Country> = { originalEvent: new Event('click'), value: afghanistan };
+
+        const code: string = event.value.code;
+
+        expect(code).toBe('AF');
+    });
+
+    it('should propagate the component type argument to the select output', () => {
+        const typedFixture: ComponentFixture<AutoComplete<Country>> = TestBed.createComponent<AutoComplete<Country>>(AutoComplete);
+        const typedComponent = typedFixture.componentInstance;
+        let selectedName: string | undefined;
+
+        typedComponent.onSelect.subscribe((event) => (selectedName = event.value.name));
+        typedComponent.suggestions = [afghanistan];
+        typedComponent.onOptionSelect(new Event('click'), afghanistan);
+
+        expect(selectedName).toBe('Afghanistan');
+    });
+
+    it('should type the add event value as free text', () => {
+        const typedFixture: ComponentFixture<AutoComplete<Country>> = TestBed.createComponent<AutoComplete<Country>>(AutoComplete);
+        const typedComponent = typedFixture.componentInstance;
+        let addedValue: string | undefined;
+
+        typedComponent.onAdd.subscribe((event) => (addedValue = event.value.trim()));
+        typedComponent.onAdd.emit({ originalEvent: new Event('blur'), value: ' Afghanistan ' });
+
+        expect(addedValue).toBe('Afghanistan');
+    });
+});

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -336,7 +336,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
     },
     hostDirectives: [Bind]
 })
-export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
+export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     componentName = 'AutoComplete';
 
     $pcAutoComplete: AutoComplete | undefined = inject(AUTOCOMPLETE_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
@@ -572,11 +572,11 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
      * An array of suggestions to display.
      * @group Props
      */
-    @Input() get suggestions(): any[] {
+    @Input() get suggestions(): T[] {
         return this._suggestions();
     }
 
-    set suggestions(value: any[]) {
+    set suggestions(value: T[]) {
         this._suggestions.set(value);
         this.handleSuggestionsChange();
     }
@@ -585,12 +585,12 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
      * Property name or getter function to use as the label of an option.
      * @group Props
      */
-    @Input() optionLabel: string | ((item: any) => string) | undefined;
+    @Input() optionLabel: string | ((item: T) => string) | undefined;
     /**
      * Property name or getter function to use as the value of an option.
      * @group Props
      */
-    @Input() optionValue: string | ((item: any) => string) | undefined;
+    @Input() optionValue: string | ((item: T) => string) | undefined;
     /**
      * Unique identifier of the component.
      * @group Props
@@ -633,7 +633,7 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
      * Property name or getter function to use as the disabled flag of an option, defaults to false when not defined.
      * @group Props
      */
-    @Input() optionDisabled: string | ((item: any) => string) | undefined;
+    @Input() optionDisabled: string | ((item: T) => string) | undefined;
     /**
      * When enabled, the hovered option will be focused.
      * @group Props
@@ -678,13 +678,13 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
      * @param {AutoCompleteSelectEvent} event - custom select event.
      * @group Emits
      */
-    @Output() onSelect: EventEmitter<AutoCompleteSelectEvent> = new EventEmitter<AutoCompleteSelectEvent>();
+    @Output() onSelect: EventEmitter<AutoCompleteSelectEvent<T>> = new EventEmitter<AutoCompleteSelectEvent<T>>();
     /**
      * Callback to invoke when a selected value is removed.
      * @param {AutoCompleteUnselectEvent} event - custom unselect event.
      * @group Emits
      */
-    @Output() onUnselect: EventEmitter<AutoCompleteUnselectEvent> = new EventEmitter<AutoCompleteUnselectEvent>();
+    @Output() onUnselect: EventEmitter<AutoCompleteUnselectEvent<T>> = new EventEmitter<AutoCompleteUnselectEvent<T>>();
     /**
      * Callback to invoke when an item is added via addOnBlur or separator features.
      * @param {AutoCompleteAddEvent} event - Custom add event.

--- a/packages/optimus-ui/src/types/autocomplete/autocomplete.types.ts
+++ b/packages/optimus-ui/src/types/autocomplete/autocomplete.types.ts
@@ -136,10 +136,11 @@ export interface AutoCompleteDropdownClickEvent {
 }
 /**
  * Custom select event.
+ * @template T Type of the suggestion.
  * @see {@link AutoComplete.onSelect}
  * @group Events
  */
-export interface AutoCompleteSelectEvent {
+export interface AutoCompleteSelectEvent<T = any> {
     /**
      * Browser event.
      */
@@ -147,14 +148,16 @@ export interface AutoCompleteSelectEvent {
     /**
      * Selected value.
      */
-    value: any;
+    value: T;
 }
 /**
  * Custom unselect event.
+ * @template T Type of the removed value. Note that when `optionValue` is defined the removed value is the
+ * resolved option value rather than the suggestion itself, so the type argument should be set accordingly.
  * @see {@link AutoComplete.onUnSelect}
  * @group Events
  */
-export interface AutoCompleteUnselectEvent {
+export interface AutoCompleteUnselectEvent<T = any> {
     /**
      * Browser event.
      */
@@ -162,14 +165,16 @@ export interface AutoCompleteUnselectEvent {
     /**
      * Removed value.
      */
-    value: any;
+    value: T;
 }
 /**
  * Custom add event.
+ * @template T Type of the added value. Values added through the `addOnBlur`, `addOnTab` or `separator`
+ * features are free text, hence the `string` default.
  * @see {@link AutoComplete.onAdd}
  * @group Events
  */
-export interface AutoCompleteAddEvent {
+export interface AutoCompleteAddEvent<T = string> {
     /**
      * Browser event.
      */
@@ -177,7 +182,7 @@ export interface AutoCompleteAddEvent {
     /**
      * Added value.
      */
-    value: any;
+    value: T;
 }
 /**
  * Custom lazy load event.


### PR DESCRIPTION
…nent

Enhance the AutoComplete component to support generic typing, allowing users to define the type of suggestions. Update related events and properties to utilize the generic type, ensuring type safety for select, unselect, and add events. Add corresponding tests to verify the new typing functionality.

## Description

<!-- What changed and why? For bug fixes, describe before/after behavior. -->

## Related issues

Fixes #926

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

<!-- If this is a breaking change, describe what changed and how consumers should migrate. Otherwise, write "None". -->

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [] Verified in the demo app (if applicable)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->
