### PR TITLE
fix(listbox): Listbox + custom template containing input

### DIFF
--- a/packages/optimus-ui/src/listbox/listbox.ts
+++ b/packages/optimus-ui/src/listbox/listbox.ts
@@ -1304,7 +1304,6 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
 
                 if (!metaKey && isPrintableCharacter(event.key)) {
                     this.searchOptions(event, event.key);
-                    event.preventDefault();
                 }
 
                 break;


### PR DESCRIPTION
## Description

Listbox + custom template + input in template -> typing in input didn't work.

Note: Normally typing in listbox searches for a matching option. If selectOnFocus = true, then this option will also be selected. 
This means that clicking into input selects but also deselects the option.
Typing into the input also finds (and optionally selects) a different option.
Since this is probably undesirable, it's recommended to do:
`<input type="text" pInputText (keydown)="$event.stopPropagation()" ... />`
if you also need selectOnFocus (this is a workaround from the original bug report).

## Related issues

Fixes #856

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [ ] `npm run build`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context


