### PR TITLE
fix(editor): Remove numbers in unordered list

### DIFF
--- a/packages/optimus-ui-styles/src/editor/index.ts
+++ b/packages/optimus-ui-styles/src/editor/index.ts
@@ -114,89 +114,89 @@ export const style = /*css*/ `
     .ql-editor ul li.ql-direction-rtl {
         padding-inline-end: 1.5rem;
     }
-    .ql-editor ol li {
+    .ql-editor ol li[data-list='ordered'] {
         counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
         counter-increment: list-0;
     }
-    .ql-editor ol li:before {
+    .ql-editor ol li[data-list='ordered']:before {
         content: counter(list-0, decimal) '. ';
     }
-    .ql-editor ol li.ql-indent-1 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-1 {
         counter-increment: list-1;
     }
-    .ql-editor ol li.ql-indent-1:before {
+    .ql-editor ol li[data-list='ordered'].ql-indent-1:before {
         content: counter(list-1, lower-alpha) '. ';
     }
-    .ql-editor ol li.ql-indent-1 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-1 {
         counter-reset: list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
     }
-    .ql-editor ol li.ql-indent-2 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-2 {
         counter-increment: list-2;
     }
-    .ql-editor ol li.ql-indent-2:before {
+    .ql-editor ol li[data-list='ordered'].ql-indent-2:before {
         content: counter(list-2, lower-roman) '. ';
     }
-    .ql-editor ol li.ql-indent-2 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-2 {
         counter-reset: list-3 list-4 list-5 list-6 list-7 list-8 list-9;
     }
-    .ql-editor ol li.ql-indent-3 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-3 {
         counter-increment: list-3;
     }
-    .ql-editor ol li.ql-indent-3:before {
+    .ql-editor ol li[data-list='ordered'].ql-indent-3:before {
         content: counter(list-3, decimal) '. ';
     }
-    .ql-editor ol li.ql-indent-3 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-3 {
         counter-reset: list-4 list-5 list-6 list-7 list-8 list-9;
     }
-    .ql-editor ol li.ql-indent-4 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-4 {
         counter-increment: list-4;
     }
-    .ql-editor ol li.ql-indent-4:before {
+    .ql-editor ol li[data-list='ordered'].ql-indent-4:before {
         content: counter(list-4, lower-alpha) '. ';
     }
-    .ql-editor ol li.ql-indent-4 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-4 {
         counter-reset: list-5 list-6 list-7 list-8 list-9;
     }
-    .ql-editor ol li.ql-indent-5 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-5 {
         counter-increment: list-5;
     }
-    .ql-editor ol li.ql-indent-5:before {
+    .ql-editor ol li[data-list='ordered'].ql-indent-5:before {
         content: counter(list-5, lower-roman) '. ';
     }
-    .ql-editor ol li.ql-indent-5 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-5 {
         counter-reset: list-6 list-7 list-8 list-9;
     }
-    .ql-editor ol li.ql-indent-6 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-6 {
         counter-increment: list-6;
     }
-    .ql-editor ol li.ql-indent-6:before {
+    .ql-editor ol li[data-list='ordered'].ql-indent-6:before {
         content: counter(list-6, decimal) '. ';
     }
-    .ql-editor ol li.ql-indent-6 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-6 {
         counter-reset: list-7 list-8 list-9;
     }
-    .ql-editor ol li.ql-indent-7 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-7 {
         counter-increment: list-7;
     }
-    .ql-editor ol li.ql-indent-7:before {
+    .ql-editor ol li[data-list='ordered'].ql-indent-7:before {
         content: counter(list-7, lower-alpha) '. ';
     }
-    .ql-editor ol li.ql-indent-7 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-7 {
         counter-reset: list-8 list-9;
     }
-    .ql-editor ol li.ql-indent-8 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-8 {
         counter-increment: list-8;
     }
-    .ql-editor ol li.ql-indent-8:before {
+    .ql-editor ol li[data-list='ordered'].ql-indent-8:before {
         content: counter(list-8, lower-roman) '. ';
     }
-    .ql-editor ol li.ql-indent-8 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-8 {
         counter-reset: list-9;
     }
-    .ql-editor ol li.ql-indent-9 {
+    .ql-editor ol li[data-list='ordered'].ql-indent-9 {
         counter-increment: list-9;
     }
-    .ql-editor ol li.ql-indent-9:before {
+    .ql-editor ol li[data-list='ordered'].ql-indent-9:before {
         content: counter(list-9, decimal) '. ';
     }
     .ql-editor .ql-video {


### PR DESCRIPTION
## Description

Numbers were being added to both ordered and unordered lists -> CSS change to only apply numbering to numbered lists.

I also tried to change the unordered list bullets at different indentation levels, but this was not easy due to the CSS from the quill package always adding the normal bullet "\\2022"...

## Related issues

Fixes #300

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

