### PR TITLE
fix(datepicker): type the custom date format

### DIFF
--- a/packages/optimus-ui/src/datepicker/datepicker.ts
+++ b/packages/optimus-ui/src/datepicker/datepicker.ts
@@ -40,6 +40,7 @@ import { Nullable, VoidListener } from '@openng/optimus-ui/ts-helpers';
 import {
     DatePickerButtonBarTemplateContext,
     DatePickerDateTemplateContext,
+    DatePickerDay,
     DatePickerDecadeTemplateContext,
     DatePickerDisabledDateTemplateContext,
     DatePickerInputIconTemplateContext,
@@ -47,6 +48,7 @@ import {
     DatePickerPassThrough,
     DatePickerResponsiveOptions,
     DatePickerTypeView,
+    DatePickerWeek,
     DatePickerYearChangeEvent,
     LocaleSettings,
     Month,
@@ -1482,7 +1484,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
     }
 
     createMonth(month: number, year: number): Month {
-        let dates = [];
+        let dates: DatePickerWeek[] = [];
         let firstDay = this.getFirstDayOfMonthIndex(month, year);
         let daysLength = this.getDaysCountInMonth(month, year);
         let prevMonthDaysLength = this.getDaysCountInPrevMonth(month, year);
@@ -1492,7 +1494,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         let monthRows = Math.ceil((daysLength + firstDay) / 7);
 
         for (let i = 0; i < monthRows; i++) {
-            let week: any[] = [];
+            let week: DatePickerWeek = [];
 
             if (i == 0) {
                 for (let j = prevMonthDaysLength - firstDay + 1; j <= prevMonthDaysLength; j++) {
@@ -1551,12 +1553,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
             (dates as any[]).push(week);
         }
 
-        return {
-            month: month,
-            year: year,
-            dates: <any>dates,
-            weekNumbers: weekNumbers
-        };
+        return { month, year, dates, weekNumbers };
     }
 
     initTime(date: Date) {
@@ -1673,7 +1670,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         event.preventDefault();
     }
 
-    onDateSelect(event: Event, dateMeta: any) {
+    onDateSelect(event: Event, dateMeta: DatePickerDay) {
         if (this.$disabled() || !dateMeta.selectable) {
             event.preventDefault();
             return;
@@ -1688,7 +1685,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
             }
             this.updateModel(this.value);
         } else {
-            if (this.shouldSelectDate(dateMeta)) {
+            if (this.shouldSelectDate()) {
                 this.selectDate(dateMeta);
             }
         }
@@ -1710,7 +1707,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         event.preventDefault();
     }
 
-    shouldSelectDate(dateMeta: any) {
+    shouldSelectDate() {
         if (this.isMultipleSelection()) return this.maxDateCount != null ? this.maxDateCount > (this.value ? this.value.length : 0) : true;
         else return true;
     }
@@ -1794,7 +1791,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         return formattedValue;
     }
 
-    formatDateMetaToDate(dateMeta: any): Date {
+    formatDateMetaToDate(dateMeta: DatePickerDay): Date {
         return new Date(dateMeta.year, dateMeta.month, dateMeta.day);
     }
 
@@ -1821,7 +1818,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         this.alignOverlay();
     }
 
-    selectDate(dateMeta: any) {
+    selectDate(dateMeta: DatePickerDay) {
         let date = this.formatDateMetaToDate(dateMeta);
 
         if (this.showTime) {
@@ -1948,7 +1945,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         return firstDayOfWeek > 0 ? 7 - firstDayOfWeek : 0;
     }
 
-    isSelected(dateMeta: any): boolean | undefined {
+    isSelected(dateMeta: DatePickerDay): boolean | undefined {
         if (this.value) {
             if (this.isSingleSelection()) {
                 return this.isDateEquals(this.value, dateMeta);
@@ -2022,12 +2019,12 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         return false;
     }
 
-    isDateEquals(value: any, dateMeta: any) {
+    isDateEquals(value: any, dateMeta: DatePickerDay) {
         if (value && isDate(value)) return value.getDate() === dateMeta.day && value.getMonth() === dateMeta.month && value.getFullYear() === dateMeta.year;
         else return false;
     }
 
-    isDateBetween(start: Date, end: Date, dateMeta: any) {
+    isDateBetween(start: Date, end: Date, dateMeta: DatePickerDay) {
         let between: boolean = false;
         if (isDate(start) && isDate(end)) {
             let date: Date = this.formatDateMetaToDate(dateMeta);
@@ -2253,7 +2250,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         }
     }
 
-    onDateCellKeydown(event: any, dateMeta: any, groupIndex: number) {
+    onDateCellKeydown(event: any, dateMeta: DatePickerDay, groupIndex: number) {
         const cellContent = event.currentTarget;
         const cell = cellContent.parentElement;
         const currentDate = this.formatDateMetaToDate(dateMeta);
@@ -3646,7 +3643,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
 
     onTodayButtonClick(event: any) {
         const date: Date = new Date();
-        const dateMeta = {
+        const dateMeta: DatePickerDay = {
             day: date.getDate(),
             month: date.getMonth(),
             year: date.getFullYear(),

--- a/packages/optimus-ui/src/datepicker/datepicker.ts
+++ b/packages/optimus-ui/src/datepicker/datepicker.ts
@@ -1490,7 +1490,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         let prevMonthDaysLength = this.getDaysCountInPrevMonth(month, year);
         let dayNo = 1;
         let today = new Date();
-        let weekNumbers = [];
+        let weekNumbers: number[] = [];
         let monthRows = Math.ceil((daysLength + firstDay) / 7);
 
         for (let i = 0; i < monthRows; i++) {
@@ -1547,10 +1547,10 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
             }
 
             if (this.showWeek) {
-                (weekNumbers as any[]).push(this.getWeekNumber(new Date(week[0].year, week[0].month, week[0].day)));
+                weekNumbers.push(this.getWeekNumber(new Date(week[0].year, week[0].month, week[0].day)));
             }
 
-            (dates as any[]).push(week);
+            dates.push(week);
         }
 
         return { month, year, dates, weekNumbers };

--- a/packages/optimus-ui/src/types/datepicker/datepicker.types.ts
+++ b/packages/optimus-ui/src/types/datepicker/datepicker.types.ts
@@ -446,6 +446,26 @@ export interface LocaleSettings {
      */
     weekHeader?: string;
 }
+
+/**
+ * Custom date format for a single day for the date picker display
+ * @group Interface
+ */
+export interface DatePickerDay {
+    day: number;
+    month: number;
+    year: number;
+    selectable: boolean;
+    today?: boolean;
+    otherMonth?: boolean;
+}
+
+/**
+ * An array of days that contains date values in a custom format
+ * @group Types
+ */
+export type DatePickerWeek = DatePickerDay[];
+
 /**
  * Month interface.
  * @group Interface
@@ -460,9 +480,9 @@ export interface Month {
      */
     year?: number;
     /**
-     * Array of dates.
+     * Array of weeks, each containing an array of days.
      */
-    dates?: Date[];
+    dates?: DatePickerWeek[];
     /**
      * Array of week numbers.
      */


### PR DESCRIPTION
Closes #739

`Month.dates` was typed `Date[]` but actually holds weeks of day metadata. Added `DatePickerDay` / `DatePickerWeek` and replaced the `any` dateMeta params with them.

Port of primefaces/primeng#17273. Credits to @zachary-svoboda-accesso.