### PR TITLE
fix(dynamicdialog): respect ariaLabelledBy from config

### DIFF
--- a/packages/optimus-ui/src/dialog/dialog.test.ts
+++ b/packages/optimus-ui/src/dialog/dialog.test.ts
@@ -45,6 +45,7 @@ import { Dialog } from './dialog';
             [closeButtonProps]="closeButtonProps"
             [maximizeButtonProps]="maximizeButtonProps"
             [role]="role"
+            [ariaLabelledBy]="ariaLabelledBy"
             (onShow)="onShowEvent($event)"
             (onHide)="onHideEvent($event)"
             (onMaximize)="onMaximizeEvent($event)"
@@ -92,6 +93,7 @@ class TestBasicDialogComponent {
     closeButtonProps: any = {};
     maximizeButtonProps: any = {};
     role = 'dialog';
+    ariaLabelledBy: string | undefined;
     breakpoints: any = null as any;
 
     // Event handlers
@@ -326,7 +328,7 @@ describe('Dialog', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(dialogInstance.header).toBe('Custom Header');
+            expect(dialogInstance.header()).toBe('Custom Header');
             expect(dialogInstance.modal).toBe(false);
             expect(dialogInstance.draggable).toBe(false);
             expect(dialogInstance.maximizable).toBe(true);
@@ -635,7 +637,7 @@ describe('Dialog', () => {
             expect(() => {
                 fixture.changeDetectorRef.markForCheck();
             }).not.toThrow();
-            expect(dialogInstance.header).toBeUndefined();
+            expect(dialogInstance.header()).toBeUndefined();
         });
 
         it('should handle invalid position values', async () => {
@@ -739,6 +741,35 @@ describe('Dialog', () => {
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             expect(dialogInstance.focusOnShow).toBe(true);
+        });
+
+        it('should label the dialog by the generated header id by default', async () => {
+            component.visible = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            const dialogElement = fixture.debugElement.query(By.css('[role="dialog"]'));
+            const titleElement = fixture.debugElement.query(By.css('.p-dialog-title'));
+            expect(dialogInstance.headerId()).toContain('_header');
+            expect(dialogElement.nativeElement.getAttribute('aria-labelledby')).toBe(dialogInstance.headerId());
+            expect(titleElement.nativeElement.getAttribute('id')).toBe(dialogInstance.headerId());
+        });
+
+        it('should use ariaLabelledBy input over the generated header id', async () => {
+            component.ariaLabelledBy = 'custom-label-id';
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            component.visible = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            const dialogElement = fixture.debugElement.query(By.css('[role="dialog"]'));
+            const titleElement = fixture.debugElement.query(By.css('.p-dialog-title'));
+            expect(dialogElement.nativeElement.getAttribute('aria-labelledby')).toBe('custom-label-id');
+            expect(titleElement.nativeElement.getAttribute('id')).toBe(dialogInstance.headerId());
         });
 
         it('should handle custom role attribute', async () => {

--- a/packages/optimus-ui/src/dialog/dialog.ts
+++ b/packages/optimus-ui/src/dialog/dialog.ts
@@ -85,7 +85,7 @@ const DIALOG_INSTANCE = new InjectionToken<Dialog>('DIALOG_INSTANCE');
                         (pMotionOnBeforeLeave)="onBeforeLeave($event)"
                         (pMotionOnAfterLeave)="onAfterLeave($event)"
                         [attr.role]="role"
-                        [attr.aria-labelledby]="ariaLabelledBy"
+                        [attr.aria-labelledby]="computedAriaLabelledBy()"
                         [attr.aria-modal]="true"
                         [attr.data-p]="dataP"
                     >
@@ -96,8 +96,8 @@ const DIALOG_INSTANCE = new InjectionToken<Dialog>('DIALOG_INSTANCE');
                         <ng-template #notHeadless>
                             <div *ngIf="resizable" [class]="cx('resizeHandle')" [pBind]="ptm('resizeHandle')" [style.z-index]="90" (mousedown)="initResize($event)"></div>
                             <div #titlebar [class]="cx('header')" [pBind]="ptm('header')" (mousedown)="initDrag($event)" *ngIf="showHeader">
-                                <span [id]="ariaLabelledBy" [class]="cx('title')" [pBind]="ptm('title')" *ngIf="!_headerTemplate && !headerTemplate && !headerT">{{ header }}</span>
-                                <ng-container *ngTemplateOutlet="_headerTemplate || headerTemplate || headerT; context: { ariaLabelledBy: ariaLabelledBy }"></ng-container>
+                                <span [id]="headerId()" [class]="cx('title')" [pBind]="ptm('title')" *ngIf="!_headerTemplate && !headerTemplate && !headerT">{{ header() }}</span>
+                                <ng-container *ngTemplateOutlet="_headerTemplate || headerTemplate || headerT; context: { ariaLabelledBy: computedAriaLabelledBy() }"></ng-container>
                                 <div [class]="cx('headerActions')" [pBind]="ptm('headerActions')">
                                     <p-button
                                         [pt]="ptm('pcMaximizeButton')"
@@ -185,7 +185,7 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
      * Title text of the dialog.
      * @group Props
      */
-    @Input() header: string | undefined;
+    header = input<string | undefined>(undefined);
     /**
      * Enables dragging to change the position using header.
      * @group Props
@@ -414,6 +414,11 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
      */
     @Input() role: string = 'dialog';
     /**
+     * Identifier of the element that labels the dialog. Defaults to the id of the generated header title.
+     * @group Props
+     */
+    ariaLabelledBy = input<string | undefined>(undefined);
+    /**
      * Target element to attach the overlay, valid values are "body" or a local ng-template variable of another element (note: use binding with brackets for template variables, e.g. [appendTo]="mydiv" for a div element having #mydiv as variable name).
      * @defaultValue 'self'
      * @group Props
@@ -558,7 +563,9 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
 
     dragging: boolean | undefined;
 
-    ariaLabelledBy: string | null = this.getAriaLabelledBy();
+    headerId = computed<string | null>(() => (this.header() !== null ? this.id + '_header' : null));
+
+    computedAriaLabelledBy = computed<string | null>(() => this.ariaLabelledBy() ?? this.headerId());
 
     documentDragListener: VoidListener;
 
@@ -688,10 +695,6 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
                     break;
             }
         });
-    }
-
-    getAriaLabelledBy() {
-        return this.header !== null ? uuid('pn_id_') + '_header' : null;
     }
 
     parseDurationToMilliseconds(durationString: string): number | undefined {

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
@@ -647,6 +647,15 @@ describe('DynamicDialog', () => {
             expect(dialogElement.nativeElement.getAttribute('aria-modal')).toBe('true');
         });
 
+        it('should pass ariaLabelledBy from config to the dialog', async () => {
+            mockConfig.ariaLabelledBy = 'custom-label-id';
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            const dialogElement = fixture.debugElement.query(By.css('[role="dialog"]'));
+            expect(dialogElement.nativeElement.getAttribute('aria-labelledby')).toBe('custom-label-id');
+        });
+
         // Focus management is now handled by Dialog component, removing focus tests
 
         it('should handle escape key press', () => {

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
@@ -226,6 +226,29 @@ describe('DynamicDialog', () => {
             component.ngAfterViewInit();
             expect(component.ariaLabelledBy).toBeNull();
         });
+
+        it('should use ariaLabelledBy from config when provided', async () => {
+            mockConfig.showHeader = true;
+            mockConfig.ariaLabelledBy = 'custom-label-id';
+            component.visible = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            component.ngAfterViewInit();
+
+            expect(component.ariaLabelledBy).toBe('custom-label-id');
+        });
+
+        it('should prioritize ariaLabelledBy from config over header when showHeader is false', async () => {
+            mockConfig.header = null as any;
+            mockConfig.showHeader = false;
+            mockConfig.ariaLabelledBy = 'custom-label-id';
+            component.visible = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            component.ngAfterViewInit();
+
+            expect(component.ariaLabelledBy).toBe('custom-label-id');
+        });
     });
 
     describe('Dialog Display and Hide Behavior', () => {

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
@@ -259,7 +259,11 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
     }
 
     getAriaLabelledBy() {
-        const { header, showHeader } = this.ddconfig;
+        const { header, showHeader, ariaLabelledBy } = this.ddconfig;
+
+        if (ariaLabelledBy) {
+            return ariaLabelledBy;
+        }
 
         if (header === null || showHeader === false) {
             return null;

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
@@ -43,6 +43,7 @@ const DYNAMIC_DIALOG_INSTANCE = new InjectionToken<DynamicDialog>('DYNAMIC_DIALO
             [focusTrap]="ddconfig?.focusTrap !== false"
             [transitionOptions]="ddconfig?.transitionOptions || '150ms cubic-bezier(0, 0, 0.2, 1)'"
             [closeAriaLabel]="ddconfig?.closeAriaLabel || defaultCloseAriaLabel"
+            [ariaLabelledBy]="ddconfig?.ariaLabelledBy"
             [minimizeIcon]="minimizeIcon"
             [maximizeIcon]="maximizeIcon"
             [closeButtonProps]="{ severity: 'secondary', variant: 'text', rounded: true }"


### PR DESCRIPTION
Fixes #423

`DynamicDialogConfig.ariaLabelledBy` was ignored. Now it wins over the generated header id.

Port of primefaces/primeng#18489, plus 2 tests.