### PR TITLE
fix(tabs): Add missing display: flex

### DIFF
--- a/packages/optimus-ui-styles/src/tabs/index.ts
+++ b/packages/optimus-ui-styles/src/tabs/index.ts
@@ -82,6 +82,8 @@ export const style = /*css*/ `
     }
 
     .p-tab {
+        display: flex;
+        align-items: center;
         flex-shrink: 0;
         cursor: pointer;
         user-select: none;


### PR DESCRIPTION
## Description

Add missing display:flex to tabs CSS.

## Related issues

Fixes #4

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [ ] `npm run build`
- [x] `npm test`
- [ ] `npm run lint`
- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context
