### PR TITLE
fix(docs): save custom theme settings to local storage

### DIFF
--- a/apps/docs/components/layout/configurator/app.configurator.component.ts
+++ b/apps/docs/components/layout/configurator/app.configurator.component.ts
@@ -20,6 +20,8 @@ const presets = {
     Nora
 };
 
+type ColorType = 'primary' | 'surface';
+
 export type ColorPalette = Record<string, string>;
 
 export interface PrimaryColor {
@@ -111,6 +113,14 @@ export class AppConfiguratorComponent {
     platformId = inject(PLATFORM_ID);
 
     presets = Object.keys(presets);
+
+    constructor() {
+        const state = this.configService.appState();
+        this.applyTheme('primary', state.primary);
+        this.applyTheme('surface', state.surface);
+        this.onPresetChange(state.preset);
+        this.toggleRTL(state.RTL);
+    }
 
     onRTLChange(value: boolean) {
         this.configService.appState.update((state) => ({ ...state, RTL: value }));
@@ -271,9 +281,7 @@ export class AppConfiguratorComponent {
         }
     ];
 
-    selectedPrimaryColor = computed(() => {
-        return this.configService.appState().primary;
-    });
+    selectedPrimaryColor = computed(() => this.configService.appState().primary);
 
     selectedSurfaceColor = computed(() => this.configService.appState().surface);
 
@@ -458,7 +466,7 @@ export class AppConfiguratorComponent {
         }
     }
 
-    updateColors(event: any, type: string, color: any) {
+    updateColors(event: any, type: ColorType, color: any) {
         if (type === 'primary') {
             this.configService.appState.update((state) => ({ ...state, primary: color.name }));
         } else if (type === 'surface') {
@@ -468,7 +476,7 @@ export class AppConfiguratorComponent {
         event.stopPropagation();
     }
 
-    applyTheme(type: string, color: any) {
+    private applyTheme(type: ColorType, color: any) {
         if (type === 'primary') {
             updatePreset(this.getPresetExt());
         } else if (type === 'surface') {
@@ -476,9 +484,9 @@ export class AppConfiguratorComponent {
         }
     }
 
-    onPresetChange(event: any) {
-        this.configService.appState.update((state) => ({ ...state, preset: event }));
-        const preset = presets[event];
+    onPresetChange(presetName: string) {
+        this.configService.appState.update((state) => ({ ...state, preset: presetName }));
+        const preset = presets[presetName];
         const surfacePalette = this.surfaces.find((s) => s.name === this.selectedSurfaceColor())?.palette;
         if (this.configService.appState().preset === 'Material') {
             document.body.classList.add('material');

--- a/apps/docs/service/appconfigservice.ts
+++ b/apps/docs/service/appconfigservice.ts
@@ -1,18 +1,14 @@
 import { AppState } from '@/domain/appstate';
 import { DOCUMENT } from '@angular/common';
 import { computed, effect, inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
+
+const LOCAL_STORAGE_KEY = 'optimus-ui-app-state';
+
 @Injectable({
     providedIn: 'root'
 })
 export class AppConfigService {
-    appState = signal<AppState>({
-        preset: 'Aura',
-        primary: 'noir',
-        surface: null,
-        darkTheme: false,
-        menuActive: false,
-        RTL: false
-    });
+    appState = signal<AppState>(this.getStateFromLocalStorage());
 
     newsActive = signal(false);
 
@@ -30,12 +26,12 @@ export class AppConfigService {
 
     constructor() {
         effect(() => {
-            const isDarkMode = this.darkMode();
-            const currentPrimaryPalette = this.primaryPalette();
-            const currentSurfacePalette = this.surfacePalette();
-
-            this.toggleDarkMode(isDarkMode);
+            this.toggleDarkMode(this.darkMode());
             this.onTransitionEnd();
+        });
+
+        effect(() => {
+            this.saveStateToLocalStorage(this.appState());
         });
     }
 
@@ -52,6 +48,26 @@ export class AppConfigService {
         setTimeout(() => {
             this.transitionComplete.set(false);
         });
+    }
+
+    private saveStateToLocalStorage(state: AppState): void {
+        localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(state));
+    }
+
+    private getStateFromLocalStorage(): AppState {
+        const savedState = localStorage.getItem(LOCAL_STORAGE_KEY);
+        if (savedState) {
+            return JSON.parse(savedState) as AppState;
+        }
+
+        return {
+            preset: 'Aura',
+            primary: 'noir',
+            surface: null,
+            darkTheme: false,
+            menuActive: false,
+            RTL: false
+        };
     }
 
     hideMenu() {


### PR DESCRIPTION
## Description

You loose custom preferences such as changing theme (dark/light), primary color or other settings on the docs site when you reload the page. This used to work in previous versions of PrimeNg.

This PR fixes this issue.

## Related issues

Fixes #1616

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking changes

None

## Test plan

- [x] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)
