### PR TITLE
fix(schematics): fail ng-add on a PrimeNG workspace instead of warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Full setup, including the manual path and icons, is in the [getting started guid
 
 ## Migrating from PrimeNG
 
-`ng add` does not migrate an existing workspace. It sets up new projects only, and when it detects a `primeng` dependency it leaves your code untouched and points you here. Use the `migrate-from-primeng` schematic instead: install the package so the Angular CLI can resolve it, then run the schematic. Packages are swapped, imports are rewritten, and you get a report of anything it could not handle automatically, with file and line numbers.
+`ng add` does not migrate an existing workspace. It sets up new projects only, and when it detects a `primeng` dependency it leaves your code untouched and fails with an error pointing you here rather than reporting success. Use the `migrate-from-primeng` schematic instead: install the package so the Angular CLI can resolve it, then run the schematic. Packages are swapped, imports are rewritten, and you get a report of anything it could not handle automatically, with file and line numbers.
 
 ```bash
 npm install @openng/optimus-ui@1

--- a/apps/docs/doc/faq/migration-doc.ts
+++ b/apps/docs/doc/faq/migration-doc.ts
@@ -16,7 +16,7 @@ import { RouterModule } from '@angular/router';
 
             <h3>How do I migrate from PrimeNG? Is it automatic?</h3>
             <p>
-                Mostly, but not through <i>ng add</i>, which only sets up new projects and makes no changes when it finds an existing <i>primeng</i> dependency. Install <i>&#64;openng/optimus-ui</i>, then run
+                Mostly, but not through <i>ng add</i>, which only sets up new projects and fails without changing anything when it finds an existing <i>primeng</i> dependency. Install <i>&#64;openng/optimus-ui</i>, then run
                 <i>ng generate &#64;openng/optimus-ui:migrate-from-primeng</i> in a PrimeNG v21 workspace: packages swapped, imports rewritten, dependencies installed. It then prints a report of anything it could not rewrite, with file and line
                 numbers. The <a href="https://v1.optimus.openng.org/migration/primeng" target="_blank" rel="noopener noreferrer" class="doc-link">migration guide</a> covers the details and the manual cases.
             </p>

--- a/apps/docs/doc/installation/ngadd-doc.ts
+++ b/apps/docs/doc/installation/ngadd-doc.ts
@@ -20,9 +20,10 @@ import { Component } from '@angular/core';
             <p>Pass the preset up front to skip the prompt, or skip the install step if you want to run it yourself:</p>
             <app-code [code]="flagsCode" [hideToggleCode]="true"></app-code>
             <p>
-                If the schematic cannot find a providers array to update it prints the three manual steps instead of guessing, so nothing in your workspace is rewritten unexpectedly. If it detects an existing <i>primeng</i> dependency it makes no
-                changes to your code and points you at the <a href="https://v1.optimus.openng.org/migration/primeng" target="_blank" rel="noopener noreferrer" class="doc-link">migration guide</a>, which covers the
-                <i>migrate-from-primeng</i> schematic. It does not run that schematic for you.
+                If the schematic cannot find a providers array to update it prints the three manual steps instead of guessing, so nothing in your workspace is rewritten unexpectedly. If it detects an existing <i>primeng</i> dependency it changes
+                nothing and fails with an error rather than reporting success, and points you at the <a href="https://v1.optimus.openng.org/migration/primeng" target="_blank" rel="noopener noreferrer" class="doc-link">migration guide</a>, which
+                covers the <i>migrate-from-primeng</i> schematic. It does not run that schematic for you. The Angular CLI installs <i>&#64;openng/optimus-ui</i> before the schematic runs, so the dependency stays in your <i>package.json</i> — the
+                migration schematic needs it there.
             </p>
         </app-docsectiontext>
     `

--- a/packages/optimus-ui/schematics/ng-add/index.ts
+++ b/packages/optimus-ui/schematics/ng-add/index.ts
@@ -9,6 +9,23 @@ import { Schema, Theme } from './schema';
 
 const THEMES_PACKAGE = '@openng/optimus-ui-themes';
 const DEFAULT_THEME: Theme = 'Aura';
+const MIGRATE_COMMAND = 'ng generate @openng/optimus-ui@1:migrate-from-primeng';
+
+function projectNotFound(name: string): string {
+    return `Project "${name}" was not found in the workspace.`;
+}
+
+/**
+ * Why ng-add refuses a PrimeNG workspace, and what the user is left holding. The Angular CLI has
+ * already installed `@openng/optimus-ui` and written it into `dependencies` by the time the
+ * factory runs (`ng-add.save` is `"dependencies"`, and the CLI only cleans the entry up when
+ * `save` is `false`), so the message has to account for it rather than pretend nothing happened.
+ */
+function primengBailMessage(): string {
+    return `primeng detected — ng add only sets up Optimus UI in new projects, so no changes were made and the theme preset was not configured.
+To migrate this workspace, run: ${MIGRATE_COMMAND}
+The Angular CLI has already added @openng/optimus-ui to your dependencies. The migration schematic needs it there, so keep it — or remove it with your package manager if you did not mean to add Optimus UI to this workspace.`;
+}
 
 /** The preset import name and its subpath module for the chosen theme (e.g. `Aura` → `@openng/optimus-ui-themes/aura`). */
 function themeImport(theme: Theme): { preset: string; module: string } {
@@ -30,20 +47,46 @@ function manualInstructions(theme: Theme): string {
 /**
  * Sets up Optimus UI in a fresh (non-PrimeNG) project. Migrating an existing PrimeNG workspace is
  * a separate concern handled by the `migrate-from-primeng` schematic
- * (`ng generate @openng/optimus-ui:migrate-from-primeng`) — when primeng is detected, ng-add
- * points the user there and makes no changes.
+ * (`ng generate @openng/optimus-ui@1:migrate-from-primeng`) — when primeng is detected, ng-add
+ * makes no changes and throws, so the CLI reports the refusal as a failure (#1447). A warning was
+ * not enough: the command exited 0 after asking for a theme preset it then discarded, which reads
+ * as a successful setup, and the freshly-installed dependency in package.json reinforces that.
  */
 export function ngAdd(options: Schema): Rule {
-    return (tree: Tree, context: SchematicContext) => {
+    return async (tree: Tree) => {
         if (!tree.read('/package.json')) {
             throw new SchematicsException('Could not read /package.json.');
         }
+        // Before the primeng bail, so a mistyped --project reports the typo rather than being
+        // masked by whichever check happens to run first (#1447).
+        await assertProjectExists(tree, options);
         if (hasPrimeng(tree)) {
-            context.logger.warn('primeng detected — ng-add only sets up Optimus UI in new projects, so no changes were made.\n' + 'To migrate this workspace, run: ng generate @openng/optimus-ui:migrate-from-primeng');
-            return tree;
+            throw new SchematicsException(primengBailMessage());
         }
         return freshSetup(options);
     };
+}
+
+/**
+ * Hard-errors when an explicit `--project` names a project the workspace does not have. Anything
+ * else unexpected about the workspace (missing or unreadable angular.json, …) is left to
+ * `wireProvideOptimus`, which degrades to manual instructions rather than aborting.
+ */
+async function assertProjectExists(tree: Tree, options: Schema): Promise<void> {
+    if (!options.project) {
+        return;
+    }
+    try {
+        const workspace = await readWorkspace(tree);
+        if (!workspace.projects.has(options.project)) {
+            throw new SchematicsException(projectNotFound(options.project));
+        }
+    } catch (err) {
+        if (err instanceof SchematicsException) {
+            throw err;
+        }
+        // Unreadable or missing angular.json — not this check's business.
+    }
 }
 
 function freshSetup(options: Schema): Rule {
@@ -95,7 +138,7 @@ async function wireProvideOptimus(tree: Tree, context: SchematicContext, options
 
         if (options.project) {
             if (!workspace.projects.has(options.project)) {
-                throw new SchematicsException(`Project "${options.project}" was not found in the workspace.`);
+                throw new SchematicsException(projectNotFound(options.project));
             }
             projectName = options.project;
         } else {
@@ -132,7 +175,7 @@ async function wireProvideOptimus(tree: Tree, context: SchematicContext, options
     const primengFile = findSourceFileContaining(tree, sourceRoot, 'providePrimeNG(');
     if (primengFile) {
         context.logger.warn(`Found a providePrimeNG call in ${primengFile} — this workspace still uses PrimeNG, so provideOptimus was not wired automatically.
-To migrate this workspace, run: ng generate @openng/optimus-ui:migrate-from-primeng
+To migrate this workspace, run: ${MIGRATE_COMMAND}
 Or finish the setup manually:
 ${manualSteps(theme)}`);
         return;

--- a/packages/optimus-ui/schematics/test/ng-add.spec.ts
+++ b/packages/optimus-ui/schematics/test/ng-add.spec.ts
@@ -95,21 +95,40 @@ describe('ng-add', () => {
         expect(result.readContent('/src/app/app.config.ts')).not.toContain('provideOptimus');
     });
 
-    it('primeng project: warns, points to migrate-from-primeng, and makes no changes', async () => {
+    it('primeng project: rejects with SchematicsException, points to migrate-from-primeng, and makes no changes (#1447)', async () => {
         const runner = createRunner();
         const appConfig = `import { providePrimeNG } from 'primeng/config';\nexport const appConfig = { providers: [providePrimeNG()] };\n`;
-        const tree = createAppTree({ '/src/app/app.config.ts': appConfig }, { ...DEFAULT_PKG, dependencies: { '@angular/core': '^21.0.0', primeng: '^21.0.2' } });
-        const logs: string[] = [];
-        runner.logger.subscribe((entry) => logs.push(entry.message));
+        const pkgRaw = JSON.stringify({ ...DEFAULT_PKG, dependencies: { '@angular/core': '^21.0.0', primeng: '^21.0.2' } }, null, 2) + '\n';
+        const tree = createAppTree({ '/src/app/app.config.ts': appConfig, '/package.json': pkgRaw });
 
-        const result = await runner.runSchematic('ng-add', { skipInstall: true }, tree);
+        await expect(runner.runSchematic('ng-add', { skipInstall: true }, tree)).rejects.toThrow(SchematicsException);
 
-        expect(logs.join('\n')).toContain('primeng detected');
-        expect(logs.join('\n')).toContain('ng generate @openng/optimus-ui:migrate-from-primeng');
-        const pkg = JSON.parse(result.readContent('/package.json'));
-        expect(pkg.dependencies.primeng).toBe('^21.0.2');
-        expect(pkg.dependencies['@openng/optimus-ui-themes']).toBeUndefined();
-        expect(result.readContent('/src/app/app.config.ts')).toBe(appConfig);
+        // A failed schematic never commits its tree, so the workspace is left exactly as it was.
+        expect(tree.readContent('/package.json')).toBe(pkgRaw);
+        expect(tree.readContent('/src/app/app.config.ts')).toBe(appConfig);
+    });
+
+    it('primeng project: the failure explains the state the CLI left behind (#1447)', async () => {
+        const runner = createRunner();
+        const tree = createAppTree({}, { ...DEFAULT_PKG, dependencies: { '@angular/core': '^21.0.0', primeng: '^21.0.2' } });
+
+        const error = await runner.runSchematic('ng-add', { skipInstall: true }, tree).then(
+            () => null,
+            (err: Error) => err
+        );
+
+        expect(error).toBeInstanceOf(SchematicsException);
+        expect(error!.message).toContain('primeng detected');
+        expect(error!.message).toContain('no changes were made');
+        expect(error!.message).toContain('ng generate @openng/optimus-ui@1:migrate-from-primeng');
+        expect(error!.message).toContain('already added @openng/optimus-ui to your dependencies');
+    });
+
+    it('primeng project with a nonexistent --project: reports the bad project name, not the primeng bail (#1447)', async () => {
+        const runner = createRunner();
+        const tree = createAppTree({}, { ...DEFAULT_PKG, dependencies: { '@angular/core': '^21.0.0', primeng: '^21.0.2' } });
+
+        await expect(runner.runSchematic('ng-add', { skipInstall: true, project: 'does-not-exist' }, tree)).rejects.toThrow('Project "does-not-exist" was not found in the workspace.');
     });
 
     it('schedules an install task unless skipInstall is set', async () => {
@@ -121,37 +140,32 @@ describe('ng-add', () => {
     it('primeng project: schedules no install task', async () => {
         const runner = createRunner();
         const tree = createAppTree({}, { ...DEFAULT_PKG, dependencies: { '@angular/core': '^21.0.0', primeng: '^21.0.2' } });
-        await runner.runSchematic('ng-add', {}, tree);
+        await expect(runner.runSchematic('ng-add', {}, tree)).rejects.toThrow(SchematicsException);
         expect(runner.tasks.some((t) => t.name === 'node-package')).toBe(false);
     });
 
-    it('primeng only in a workspace sub-package: still warns and makes no changes', async () => {
+    it('primeng only in a workspace sub-package: still rejects and makes no changes', async () => {
         const runner = createRunner();
         const libPkgRaw = JSON.stringify({ name: 'app-lib', dependencies: { primeng: '^21.0.2' } }, null, 2) + '\n';
         const tree = createAppTree({ '/libs/app/package.json': libPkgRaw });
-        const logs: string[] = [];
-        runner.logger.subscribe((entry) => logs.push(entry.message));
 
-        const result = await runner.runSchematic('ng-add', { skipInstall: true }, tree);
-        expect(logs.join('\n')).toContain('primeng detected');
-        expect(result.readContent('/libs/app/package.json')).toBe(libPkgRaw);
-        expect(JSON.parse(result.readContent('/package.json')).dependencies['@openng/optimus-ui-themes']).toBeUndefined();
+        await expect(runner.runSchematic('ng-add', { skipInstall: true }, tree)).rejects.toThrow('primeng detected');
+
+        expect(tree.readContent('/libs/app/package.json')).toBe(libPkgRaw);
+        expect(JSON.parse(tree.readContent('/package.json')).dependencies?.['@openng/optimus-ui-themes']).toBeUndefined();
     });
 
-    it('primeng declared only in peerDependencies: still warns and makes no changes (#1448)', async () => {
+    it('primeng declared only in peerDependencies: still rejects and makes no changes (#1448)', async () => {
         const runner = createRunner();
         const appConfig = `import { providePrimeNG } from 'primeng/config';\nexport const appConfig = { providers: [providePrimeNG()] };\n`;
         const tree = createAppTree({ '/src/app/app.config.ts': appConfig }, { ...DEFAULT_PKG, peerDependencies: { primeng: '^21.0.0' } });
-        const logs: string[] = [];
-        runner.logger.subscribe((entry) => logs.push(entry.message));
 
-        const result = await runner.runSchematic('ng-add', { skipInstall: true }, tree);
+        await expect(runner.runSchematic('ng-add', { skipInstall: true }, tree)).rejects.toThrow('primeng detected');
 
-        expect(logs.join('\n')).toContain('primeng detected');
-        const pkg = JSON.parse(result.readContent('/package.json'));
+        const pkg = JSON.parse(tree.readContent('/package.json'));
         expect(pkg.peerDependencies.primeng).toBe('^21.0.0');
         expect(pkg.dependencies['@openng/optimus-ui-themes']).toBeUndefined();
-        expect(result.readContent('/src/app/app.config.ts')).toBe(appConfig);
+        expect(tree.readContent('/src/app/app.config.ts')).toBe(appConfig);
     });
 
     it.each([
@@ -159,15 +173,13 @@ describe('ng-add', () => {
         ['resolutions', { resolutions: { '**/primeng': '21.0.2' } }],
         ['overrides', { overrides: { primeng: '21.0.2' } }],
         ['pnpm.overrides', { pnpm: { overrides: { primeng: '21.0.2' } } }]
-    ] as const)('primeng declared only in %s: still warns and makes no changes (#1448)', async (_section, extra) => {
+    ] as const)('primeng declared only in %s: still rejects and makes no changes (#1448)', async (_section, extra) => {
         const runner = createRunner();
         const tree = createAppTree({}, { ...DEFAULT_PKG, ...extra });
-        const logs: string[] = [];
-        runner.logger.subscribe((entry) => logs.push(entry.message));
 
-        const result = await runner.runSchematic('ng-add', { skipInstall: true }, tree);
-        expect(logs.join('\n')).toContain('primeng detected');
-        expect(JSON.parse(result.readContent('/package.json')).dependencies['@openng/optimus-ui-themes']).toBeUndefined();
+        await expect(runner.runSchematic('ng-add', { skipInstall: true }, tree)).rejects.toThrow('primeng detected');
+
+        expect(JSON.parse(tree.readContent('/package.json')).dependencies['@openng/optimus-ui-themes']).toBeUndefined();
     });
 
     it('pre-existing Aura binding (real CLI tree): imports the preset under an alias and retargets the provider call (#1448)', async () => {
@@ -223,7 +235,7 @@ describe('ng-add', () => {
         expect(result.readContent('/src/app/app.config.ts')).toBe(primengConfig);
         const log = logs.join('\n');
         expect(log).toContain('Found a providePrimeNG call in /src/app/app.config.ts');
-        expect(log).toContain('ng generate @openng/optimus-ui:migrate-from-primeng');
+        expect(log).toContain('ng generate @openng/optimus-ui@1:migrate-from-primeng');
         expect(log).toContain('provideOptimus({ theme: { preset: Aura } })');
         expect(log).not.toContain('Added provideOptimus');
     });


### PR DESCRIPTION
Closes #1447.

## The problem

`ng add @openng/optimus-ui` on a PrimeNG v21 workspace asked for a theme preset, installed the package, changed nothing, and exited 0. Every signal the user got said "this worked": a setup question answered, a new entry in `dependencies`, a modified lockfile, and a `logger.warn` in the middle of the output.

The bail itself is correct — `ng add` only sets up fresh projects, migration is `migrate-from-primeng`'s job — but a warning is the wrong way to report it.

## The change

`schematics/ng-add/index.ts` throws a `SchematicsException` instead of warning, so the CLI reports the refusal as a failure with a non-zero exit code. Nothing in the workspace is touched either way: a failed schematic never commits its tree.

Of the three directions listed in the issue, this is the first one. The second (suppress the theme prompt when primeng is present) is not implementable — as [@geromegrignon noted](https://github.com/openng-org/optimus-ui/issues/1447#issuecomment-5218327220), the CLI resolves `x-prompt`s before the factory runs, so the schematic cannot influence them. The third (offer to run the migration) was deliberately removed in 851df785bf. Failing loudly is what is left, and it matches the first branch of the issue's expected behaviour.

One caveat worth stating plainly, because the issue assumed otherwise: **the CLI does not roll the install back.** `AddCommandModule` only removes the dependency it added when `ng-add.save` is `false` (`node_modules/@angular/cli/src/commands/add/cli.js`, the `shouldCleanUp` branch), and ours is `"dependencies"`. So `@openng/optimus-ui` stays in `package.json` after the failure. That is not purely a wart — `ng generate @openng/optimus-ui@1:migrate-from-primeng` needs the package installed to resolve — so the new message says so instead of leaving the user to guess:

```
primeng detected — ng add only sets up Optimus UI in new projects, so no changes were made and the theme preset was not configured.
To migrate this workspace, run: ng generate @openng/optimus-ui@1:migrate-from-primeng
The Angular CLI has already added @openng/optimus-ui to your dependencies. The migration schematic needs it there, so keep it — or remove it with your package manager if you did not mean to add Optimus UI to this workspace.
```

Two smaller things folded in:

- **The side note from the issue.** An explicit `--project` is now validated *before* the primeng check, so `ng add @openng/optimus-ui --project=does-not-exist` on a PrimeNG workspace reports the typo rather than having it masked by whichever check ran first.
- **The migration hint is now pinned to `@1`.** `migrate-from-primeng` is only maintained on `release/1.x` (per its own `@deprecated` tag and the README), so the unpinned `ng generate @openng/optimus-ui:migrate-from-primeng` in both ng-add messages pointed at the wrong line.

Docs updated to match in `README.md`, `apps/docs/doc/installation/ngadd-doc.ts` and `apps/docs/doc/faq/migration-doc.ts` — all three said ng-add "makes no changes" when primeng is found, which now undersells it. The generated files under `apps/docs/public/llms` are left to their build.

## Tests

`packages/optimus-ui/schematics/test/ng-add.spec.ts` — the eight existing primeng cases now assert rejection instead of a warning, plus three new ones:

- the failure is a `SchematicsException` and the workspace files are byte-identical afterwards
- the message names the state the CLI left behind (`already added @openng/optimus-ui to your dependencies`, the `@1`-pinned migrate command)
- a mistyped `--project` in a PrimeNG workspace reports the bad project name, not the primeng bail

All 11 fail on `main` and pass here; the full schematics suite is 134 passing.

## Proof of work

The compiled schematic driven through `NodeWorkflow` — the same workflow `ng add` uses — against a real on-disk PrimeNG v21 workspace, before and after, plus the fresh-workspace path to show it is unaffected:

![ng add on a PrimeNG workspace: before/after terminal output and the passing schematics suite](https://raw.githubusercontent.com/rene-schakmann/optimus-ui/pr-assets-1447/issue-1447-ng-add-proof.png)

---

Co-authored by Claude.
