### PR TITLE
fix(autocomplete): match options against the model when optionValue is set

### DIFF
--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -681,6 +681,69 @@ describe('AutoComplete', () => {
             expect(valueResult).toBe('CUSTOM_AF');
         });
 
+        it('should display the option label in the input when the model holds an optionValue', async () => {
+            fixture.componentRef.setInput('optionLabel', 'name');
+            fixture.componentRef.setInput('optionValue', 'code');
+            fixture.componentRef.setInput('suggestions', mockCountries);
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            component.writeValue('AF');
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            const inputElement = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+            expect(inputElement.value).toBe('Afghanistan');
+        });
+
+        it('should display the option label in the input when a numeric optionValue is written before suggestions arrive', async () => {
+            fixture.componentRef.setInput('optionLabel', 'name');
+            fixture.componentRef.setInput('optionValue', 'id');
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            component.writeValue(2);
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            fixture.componentRef.setInput('suggestions', [
+                { id: 1, name: 'One' },
+                { id: 2, name: 'Two' }
+            ]);
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            expect(component.inputValue()).toBe('Two');
+        });
+
+        it('should mark the option matching the written optionValue as selected', async () => {
+            fixture.componentRef.setInput('optionLabel', 'name');
+            fixture.componentRef.setInput('optionValue', 'code');
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            component.writeValue('AL');
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            fixture.componentRef.setInput('suggestions', mockCountries);
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            expect(mockCountries.map((country) => component.isSelected(country))).toEqual([false, true, false, false, false]);
+        });
+
+        it('should pass the resolved option to the selected item template when the model holds an optionValue', async () => {
+            testComponent.optionValue = 'code';
+            testComponent.suggestions = testComponent.objectOptions;
+            testComponent.selectedValue = 'AF';
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            const inputElement = testFixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+            expect(inputElement.value).toBe('Afghanistan');
+        });
+
         it('should work with optionDisabled as string', async () => {
             testComponent.optionDisabled = 'disabled';
             testComponent.suggestions = [

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -898,7 +898,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     inputValue = computed(() => {
         const modelValue = this.modelValue();
-        const selectedOption = this.optionValueSelected ? (this.suggestions || []).find((option: any) => equals(option, modelValue, this.equalityKey())) : modelValue;
+        const selectedOption = this.optionValueSelected ? (this.suggestions || []).find((option: any) => this.isOptionEqualToValue(option, modelValue)) : modelValue;
 
         if (isNotEmpty(modelValue)) {
             if (typeof modelValue === 'object' || this.optionValueSelected) {
@@ -964,7 +964,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     }
 
     get optionValueSelected() {
-        return typeof this.modelValue() === 'string' && this.optionValue;
+        return this.isResolvedOptionValue(this.modelValue());
     }
 
     chipItemClass(index) {
@@ -1140,9 +1140,25 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     isSelected(option) {
         if (this.multiple) {
-            return this.unique ? (this.modelValue() as string[])?.some((model) => equals(model, option, this.equalityKey())) : false;
+            return this.unique ? (this.modelValue() as any[])?.some((model) => this.isOptionEqualToValue(option, model)) : false;
         }
-        return equals(this.modelValue(), option, this.equalityKey());
+        return this.isOptionEqualToValue(option, this.modelValue());
+    }
+
+    /**
+     * Whether the model holds a value produced by `optionValue` (a primitive) rather than an option object.
+     * This happens when a value is written before the matching option is available in the suggestions.
+     */
+    private isResolvedOptionValue(value: any): boolean {
+        return !!this.optionValue && value != null && typeof value !== 'object';
+    }
+
+    /**
+     * Whether an option corresponds to a model value, regardless of whether the model holds
+     * the option object itself or the value resolved through `optionValue`.
+     */
+    private isOptionEqualToValue(option: any, value: any): boolean {
+        return equals(value, option, this.equalityKey()) || (this.isResolvedOptionValue(value) && equals(this.getOptionValue(option), value));
     }
 
     isOptionMatched(option, value) {
@@ -1916,12 +1932,12 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
         if (this.multiple) {
             const resolved = (value || []).map((val: any) => {
-                const match = this.visibleOptions().find((option: any) => equals(val, option, this.equalityKey()));
+                const match = this.visibleOptions().find((option: any) => this.isOptionEqualToValue(option, val));
                 return match ?? val;
             });
             resolvedValue = isEmpty(value) ? value : resolved;
         } else {
-            const option = this.visibleOptions().find((option: any) => equals(value, option, this.equalityKey()));
+            const option = this.visibleOptions().find((option: any) => this.isOptionEqualToValue(option, value));
             resolvedValue = isEmpty(option) ? value : option;
         }
 


### PR DESCRIPTION
With optionValue set, the model holds the resolved value while the suggestions are option objects. The input label lookup, isSelected and writeValue compared the two directly, so the input showed the raw value instead of the label, no option was ever marked selected and the selecteditem template received the primitive. Non-string values were not recognised at all because optionValueSelected only checked for strings.

Add isOptionEqualToValue/isResolvedOptionValue helpers that compare getOptionValue(option) against a resolved primitive model, and use them in inputValue, isSelected and writeControlValue.

Fixes #212 
