### PR TITLE
fix(stepper): Partial fix to stepper a11y

### DIFF
--- a/packages/optimus-ui/src/stepper/stepper.test.ts
+++ b/packages/optimus-ui/src/stepper/stepper.test.ts
@@ -420,12 +420,12 @@ describe('Stepper', () => {
 
     describe('Accessibility', () => {
         it('should have correct ARIA roles', () => {
-            const stepperElement = fixture.debugElement.query(By.css('p-stepper'));
-            const stepButtons = fixture.debugElement.queryAll(By.css('p-step button'));
+            const stepListElement = fixture.debugElement.query(By.css('p-step-list'));
+            const steps = fixture.debugElement.queryAll(By.css('p-step'));
             const stepPanels = fixture.debugElement.queryAll(By.css('p-step-panel'));
 
-            expect(stepperElement.nativeElement.getAttribute('role')).toBe('tablist');
-            expect(stepButtons[0].nativeElement.getAttribute('role')).toBe('tab');
+            expect(stepListElement.nativeElement.getAttribute('role')).toBe('tablist');
+            expect(steps[0].nativeElement.getAttribute('role')).toBe('tab');
             expect(stepPanels[0].nativeElement.getAttribute('role')).toBe('tabpanel');
         });
 
@@ -444,8 +444,8 @@ describe('Stepper', () => {
             fixture.detectChanges();
 
             const steps = fixture.debugElement.queryAll(By.css('p-step'));
-            expect(steps[1].nativeElement.getAttribute('aria-current')).toBe('step');
-            expect(steps[0].nativeElement.getAttribute('aria-current')).toBeNull();
+            expect(steps[1].nativeElement.getAttribute('aria-selected')).toBe('true');
+            expect(steps[0].nativeElement.getAttribute('aria-selected')).toBe('false');
         });
 
         it('should set correct tabindex for disabled steps', async () => {

--- a/packages/optimus-ui/src/stepper/stepper.ts
+++ b/packages/optimus-ui/src/stepper/stepper.ts
@@ -80,7 +80,8 @@ export interface StepPanelContentTemplateContext {
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[class]': 'cx("root")'
+        '[class]': 'cx("root")',
+        '[attr.role]': '"tablist"'
     },
     providers: [StepListStyle, { provide: STEPLIST_INSTANCE, useExisting: StepList }, { provide: PARENT_INSTANCE, useExisting: StepList }],
     hostDirectives: [Bind]
@@ -199,17 +200,7 @@ export class StepItem extends BaseComponent<StepItemPassThrough> {
     imports: [CommonModule, StepperSeparator, SharedModule, BindModule],
     template: `
         @if (!content && !_contentTemplate) {
-            <button
-                [attr.id]="id()"
-                [class]="cx('header')"
-                [pBind]="ptm('header')"
-                [attr.role]="'tab'"
-                [tabindex]="isStepDisabled() ? -1 : undefined"
-                [attr.aria-controls]="ariaControls()"
-                [disabled]="isStepDisabled()"
-                (click)="onStepClick()"
-                type="button"
-            >
+            <button [attr.id]="id()" [class]="cx('header')" [pBind]="ptm('header')" [tabindex]="isStepDisabled() ? -1 : undefined" [attr.aria-controls]="ariaControls()" [disabled]="isStepDisabled()" (click)="onStepClick()" type="button">
                 <span [class]="cx('number')" [pBind]="ptm('number')">{{ value() }}</span>
                 <span [class]="cx('title')" [pBind]="ptm('title')">
                     <ng-content></ng-content>
@@ -230,9 +221,11 @@ export class StepItem extends BaseComponent<StepItemPassThrough> {
     host: {
         '[class]': 'cx("root")',
         '[attr.aria-current]': 'active() ? "step" : undefined',
-        '[attr.role]': '"presentation"',
+        '[attr.role]': '"tab"',
         '[attr.data-p-active]': 'active()',
-        '[attr.data-p-disabled]': 'isStepDisabled()'
+        '[attr.aria-selected]': 'active()',
+        '[attr.data-p-disabled]': 'isStepDisabled()',
+        '[attr.aria-disabled]': 'isStepDisabled()'
     },
     providers: [StepStyle, { provide: STEP_INSTANCE, useExisting: Step }, { provide: PARENT_INSTANCE, useExisting: Step }],
     hostDirectives: [Bind]
@@ -462,7 +455,6 @@ export class StepPanels extends BaseComponent<StepPanelsPassThrough> {
     providers: [StepperStyle, { provide: STEPPER_INSTANCE, useExisting: Stepper }, { provide: PARENT_INSTANCE, useExisting: Stepper }],
     host: {
         '[class]': 'cx("root")',
-        '[attr.role]': '"tablist"',
         '[attr.id]': 'id()'
     },
     hostDirectives: [Bind]

--- a/packages/optimus-ui/src/stepper/stepper.ts
+++ b/packages/optimus-ui/src/stepper/stepper.ts
@@ -220,7 +220,6 @@ export class StepItem extends BaseComponent<StepItemPassThrough> {
     encapsulation: ViewEncapsulation.None,
     host: {
         '[class]': 'cx("root")',
-        '[attr.aria-current]': 'active() ? "step" : undefined',
         '[attr.role]': '"tab"',
         '[attr.data-p-active]': 'active()',
         '[attr.aria-selected]': 'active()',


### PR DESCRIPTION
## Description

Moved role attributes to the correct location to fix an aria-required-children error.
What's missing: arrow left and right still do not move between the steps - this is a bigger change that I'm not confident to make right now...

## Related issues

Partially fixes #2

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

Lighthouse no longer complains of this error

- [x] `npm run build`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context
