### PR TITLE
feat(select,multiselect): make lazy loading work with filtering

### DIFF
--- a/apps/docs/doc/multiselect/lazyvirtualscroll-doc.ts
+++ b/apps/docs/doc/multiselect/lazyvirtualscroll-doc.ts
@@ -1,27 +1,38 @@
-import { AppCode } from '@/components/doc/app.code';
+import { AppCodeModule } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SelectItem } from '@openng/optimus-ui/api';
-import { SelectModule } from '@openng/optimus-ui/select';
-import { SelectLazyLoadEvent } from '@openng/optimus-ui/types/select';
+import { MultiSelectModule } from '@openng/optimus-ui/multiselect';
+import { MultiSelectLazyLoadEvent } from '@openng/optimus-ui/types/multiselect';
 
 @Component({
     selector: 'lazyvirtualscroll-doc',
     standalone: true,
-    imports: [AppCode, FormsModule, SelectModule],
+    imports: [FormsModule, MultiSelectModule, AppCodeModule, AppDocSectionText],
     template: `
+        <app-docsectiontext>
+            <p>
+                Enabling <i>lazy</i> on top of <i>virtualScroll</i> loads the options from a backend as they are scrolled into view. The <i>onLazyLoad</i> event carries the requested range along with the current <i>filter</i>, so filtering can be
+                delegated to the backend as well. Options behind the current selection that the backend has not returned yet are supplied through <i>lazySelectedOptions</i>, which is what keeps their labels resolvable.
+            </p>
+        </app-docsectiontext>
         <div class="card flex justify-center">
-            <p-select
+            <p-multiselect
                 [options]="items()"
-                [(ngModel)]="selectedItem"
-                placeholder="Select Item"
+                [(ngModel)]="selectedItems"
+                optionLabel="label"
+                optionValue="value"
+                [lazySelectedOptions]="lazySelectedOptions"
                 [filter]="true"
                 [virtualScroll]="true"
-                [virtualScrollItemSize]="32"
+                [virtualScrollItemSize]="43"
                 [lazy]="true"
                 (onLazyLoad)="onLazyLoad($event)"
                 [loading]="loading()"
-                class="w-full md:w-56"
+                placeholder="Select Items"
+                [maxSelectedLabels]="3"
+                class="w-full md:w-80"
             />
         </div>
         <app-code></app-code>
@@ -31,8 +42,10 @@ export class LazyVirtualScrollDoc {
     // Simulates backend database
     backendItems: SelectItem[] = Array.from({ length: 10000 }, (_, i) => ({ label: `Item #${i}`, value: i }));
 
-    // The selection is deliberately outside the first page, to show that its label survives lazy loading
-    selectedItem: SelectItem | undefined = this.backendItems[5000];
+    // The selection is deliberately outside the first page, so its options have to be handed over upfront
+    selectedItems: number[] = [5000, 7000];
+
+    lazySelectedOptions: SelectItem[] = [this.backendItems[5000], this.backendItems[7000]];
 
     items = signal<SelectItem[] | null>(null);
 
@@ -42,7 +55,7 @@ export class LazyVirtualScrollDoc {
 
     currentFilter: string | null = null;
 
-    onLazyLoad(event: SelectLazyLoadEvent) {
+    onLazyLoad(event: MultiSelectLazyLoadEvent) {
         this.loading.set(true);
 
         if (this.loadLazyTimeout) {

--- a/apps/docs/pages/multiselect/index.ts
+++ b/apps/docs/pages/multiselect/index.ts
@@ -9,6 +9,7 @@ import { GroupDoc } from '@/doc/multiselect/group-doc';
 import { IftaLabelDoc } from '@/doc/multiselect/iftalabel-doc';
 import { ImportDoc } from '@/doc/multiselect/import-doc';
 import { InvalidDoc } from '@/doc/multiselect/invalid-doc';
+import { LazyVirtualScrollDoc } from '@/doc/multiselect/lazyvirtualscroll-doc';
 import { LoadingStateDoc } from '@/doc/multiselect/loadingstate-doc';
 import { ReactiveFormsDoc } from '@/doc/multiselect/reactiveforms-doc';
 import { SizesDoc } from '@/doc/multiselect/sizes-doc';
@@ -76,6 +77,11 @@ export class MultiSelectDemo {
             id: 'virtualscroll',
             label: 'VirtualScroll',
             component: VirtualScrollDoc
+        },
+        {
+            id: 'lazyvirtualscroll',
+            label: 'Lazy Virtual Scroll',
+            component: LazyVirtualScrollDoc
         },
         {
             id: 'floatlabel',

--- a/packages/optimus-ui/src/multiselect/multiselect.spec.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.spec.ts
@@ -3892,3 +3892,99 @@ describe('MultiSelect Complex Edge Cases', () => {
         });
     });
 });
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <p-multiselect
+            [options]="items"
+            [(ngModel)]="selectedItems"
+            optionLabel="label"
+            optionValue="value"
+            [lazySelectedOptions]="lazySelectedOptions"
+            [filter]="true"
+            [virtualScroll]="true"
+            [virtualScrollItemSize]="43"
+            [lazy]="lazy"
+            (onLazyLoad)="onLazyLoad($event)"
+        ></p-multiselect>
+    `
+})
+class TestLazyFilterMultiSelectComponent {
+    items: any[] = [
+        { label: 'Item #0', value: 0 },
+        { label: 'Other', value: 1 }
+    ];
+
+    lazySelectedOptions: any[] = [{ label: 'Item #9999', value: 9999 }];
+
+    selectedItems: any[] = [9999];
+
+    lazy = true;
+
+    events: any[] = [];
+
+    onLazyLoad(event: any) {
+        this.events.push(event);
+    }
+}
+
+describe('MultiSelect Lazy Filtering', () => {
+    let fixture: ComponentFixture<TestLazyFilterMultiSelectComponent>;
+    let component: TestLazyFilterMultiSelectComponent;
+    let multiSelect: MultiSelect;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [TestLazyFilterMultiSelectComponent],
+            imports: [CommonModule, FormsModule, MultiSelectModule],
+            providers: [provideNoopAnimations(), provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestLazyFilterMultiSelectComponent);
+        component = fixture.componentInstance;
+        multiSelect = fixture.debugElement.query(By.directive(MultiSelect)).componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should request a reload carrying the filter when the filter changes', async () => {
+        component.events.length = 0;
+
+        multiSelect.onFilterInputChange({ target: { value: 'Item' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const event = component.events[component.events.length - 1];
+        expect(event).toBeTruthy();
+        expect(event.first).toBe(0);
+        expect(event.filter).toBe('Item');
+    });
+
+    it('should leave filtering to the data source when lazy', async () => {
+        multiSelect.onFilterInputChange({ target: { value: 'Other' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(multiSelect.visibleOptions().length).toBe(2);
+    });
+
+    it('should filter locally when not lazy', async () => {
+        component.lazy = false;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        multiSelect.onFilterInputChange({ target: { value: 'Other' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(multiSelect.visibleOptions().length).toBe(1);
+    });
+
+    it('should resolve the label of a selection the data source has not returned', () => {
+        expect(multiSelect.getLabelByValue(9999)).toBe('Item #9999');
+        // the remembered options resolve labels only, they are never rendered as list items
+        expect(multiSelect.visibleOptions().length).toBe(2);
+    });
+});

--- a/packages/optimus-ui/src/multiselect/multiselect.test.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.test.ts
@@ -3735,3 +3735,99 @@ describe('MultiSelect Complex Edge Cases', () => {
         });
     });
 });
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <p-multiselect
+            [options]="items"
+            [(ngModel)]="selectedItems"
+            optionLabel="label"
+            optionValue="value"
+            [lazySelectedOptions]="lazySelectedOptions"
+            [filter]="true"
+            [virtualScroll]="true"
+            [virtualScrollItemSize]="43"
+            [lazy]="lazy"
+            (onLazyLoad)="onLazyLoad($event)"
+        ></p-multiselect>
+    `
+})
+class TestLazyFilterMultiSelectComponent {
+    items: any[] = [
+        { label: 'Item #0', value: 0 },
+        { label: 'Other', value: 1 }
+    ];
+
+    lazySelectedOptions: any[] = [{ label: 'Item #9999', value: 9999 }];
+
+    selectedItems: any[] = [9999];
+
+    lazy = true;
+
+    events: any[] = [];
+
+    onLazyLoad(event: any) {
+        this.events.push(event);
+    }
+}
+
+describe('MultiSelect Lazy Filtering', () => {
+    let fixture: ComponentFixture<TestLazyFilterMultiSelectComponent>;
+    let component: TestLazyFilterMultiSelectComponent;
+    let multiSelect: MultiSelect;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [TestLazyFilterMultiSelectComponent],
+            imports: [CommonModule, FormsModule, MultiSelectModule],
+            providers: [provideNoopAnimations(), provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestLazyFilterMultiSelectComponent);
+        component = fixture.componentInstance;
+        multiSelect = fixture.debugElement.query(By.directive(MultiSelect)).componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should request a reload carrying the filter when the filter changes', async () => {
+        component.events.length = 0;
+
+        multiSelect.onFilterInputChange({ target: { value: 'Item' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const event = component.events[component.events.length - 1];
+        expect(event).toBeTruthy();
+        expect(event.first).toBe(0);
+        expect(event.filter).toBe('Item');
+    });
+
+    it('should leave filtering to the data source when lazy', async () => {
+        multiSelect.onFilterInputChange({ target: { value: 'Other' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(multiSelect.visibleOptions().length).toBe(2);
+    });
+
+    it('should filter locally when not lazy', async () => {
+        component.lazy = false;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        multiSelect.onFilterInputChange({ target: { value: 'Other' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(multiSelect.visibleOptions().length).toBe(1);
+    });
+
+    it('should resolve the label of a selection the data source has not returned', () => {
+        expect(multiSelect.getLabelByValue(9999)).toBe('Item #9999');
+        // the remembered options resolve labels only, they are never rendered as list items
+        expect(multiSelect.visibleOptions().length).toBe(2);
+    });
+});

--- a/packages/optimus-ui/src/multiselect/multiselect.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.ts
@@ -45,6 +45,7 @@ import { Overlay } from '@openng/optimus-ui/overlay';
 import { Scroller } from '@openng/optimus-ui/scroller';
 import { Tooltip } from '@openng/optimus-ui/tooltip';
 import { Nullable } from '@openng/optimus-ui/ts-helpers';
+import type { ScrollerLazyLoadEvent } from '@openng/optimus-ui/types/scroller';
 import {
     MultiSelectBlurEvent,
     MultiSelectChangeEvent,
@@ -67,6 +68,12 @@ import {
 } from '@openng/optimus-ui/types/multiselect';
 import { ObjectUtils } from '@openng/optimus-ui/utils';
 import { MultiSelectStyle } from './style/multiselectstyle';
+
+/**
+ * Number of options requested when a filter change forces a reload before the scroller has
+ * measured its viewport.
+ */
+const DEFAULT_LAZY_PAGE_SIZE = 20;
 
 const MULTISELECT_INSTANCE = new InjectionToken<MultiSelect>('MULTISELECT_INSTANCE');
 const MULTISELECT_ITEM_INSTANCE = new InjectionToken<MultiSelectItem>('MULTISELECT_ITEM_INSTANCE');
@@ -392,7 +399,7 @@ export class MultiSelectItem extends BaseComponent {
                             [autoSize]="true"
                             [tabindex]="-1"
                             [lazy]="lazy"
-                            (onLazyLoad)="onLazyLoad.emit($event)"
+                            (onLazyLoad)="onScrollerLazyLoad($event)"
                             [options]="virtualScrollOptions"
                         >
                             <ng-template #content let-items let-scrollerOptions="options">
@@ -792,6 +799,14 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
     set filterValue(val: string | undefined | null) {
         this._filterValue.set(val);
+    }
+    /**
+     * Options behind the current selection, for the lazy case where the selected options are not
+     * part of the loaded page. Only used to resolve the labels of the chips and of the value.
+     * @group Props
+     */
+    @Input() set lazySelectedOptions(val: any[]) {
+        this._lazySelectedOptions = val || [];
     }
     /**
      * Whether all data is selected.
@@ -1222,6 +1237,8 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     clickInProgress: boolean = false;
 
+    _lazySelectedOptions: any[] = [];
+
     get emptyMessageLabel(): string {
         return this.emptyMessage || this.config.getTranslation(TranslationKeys.EMPTY_MESSAGE);
     }
@@ -1242,15 +1259,30 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         return this.config.getTranslation(TranslationKeys.ARIA)['listLabel'];
     }
 
-    private getAllVisibleAndNonVisibleOptions() {
-        return this.group ? this.flatOptions(this.options) : this.options || [];
+    private getAllVisibleAndNonVisibleOptions = computed(() => {
+        const options = this._options();
+
+        return this.group ? this.flatOptions(options) : options || [];
+    });
+
+    /**
+     * Every option a model value can be resolved against: the loaded options plus the options behind
+     * a selection that lazy loading has not brought back. Never rendered as list items.
+     */
+    private getResolvableOptions() {
+        const options = this.getAllVisibleAndNonVisibleOptions();
+
+        return this.lazy && this._lazySelectedOptions.length ? [...options, ...this._lazySelectedOptions] : options;
     }
 
     visibleOptions = computed(() => {
         const options = this.getAllVisibleAndNonVisibleOptions();
         const isArrayOfObjects = isArray(options) && ObjectUtils.isObject(options[0]);
+        // read outside the condition so the filter stays a dependency of this computed whatever lazy is
+        const filterValue = this._filterValue();
 
-        if (this._filterValue()) {
+        // when lazy, filtering is the data source's job: the options it returns are already filtered
+        if (!this.lazy && filterValue) {
             let filteredOptions;
 
             if (isArrayOfObjects) {
@@ -1319,14 +1351,22 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         effect(() => {
             const modelValue = this.modelValue();
 
-            const allVisibleAndNonVisibleOptions = this.getAllVisibleAndNonVisibleOptions();
-            if (allVisibleAndNonVisibleOptions && isNotEmpty(allVisibleAndNonVisibleOptions)) {
+            const resolvableOptions = this.getResolvableOptions();
+            if (resolvableOptions && isNotEmpty(resolvableOptions)) {
                 if (this.optionValue && this.optionLabel && modelValue) {
-                    this.selectedOptions = allVisibleAndNonVisibleOptions.filter((option) => modelValue.includes(option[this.optionLabel!]) || modelValue.includes(option[this.optionValue!]));
+                    this.selectedOptions = resolvableOptions.filter((option) => modelValue.includes(option[this.optionLabel!]) || modelValue.includes(option[this.optionValue!]));
                 } else {
                     this.selectedOptions = modelValue;
                 }
                 this.cd.markForCheck();
+            }
+        });
+
+        effect(() => {
+            const filter = this._filterValue();
+
+            if (this.lazy) {
+                this.emitLazyLoadForFilter(filter);
             }
         });
     }
@@ -1559,8 +1599,20 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     getLabelByValue(value) {
-        const options = this.group ? this.flatOptions(this._options()) : this._options() || [];
-        const matchedOption = options.find((option) => !this.isOptionGroup(option) && equals(this.getOptionValue(option), value, this.equalityKey() || ''));
+        const matches = (option) => !this.isOptionGroup(option) && equals(this.getOptionValue(option), value, this.equalityKey() || '');
+        let matchedOption = this.getAllVisibleAndNonVisibleOptions().find(matches);
+
+        if (this.lazy) {
+            if (matchedOption) {
+                // remember the option, so that the label survives the page it came with being replaced
+                if (!this._lazySelectedOptions.some(matches)) {
+                    this._lazySelectedOptions.push(matchedOption);
+                }
+            } else {
+                matchedOption = this._lazySelectedOptions.find(matches);
+            }
+        }
+
         return matchedOption ? this.getOptionLabel(matchedOption) : null;
     }
 
@@ -1899,6 +1951,22 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         !this.virtualScrollerDisabled && this.scroller?.scrollToIndex(0);
         setTimeout(() => {
             this.overlayViewChild?.alignOverlay();
+        });
+    }
+
+    onScrollerLazyLoad(event: ScrollerLazyLoadEvent): void {
+        this.onLazyLoad.emit({ ...event, filter: this._filterValue() ?? null });
+    }
+
+    /**
+     * The scroller only reports a range once it has rendered, so a filter change has to ask for a
+     * first page itself. The scroller re-emits the exact range right after, through onScrollerLazyLoad.
+     */
+    private emitLazyLoadForFilter(filter: string | undefined | null): void {
+        this.onLazyLoad.emit({
+            first: 0,
+            last: this.scroller?.numItemsInViewport || DEFAULT_LAZY_PAGE_SIZE,
+            filter: filter ?? null
         });
     }
 

--- a/packages/optimus-ui/src/select/select.spec.ts
+++ b/packages/optimus-ui/src/select/select.spec.ts
@@ -4457,3 +4457,87 @@ describe('Select PT (PassThrough)', () => {
         });
     });
 });
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `<p-select [options]="items" [(ngModel)]="selectedItem" optionLabel="label" [filter]="true" [virtualScroll]="true" [virtualScrollItemSize]="32" [lazy]="lazy" (onLazyLoad)="onLazyLoad($event)"></p-select>`
+})
+class TestLazyFilterSelectComponent {
+    items: any[] = [
+        { label: 'Item #0', value: 0 },
+        { label: 'Other', value: 1 }
+    ];
+
+    selectedItem: any;
+
+    lazy = true;
+
+    events: any[] = [];
+
+    onLazyLoad(event: any) {
+        this.events.push(event);
+    }
+}
+
+describe('Select Lazy Filtering', () => {
+    let fixture: ComponentFixture<TestLazyFilterSelectComponent>;
+    let component: TestLazyFilterSelectComponent;
+    let selectInstance: Select;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [CommonModule, FormsModule, Select],
+            declarations: [TestLazyFilterSelectComponent],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestLazyFilterSelectComponent);
+        component = fixture.componentInstance;
+        selectInstance = fixture.debugElement.query(By.css('p-select')).componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should request a reload carrying the filter when the filter changes', async () => {
+        component.events.length = 0;
+
+        selectInstance.onFilterInputChange({ target: { value: 'Item' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const event = component.events[component.events.length - 1];
+        expect(event).toBeTruthy();
+        expect(event.first).toBe(0);
+        expect(event.filter).toBe('Item');
+    });
+
+    it('should leave filtering to the data source when lazy', async () => {
+        selectInstance.onFilterInputChange({ target: { value: 'Other' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(selectInstance.visibleOptions().length).toBe(2);
+    });
+
+    it('should filter locally when not lazy', async () => {
+        component.lazy = false;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        selectInstance.onFilterInputChange({ target: { value: 'Other' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(selectInstance.visibleOptions().length).toBe(1);
+    });
+
+    it('should label the value from the model when its option is not loaded', async () => {
+        component.selectedItem = { label: 'Item #9999', value: 9999 };
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(selectInstance.label()).toBe('Item #9999');
+    });
+});

--- a/packages/optimus-ui/src/select/select.test.ts
+++ b/packages/optimus-ui/src/select/select.test.ts
@@ -4457,3 +4457,87 @@ describe('Select PT (PassThrough)', () => {
         });
     });
 });
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `<p-select [options]="items" [(ngModel)]="selectedItem" optionLabel="label" [filter]="true" [virtualScroll]="true" [virtualScrollItemSize]="32" [lazy]="lazy" (onLazyLoad)="onLazyLoad($event)"></p-select>`
+})
+class TestLazyFilterSelectComponent {
+    items: any[] = [
+        { label: 'Item #0', value: 0 },
+        { label: 'Other', value: 1 }
+    ];
+
+    selectedItem: any;
+
+    lazy = true;
+
+    events: any[] = [];
+
+    onLazyLoad(event: any) {
+        this.events.push(event);
+    }
+}
+
+describe('Select Lazy Filtering', () => {
+    let fixture: ComponentFixture<TestLazyFilterSelectComponent>;
+    let component: TestLazyFilterSelectComponent;
+    let selectInstance: Select;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [CommonModule, FormsModule, Select],
+            declarations: [TestLazyFilterSelectComponent],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestLazyFilterSelectComponent);
+        component = fixture.componentInstance;
+        selectInstance = fixture.debugElement.query(By.css('p-select')).componentInstance;
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should request a reload carrying the filter when the filter changes', async () => {
+        component.events.length = 0;
+
+        selectInstance.onFilterInputChange({ target: { value: 'Item' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const event = component.events[component.events.length - 1];
+        expect(event).toBeTruthy();
+        expect(event.first).toBe(0);
+        expect(event.filter).toBe('Item');
+    });
+
+    it('should leave filtering to the data source when lazy', async () => {
+        selectInstance.onFilterInputChange({ target: { value: 'Other' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(selectInstance.visibleOptions().length).toBe(2);
+    });
+
+    it('should filter locally when not lazy', async () => {
+        component.lazy = false;
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        selectInstance.onFilterInputChange({ target: { value: 'Other' } } as any);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(selectInstance.visibleOptions().length).toBe(1);
+    });
+
+    it('should label the value from the model when its option is not loaded', async () => {
+        component.selectedItem = { label: 'Item #9999', value: 9999 };
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(selectInstance.label()).toBe('Item #9999');
+    });
+});

--- a/packages/optimus-ui/src/select/select.ts
+++ b/packages/optimus-ui/src/select/select.ts
@@ -45,6 +45,7 @@ import { Ripple } from '@openng/optimus-ui/ripple';
 import { Scroller } from '@openng/optimus-ui/scroller';
 import { Tooltip } from '@openng/optimus-ui/tooltip';
 import { Nullable } from '@openng/optimus-ui/ts-helpers';
+import type { ScrollerLazyLoadEvent } from '@openng/optimus-ui/types/scroller';
 import {
     SelectChangeEvent,
     SelectFilterEvent,
@@ -59,6 +60,12 @@ import {
     SelectSelectedItemTemplateContext
 } from '@openng/optimus-ui/types/select';
 import { SelectStyle } from './style/selectstyle';
+
+/**
+ * Number of options requested when a filter change forces a reload before the scroller has
+ * measured its viewport.
+ */
+const DEFAULT_LAZY_PAGE_SIZE = 20;
 
 const SELECT_INSTANCE = new InjectionToken<Select>('SELECT_INSTANCE');
 const SELECT_ITEM_INSTANCE = new InjectionToken<SelectItem>('SELECT_ITEM_INSTANCE');
@@ -342,7 +349,7 @@ export class SelectItem extends BaseComponent {
                             [itemSize]="virtualScrollItemSize"
                             [autoSize]="true"
                             [lazy]="lazy"
-                            (onLazyLoad)="onLazyLoad.emit($event)"
+                            (onLazyLoad)="onScrollerLazyLoad($event)"
                             [options]="virtualScrollOptions"
                             [pt]="ptm('virtualScroller')"
                         >
@@ -992,8 +999,11 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
     visibleOptions = computed(() => {
         const options = this.getAllVisibleAndNonVisibleOptions();
+        // read outside the condition so the filter stays a dependency of this computed whatever lazy is
+        const filterValue = this._filterValue();
 
-        if (this._filterValue()) {
+        // when lazy, filtering is the data source's job: the options it returns are already filtered
+        if (!this.lazy && filterValue) {
             const _filterBy = this.filterBy || this.optionLabel;
 
             const filteredOptions =
@@ -1046,6 +1056,12 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
             return this.getOptionLabel(selectedOption);
         }
 
+        // with lazy loading the selected option is not necessarily part of the loaded page,
+        // fall back to the model value rather than showing the placeholder over a filled control
+        if (this.lazy && this.$filled()) {
+            return this.getOptionLabel(this.modelValue());
+        }
+
         return this.placeholder() || 'p-emptylabel';
     });
 
@@ -1084,15 +1100,25 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
             }
             this.cd.markForCheck();
         });
+
+        effect(() => {
+            const filter = this._filterValue();
+
+            if (this.lazy) {
+                this.emitLazyLoadForFilter(filter);
+            }
+        });
     }
 
     private isModelValueNotSet(): boolean {
         return this.modelValue() === null && !this.isOptionValueEqualsModelValue(this.selectedOption);
     }
 
-    private getAllVisibleAndNonVisibleOptions() {
-        return this.group ? this.flatOptions(this.options) : this.options || [];
-    }
+    private getAllVisibleAndNonVisibleOptions = computed(() => {
+        const options = this._options();
+
+        return this.group ? this.flatOptions(options) : options || [];
+    });
 
     onInit() {
         this.id = this.id || uuid('pn_id_');
@@ -1931,6 +1957,22 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
             this.overlayViewChild?.alignOverlay();
         });
         this.cd.markForCheck();
+    }
+
+    onScrollerLazyLoad(event: ScrollerLazyLoadEvent): void {
+        this.onLazyLoad.emit({ ...event, filter: this._filterValue() ?? null });
+    }
+
+    /**
+     * The scroller only reports a range once it has rendered, so a filter change has to ask for a
+     * first page itself. The scroller re-emits the exact range right after, through onScrollerLazyLoad.
+     */
+    private emitLazyLoadForFilter(filter: string | undefined | null): void {
+        this.onLazyLoad.emit({
+            first: 0,
+            last: this.scroller?.numItemsInViewport || DEFAULT_LAZY_PAGE_SIZE,
+            filter: filter ?? null
+        });
     }
 
     applyFocus(): void {

--- a/packages/optimus-ui/src/types/multiselect/multiselect.types.ts
+++ b/packages/optimus-ui/src/types/multiselect/multiselect.types.ts
@@ -211,6 +211,10 @@ export interface MultiSelectLazyLoadEvent {
      * Index of the last element in viewport.
      */
     last: number;
+    /**
+     * Current value of the filter input, null when no filter is applied.
+     */
+    filter?: string | null;
 }
 
 /**

--- a/packages/optimus-ui/src/types/select/select.types.ts
+++ b/packages/optimus-ui/src/types/select/select.types.ts
@@ -195,6 +195,10 @@ export interface SelectLazyLoadEvent {
      * Index of the last element in viewport.
      */
     last: number;
+    /**
+     * Current value of the filter input, null when no filter is applied.
+     */
+    filter?: string | null;
 }
 
 /**


### PR DESCRIPTION
## Problem

`p-select` and `p-multiselect` support `[lazy]` on their virtual scroller, and both support `[filter]`, but the two do not work together.

- `onLazyLoad` reports only `first`/`last`. The data source has no way of knowing what the user typed, so it can only ever return an unfiltered page.
- Both components then filter the returned page **again**, client-side. With lazy loading the page is a small window over a much larger result set, so the visible list is whatever survives filtering ~20 rows — the rest of the matches are never requested.
- A selection whose option is not part of the currently loaded page has no label. `p-select` falls back to the placeholder even though the control is filled, and `p-multiselect` renders an empty chip.

The net effect is that a lazy select with a filter is unusable: typing narrows the list to almost nothing and the selection loses its label as soon as the page it came from is replaced.

## Changes

**`onLazyLoad` carries the filter.** `SelectLazyLoadEvent` and `MultiSelectLazyLoadEvent` gain an optional `filter`, populated from the current filter value on every emission — both the ranges the scroller reports and the reload a filter change triggers. The field is optional, so existing handlers keep compiling.

**A filter change asks for a fresh first page.** The scroller only reports a range once it has rendered, so an effect on the filter value emits `{ first: 0, last, filter }` when the filter changes while `lazy` is on. The scroller re-emits the exact range immediately after, through the same path. `last` comes from the scroller's viewport when it has one, otherwise a small default.

**Client-side filtering is skipped when lazy.** Whatever the data source returns for a filter is already the filtered result, so `visibleOptions()` no longer re-filters it. Non-lazy filtering is untouched.

**Labels survive lazy loading.**
- `p-multiselect` gains a `lazySelectedOptions` input, for the options behind a selection the backend has not returned (a form restored from saved values, for instance). It also remembers options as it resolves their labels, so a chip's label survives the page it came with being replaced. These options only resolve labels — they are never rendered as list items.
- `p-select` falls back to the model value when the selected option is not in the loaded page, rather than showing the placeholder over a filled control. Only when `lazy` is on.

**Options reactivity.** `getAllVisibleAndNonVisibleOptions` in both components read the `options` *getter* from inside a `computed`. It is now a `computed` over the options signal, so `visibleOptions()` and `label()` recompute when a lazy page arrives instead of going stale. `visibleOptions()` also reads the filter signal unconditionally, so it does not miss a filter change made while `lazy` was on.

## Docs

- `select/lazyvirtualscroll-doc` now enables `filter` and filters against its simulated backend, and starts with a selection outside the first page to show the label surviving.
- New `multiselect/lazyvirtualscroll-doc` section, showing the same thing plus `lazySelectedOptions`. The existing MultiSelect *VirtualScroll* section is left alone.

Generated files (`typedoc.json`, `apidoc/index.json`, `demos.json`, the llms bundle) are left out — history shows those are regenerated in the release `chore: prepare …` commits, and CI rebuilds them.

## Tests

New `Select Lazy Filtering` and `MultiSelect Lazy Filtering` suites in both the jasmine (`*.spec.ts`) and vitest (`*.test.ts`) files:

- a filter change emits `onLazyLoad` with `first: 0` and the filter;
- options are not re-filtered client-side when `lazy`, and still are when not;
- `p-select` labels the value from the model when its option is not loaded;
- `p-multiselect` resolves a label from `lazySelectedOptions`, and those options do not show up as list items.

The select and multiselect suites pass in full (388 tests). The full vitest suite was run as well: the only failures are two pre-existing flaky tests unrelated to this change (`orderlist` "large datasets efficiently", a timing assertion, and a `toast` timeout test).
