### PR TITLE
fix(inputnumber): Do not prevent pasting

### DIFF
--- a/packages/optimus-ui/src/inputnumber/inputnumber.ts
+++ b/packages/optimus-ui/src/inputnumber/inputnumber.ts
@@ -86,7 +86,6 @@ export const INPUTNUMBER_VALUE_ACCESSOR: any = {
             (input)="onUserInput($event)"
             (keydown)="onInputKeyDown($event)"
             (keypress)="onInputKeyPress($event)"
-            (paste)="onPaste($event)"
             (click)="onInputClick()"
             (focus)="onInputFocus($event)"
             (blur)="onInputBlur($event)"
@@ -806,6 +805,19 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
             return;
         }
 
+        let data = this.input.nativeElement.value;
+        if (data) {
+            if (this.inputId === 'integeronly') {
+                data = data.replace(/[^\d-]/g, '');
+            }
+
+            if (this.maxlength()) {
+                data = data.substring(0, this.maxlength()!);
+            }
+
+            this.input.nativeElement.value = data;
+        }
+
         if (this.isSpecialChar) {
             (event.target as HTMLInputElement).value = this.lastValue as string;
         }
@@ -1020,26 +1032,6 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
 
         if ((48 <= code && code <= 57) || isMinusSign || isDecimalSign) {
             this.insert(event, char, { isDecimalSign, isMinusSign });
-        }
-    }
-
-    onPaste(event: ClipboardEvent) {
-        if (!this.$disabled() && !this.readonly) {
-            event.preventDefault();
-            let data = (event.clipboardData || (this.document as any).defaultView['clipboardData']).getData('Text');
-            if (this.inputId === 'integeronly' && /[^\d-]/.test(data)) {
-                return;
-            }
-            if (data) {
-                if (this.maxlength()) {
-                    data = data.toString().substring(0, this.maxlength());
-                }
-
-                let filteredData = this.parseValue(data);
-                if (filteredData != null) {
-                    this.insert(event, filteredData.toString());
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Description

Do not prevent pasting in inputnumber - instead do filtering in the onInput handler.

## Related issues

Fixes #8

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [ ] `npm run build`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context
