### PR TITLE
fix(treeselect): realign overlay when virtual scroll settles

### DIFF
--- a/packages/optimus-ui/src/treeselect/treeselect.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.ts
@@ -739,7 +739,6 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     }
 
     onOverlayBeforeEnter() {
-        console.log('onOverlayBeforeEnter');
         if (this.filter) {
             isNotEmpty(this.filterValue) && this.treeViewChild?._filter(<any>this.filterValue);
             this.filterInputAutoFocus && this.filterViewChild?.nativeElement.focus();
@@ -753,17 +752,17 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
         const panelElement = this.panelEl?.nativeElement;
         if (this.virtualScroll && panelElement) {
             let lastHeight = panelElement.offsetHeight;
-            const ro = new ResizeObserver((entries) => {
+            const virtualScrollResizeObserver = new ResizeObserver((entries) => {
                 const newHeight = entries[0].contentRect.height;
                 if (newHeight !== lastHeight) {
                     lastHeight = newHeight;
                     this.overlayViewChild?.alignOverlay();
                 }
             });
-            ro.observe(panelElement);
+            virtualScrollResizeObserver.observe(panelElement);
 
             // clean up when overlay closes, not after first callback
-            this.overlayViewChild?.onHide.pipe(take(1)).subscribe(() => ro.disconnect());
+            this.overlayViewChild?.onHide.pipe(take(1)).subscribe(() => virtualScrollResizeObserver.disconnect());
         }
     }
 

--- a/packages/optimus-ui/src/treeselect/treeselect.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.ts
@@ -44,6 +44,7 @@ import {
     TreeSelectPassThrough,
     TreeSelectValueTemplateContext
 } from '@openng/optimus-ui/types/treeselect';
+import { take } from 'rxjs';
 import { TreeSelectStyle } from './style/treeselectstyle';
 
 export const TREESELECT_VALUE_ACCESSOR: any = {
@@ -738,6 +739,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     }
 
     onOverlayBeforeEnter() {
+        console.log('onOverlayBeforeEnter');
         if (this.filter) {
             isNotEmpty(this.filterValue) && this.treeViewChild?._filter(<any>this.filterValue);
             this.filterInputAutoFocus && this.filterViewChild?.nativeElement.focus();
@@ -747,6 +749,21 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
             if (focusableElements && focusableElements.length > 0) {
                 focusableElements[0].focus();
             }
+        }
+        const panelElement = this.panelEl?.nativeElement;
+        if (this.virtualScroll && panelElement) {
+            let lastHeight = panelElement.offsetHeight;
+            const ro = new ResizeObserver((entries) => {
+                const newHeight = entries[0].contentRect.height;
+                if (newHeight !== lastHeight) {
+                    lastHeight = newHeight;
+                    this.overlayViewChild?.alignOverlay();
+                }
+            });
+            ro.observe(panelElement);
+
+            // clean up when overlay closes, not after first callback
+            this.overlayViewChild?.onHide.pipe(take(1)).subscribe(() => ro.disconnect());
         }
     }
 


### PR DESCRIPTION
## Description
When `virtualScroll` is enabled on `TreeSelect`, the overlay's flip-to-above positioning was calculated before the virtual scroller finished settling its content height, so panels near the bottom of the viewport stayed clipped below the trigger instead of flipping above it.

**Before:** With `virtualScroll` enabled, opening the overlay near the bottom of the viewport left it clipped/cut off instead of repositioning above the trigger.

**After:** Added a `ResizeObserver` on the panel element (scoped to `virtualScroll`) that re-runs `alignOverlay()` whenever the panel's height actually changes, rather than only on the observer's guaranteed initial callback. The observer disconnects when the overlay hides, so it doesn't leak across open/close cycles.

## Related issues
Fixes #20

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes
None

## Test plan
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] Verified in the demo app (if applicable)

Manually reproduced the bug with `TreeSelect` + `virtualScroll` positioned near the bottom of the viewport — overlay opened downward and was clipped. Confirmed the fix: overlay now correctly flips above the trigger once the virtual scroller's content settles. Also verified existing realignment behavior on `nodeExpand` / `nodeCollapse` / `onFilterInput` is unaffected, and that the observer disconnects on overlay close with no leaked observers across repeated open/close cycles.

## Checklist
- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context
Reproduced on the official docs' virtual scroll demo for `TreeSelect` — screenshots attached in the linked issue (#20).