### PR TITLE
fix(docs): save custom theme settings to local storage

### DIFF
--- a/apps/docs/components/layout/configurator/app.configurator.component.ts
+++ b/apps/docs/components/layout/configurator/app.configurator.component.ts
@@ -1,5 +1,5 @@
 import { AppConfigService } from '@/service/appconfigservice';
-import { CommonModule } from '@angular/common';
+import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { Component, computed, inject, PLATFORM_ID } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { $t, updatePreset, updateSurfacePalette } from '@openng/optimus-ui-themes';
@@ -19,6 +19,9 @@ const presets = {
     Lara,
     Nora
 };
+
+// The configurator is rendered in both the topbar and the menu; the stored theme only needs to be applied once.
+let storedThemeApplied = false;
 
 export type ColorPalette = Record<string, string>;
 
@@ -111,6 +114,13 @@ export class AppConfiguratorComponent {
     platformId = inject(PLATFORM_ID);
 
     presets = Object.keys(presets);
+
+    constructor() {
+        if (isPlatformBrowser(this.platformId) && !storedThemeApplied) {
+            storedThemeApplied = true;
+            this.applyStoredTheme();
+        }
+    }
 
     onRTLChange(value: boolean) {
         this.configService.appState.update((state) => ({ ...state, RTL: value }));
@@ -488,5 +498,26 @@ export class AppConfiguratorComponent {
             this.config.ripple.set(false);
         }
         $t().preset(preset).preset(this.getPresetExt()).surfacePalette(surfacePalette).use({ useDefaultOptions: true });
+    }
+
+    private applyStoredTheme() {
+        const state = this.configService.appState();
+        const preset = presets[state.preset];
+        const surfacePalette = this.surfaces.find((s) => s.name === state.surface)?.palette;
+
+        if (state.preset === 'Material') {
+            document.body.classList.add('material');
+            this.config.ripple.set(true);
+        }
+
+        let theme = $t().preset(preset).preset(this.getPresetExt());
+
+        if (surfacePalette) {
+            theme = theme.surfacePalette(surfacePalette);
+        }
+
+        theme.use({ useDefaultOptions: true });
+
+        this.toggleRTL(state.RTL);
     }
 }

--- a/apps/docs/service/appconfigservice.ts
+++ b/apps/docs/service/appconfigservice.ts
@@ -1,18 +1,14 @@
 import { AppState } from '@/domain/appstate';
 import { DOCUMENT } from '@angular/common';
 import { computed, effect, inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
+
+const LOCAL_STORAGE_KEY = 'optimus-ui-app-state';
+
 @Injectable({
     providedIn: 'root'
 })
 export class AppConfigService {
-    appState = signal<AppState>({
-        preset: 'Aura',
-        primary: 'noir',
-        surface: null,
-        darkTheme: false,
-        menuActive: false,
-        RTL: false
-    });
+    appState = signal<AppState>(this.getStateFromLocalStorage());
 
     newsActive = signal(false);
 
@@ -30,12 +26,12 @@ export class AppConfigService {
 
     constructor() {
         effect(() => {
-            const isDarkMode = this.darkMode();
-            const currentPrimaryPalette = this.primaryPalette();
-            const currentSurfacePalette = this.surfacePalette();
-
-            this.toggleDarkMode(isDarkMode);
+            this.toggleDarkMode(this.darkMode());
             this.onTransitionEnd();
+        });
+
+        effect(() => {
+            this.saveStateToLocalStorage(this.appState());
         });
     }
 
@@ -52,6 +48,26 @@ export class AppConfigService {
         setTimeout(() => {
             this.transitionComplete.set(false);
         });
+    }
+
+    private saveStateToLocalStorage(state: AppState): void {
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(state));
+    }
+
+    private getStateFromLocalStorage(): AppState {
+        const savedState = localStorage.getItem(LOCAL_STORAGE_KEY);
+        if (savedState) {
+            return JSON.parse(savedState) as AppState;
+        }
+
+        return {
+            preset: 'Aura',
+            primary: 'noir',
+            surface: null,
+            darkTheme: false,
+            menuActive: false,
+            RTL: false
+        };
     }
 
     hideMenu() {


### PR DESCRIPTION
## Description

You loose custom preferences such as changing theme (dark/light), primary color or other settings on the docs site when you reload the page. This used to work in previous versions of PrimeNg.

This PR fixes this issue.

## Related issues

Fixes #1616 


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)