### PR TITLE
fix(select): keep the lazy virtual scroll list at its full height

### DIFF
--- a/packages/optimus-ui/src/scroller/scroller.ts
+++ b/packages/optimus-ui/src/scroller/scroller.ts
@@ -900,7 +900,9 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
 
     calculateAutoSize() {
         if (this._autoSize && !this.d_loading) {
-            Promise.resolve().then(() => {
+            // a macrotask is required here: when items are lazy loaded, the new items are only
+            // rendered on the next tick, and a microtask would measure the still empty content
+            setTimeout(() => {
                 if (this.contentEl) {
                     this.contentEl.style.minHeight = this.contentEl.style.minWidth = 'auto';
                     this.contentEl.style.position = 'relative';
@@ -918,7 +920,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
                     this.contentEl.style.position = '';
                     (<ElementRef>this.elementViewChild).nativeElement.style.contain = '';
                 }
-            });
+            }, 1);
         }
     }
 

--- a/packages/optimus-ui/src/select/select.spec.ts
+++ b/packages/optimus-ui/src/select/select.spec.ts
@@ -4457,3 +4457,81 @@ describe('Select PT (PassThrough)', () => {
         });
     });
 });
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `<p-select [options]="items" [(ngModel)]="selectedItem" placeholder="Select Item" [virtualScroll]="true" [virtualScrollItemSize]="32" [lazy]="true" (onLazyLoad)="onLazyLoad($event)"></p-select>`
+})
+class TestLazyVirtualScrollComponent {
+    items: any[] = [];
+    selectedItem: any;
+
+    onLazyLoad(event: any) {
+        const { first, last } = event;
+        const items = [...this.items];
+
+        // the total number of records is known upfront, only the requested window is filled in
+        if (items.length < 10000) {
+            items.length = 10000;
+        }
+
+        for (let i = first; i < last; i++) {
+            items[i] = { label: `Item #${i}`, value: i };
+        }
+
+        this.items = items;
+    }
+}
+
+describe('Select Lazy Virtual Scroll', () => {
+    let fixture: ComponentFixture<TestLazyVirtualScrollComponent>;
+    let component: TestLazyVirtualScrollComponent;
+    let selectInstance: Select;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [CommonModule, FormsModule, Select],
+            declarations: [TestLazyVirtualScrollComponent],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestLazyVirtualScrollComponent);
+        component = fixture.componentInstance;
+        selectInstance = fixture.debugElement.query(By.css('p-select')).componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should render the lazy loaded options and keep the scroller at its full height', async () => {
+        const lazyLoadSpy = spyOn(component, 'onLazyLoad').and.callThrough();
+
+        selectInstance.show();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(lazyLoadSpy).toHaveBeenCalled();
+
+        fixture.detectChanges();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const options = fixture.debugElement.queryAll(By.css('.p-select-option'));
+        expect(options.length).toBeGreaterThan(0);
+        expect(options[0].nativeElement.textContent).toContain('Item #0');
+
+        // autoSize used to measure the content before the lazy loaded items were rendered,
+        // which collapsed the scroller to the height of an empty list
+        const scroller = fixture.debugElement.query(By.css('p-scroller'));
+        expect(scroller.nativeElement.offsetHeight).toBeGreaterThan(100);
+    });
+
+    it('should not throw when an option of the lazy loaded window is not resolved yet', () => {
+        selectInstance.optionGroupLabel = 'label';
+
+        expect(() => selectInstance.isOptionGroup(undefined)).not.toThrow();
+        expect(selectInstance.isOptionGroup(undefined)).toBeFalsy();
+    });
+});

--- a/packages/optimus-ui/src/select/select.test.ts
+++ b/packages/optimus-ui/src/select/select.test.ts
@@ -4457,3 +4457,81 @@ describe('Select PT (PassThrough)', () => {
         });
     });
 });
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `<p-select [options]="items" [(ngModel)]="selectedItem" placeholder="Select Item" [virtualScroll]="true" [virtualScrollItemSize]="32" [lazy]="true" (onLazyLoad)="onLazyLoad($event)"></p-select>`
+})
+class TestLazyVirtualScrollComponent {
+    items: any[] = [];
+    selectedItem: any;
+
+    onLazyLoad(event: any) {
+        const { first, last } = event;
+        const items = [...this.items];
+
+        // the total number of records is known upfront, only the requested window is filled in
+        if (items.length < 10000) {
+            items.length = 10000;
+        }
+
+        for (let i = first; i < last; i++) {
+            items[i] = { label: `Item #${i}`, value: i };
+        }
+
+        this.items = items;
+    }
+}
+
+describe('Select Lazy Virtual Scroll', () => {
+    let fixture: ComponentFixture<TestLazyVirtualScrollComponent>;
+    let component: TestLazyVirtualScrollComponent;
+    let selectInstance: Select;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [CommonModule, FormsModule, Select],
+            declarations: [TestLazyVirtualScrollComponent],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestLazyVirtualScrollComponent);
+        component = fixture.componentInstance;
+        selectInstance = fixture.debugElement.query(By.css('p-select')).componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should render the lazy loaded options and keep the scroller at its full height', async () => {
+        const lazyLoadSpy = vi.spyOn(component, 'onLazyLoad');
+
+        selectInstance.show();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(lazyLoadSpy).toHaveBeenCalled();
+
+        fixture.detectChanges();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const options = fixture.debugElement.queryAll(By.css('.p-select-option'));
+        expect(options.length).toBeGreaterThan(0);
+        expect(options[0].nativeElement.textContent).toContain('Item #0');
+
+        // autoSize used to measure the content before the lazy loaded items were rendered,
+        // which collapsed the scroller to the height of an empty list
+        const scroller = fixture.debugElement.query(By.css('p-scroller'));
+        expect(scroller.nativeElement.offsetHeight).toBeGreaterThan(100);
+    });
+
+    it('should not throw when an option of the lazy loaded window is not resolved yet', () => {
+        selectInstance.optionGroupLabel = 'label';
+
+        expect(() => selectInstance.isOptionGroup(undefined)).not.toThrow();
+        expect(selectInstance.isOptionGroup(undefined)).toBeFalsy();
+    });
+});

--- a/packages/optimus-ui/src/select/select.ts
+++ b/packages/optimus-ui/src/select/select.ts
@@ -1731,7 +1731,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
     }
 
     isOptionGroup(option) {
-        return this.optionGroupLabel !== undefined && this.optionGroupLabel !== null && option.optionGroup !== undefined && option.optionGroup !== null && option.group;
+        return this.optionGroupLabel !== undefined && this.optionGroupLabel !== null && option?.optionGroup !== undefined && option?.optionGroup !== null && option.group;
     }
 
     onArrowUpKey(event: KeyboardEvent, pressedInInputText: boolean = false) {


### PR DESCRIPTION
## Problem

With a lazy virtual-scrolled `p-select` (`[virtualScroll]="true" [lazy]="true"`), the overlay list collapses to the height of an empty list, and the component can throw before the first page of options arrives.

Two separate causes:

**1. `Scroller.calculateAutoSize()` measures before the lazy items render.**

`autoSize` (which `p-select` and `p-multiselect` always turn on for their scrollers) measures the content element inside `Promise.resolve().then(...)`. That is a microtask, so it runs before Angular has rendered the items that the `onLazyLoad` handler just supplied — the content element is still empty, and the scroller pins itself to that empty height. With non-lazy options the items are already in the DOM when the measurement runs, so the bug only shows up when data arrives asynchronously.

Switching to a macrotask (`setTimeout(..., 1)`) lets the pending render flush first, so the measurement sees the real content.

**2. `Select.isOptionGroup()` throws on a not-yet-loaded option.**

A lazy data source typically hands back a sparse array sized to the total record count, with only the requested window filled in. The template calls `isOptionGroup(option)` for every rendered row, and for a hole in that array the current `option.optionGroup` access throws `Cannot read properties of undefined`. `p-multiselect` and the rest of the option helpers already guard against this; `Select.isOptionGroup` is the one that does not.

## Changes

- `scroller`: `calculateAutoSize()` defers its measurement to a macrotask, with a comment explaining why the microtask is not enough.
- `select`: `isOptionGroup()` uses optional chaining, matching how the other option helpers handle undefined entries.

## Tests

Added a `Select Lazy Virtual Scroll` suite to both `select.spec.ts` (jasmine) and `select.test.ts` (vitest):

- renders the lazy-loaded options and asserts the scroller keeps its full height — this fails on `main` because the scroller collapses;
- asserts `isOptionGroup(undefined)` does not throw when `optionGroupLabel` is set.
