### PR TITLE
fix(dynamicdialog): add generic types for close, maximize and events

### DIFF
--- a/packages/optimus-ui/src/dynamicdialog/dialogservice.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dialogservice.ts
@@ -12,7 +12,7 @@ import { DynamicDialogRef } from './dynamicdialog-ref';
  */
 @Injectable()
 export class DialogService {
-    dialogComponentRefMap: Map<DynamicDialogRef<any>, ComponentRef<DynamicDialog>> = new Map();
+    dialogComponentRefMap: Map<DynamicDialogRef<any, any, any>, ComponentRef<DynamicDialog>> = new Map();
 
     constructor(
         private appRef: ApplicationRef,
@@ -26,12 +26,15 @@ export class DialogService {
      * @returns {DynamicDialogRef} DynamicDialog instance.
      * @group Method
      */
-    public open<T, DataType = any, InputValuesType extends Record<string, any> = {}>(componentType: Type<T>, config: DynamicDialogConfig<DataType, InputValuesType>): DynamicDialogRef<T> | null {
+    public open<T, DataType = any, InputValuesType extends Record<string, any> = {}, CloseResult = any, MaximizeResult = any>(
+        componentType: Type<T>,
+        config: DynamicDialogConfig<DataType, InputValuesType>
+    ): DynamicDialogRef<T, CloseResult, MaximizeResult> | null {
         if (!this.duplicationPermission(componentType, config)) {
             return null;
         }
 
-        const dialogRef = this.appendDialogComponentToBody<T>(config, componentType);
+        const dialogRef = this.appendDialogComponentToBody<T, CloseResult, MaximizeResult>(config, componentType);
 
         const componentRefInstance = this.dialogComponentRefMap.get(dialogRef);
         if (componentRefInstance) {
@@ -46,15 +49,15 @@ export class DialogService {
      * @param {DynamicDialogRef} ref - DynamicDialog instance.
      * @group Method
      */
-    public getInstance(ref: DynamicDialogRef<any>) {
+    public getInstance(ref: DynamicDialogRef<any, any, any>) {
         return this.dialogComponentRefMap.get(ref)?.instance;
     }
 
-    private appendDialogComponentToBody<T>(config: DynamicDialogConfig, componentType: Type<T>): DynamicDialogRef<T> {
+    private appendDialogComponentToBody<T, CloseResult = any, MaximizeResult = any>(config: DynamicDialogConfig, componentType: Type<T>): DynamicDialogRef<T, CloseResult, MaximizeResult> {
         const map = new WeakMap();
         map.set(DynamicDialogConfig, config);
 
-        const dialogRef = new DynamicDialogRef<T>();
+        const dialogRef = new DynamicDialogRef<T, CloseResult, MaximizeResult>();
         map.set(DynamicDialogRef, dialogRef);
 
         const sub = dialogRef.onClose.subscribe(() => {
@@ -86,7 +89,7 @@ export class DialogService {
         return dialogRef;
     }
 
-    private removeDialogComponentFromBody(dialogRef: DynamicDialogRef<any>) {
+    private removeDialogComponentFromBody(dialogRef: DynamicDialogRef<any, any, any>) {
         if (!dialogRef || !this.dialogComponentRefMap.has(dialogRef)) {
             return;
         }

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog-ref.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog-ref.ts
@@ -3,14 +3,12 @@ import { Observable, Subject } from 'rxjs';
  * Dynamic Dialog instance.
  * @group Components
  */
-export class DynamicDialogRef<ComponentType = any> {
-    constructor() {}
-
+export class DynamicDialogRef<ComponentType = any, CloseResult = any, MaximizeResult = any> {
     /**
      * Closes dialog.
      * @group Method
      */
-    close(result?: any) {
+    close(result?: CloseResult) {
         this._onClose.next(result);
 
         setTimeout(() => {
@@ -61,63 +59,63 @@ export class DynamicDialogRef<ComponentType = any> {
      * @param {*} value - Size value.
      * @group Method
      */
-    maximize(value: any) {
+    maximize(value: MaximizeResult) {
         this._onMaximize.next(value);
     }
 
-    private readonly _onClose = new Subject<any>();
+    private readonly _onClose = new Subject<CloseResult | undefined>();
     /**
      * Event triggered on dialog is closed.
      * @group Events
      */
-    onClose: Observable<any> = this._onClose.asObservable();
+    onClose: Observable<CloseResult | undefined> = this._onClose.asObservable();
 
-    private readonly _onDestroy = new Subject<any>();
+    private readonly _onDestroy = new Subject<null>();
     /**
      * Event triggered on dialog instance is destroyed.
      * @group Events
      */
-    onDestroy: Observable<any> = this._onDestroy.asObservable();
+    onDestroy: Observable<null> = this._onDestroy.asObservable();
 
-    private readonly _onDragStart = new Subject<any>();
+    private readonly _onDragStart = new Subject<MouseEvent>();
     /**
      * Event triggered on drag start.
      * @param {MouseEvent} event - Mouse event.
      * @group Events
      */
-    onDragStart: Observable<any> = this._onDragStart.asObservable();
+    onDragStart: Observable<MouseEvent> = this._onDragStart.asObservable();
 
-    private readonly _onDragEnd = new Subject<any>();
+    private readonly _onDragEnd = new Subject<MouseEvent>();
     /**
      * Event triggered on drag end.
      * @param {MouseEvent} event - Mouse event.
      * @group Events
      */
-    onDragEnd: Observable<any> = this._onDragEnd.asObservable();
+    onDragEnd: Observable<MouseEvent> = this._onDragEnd.asObservable();
 
-    private readonly _onResizeInit = new Subject<any>();
+    private readonly _onResizeInit = new Subject<MouseEvent>();
     /**
      * Event triggered on resize start.
      * @param {MouseEvent} event - Mouse event.
      * @group Events
      */
-    onResizeInit: Observable<any> = this._onResizeInit.asObservable();
+    onResizeInit: Observable<MouseEvent> = this._onResizeInit.asObservable();
 
-    private readonly _onResizeEnd = new Subject<any>();
+    private readonly _onResizeEnd = new Subject<MouseEvent>();
     /**
      * Event triggered on resize end.
      * @param {MouseEvent} event - Mouse event.
      * @group Events
      */
-    onResizeEnd: Observable<any> = this._onResizeEnd.asObservable();
+    onResizeEnd: Observable<MouseEvent> = this._onResizeEnd.asObservable();
 
-    private readonly _onMaximize = new Subject<any>();
+    private readonly _onMaximize = new Subject<MaximizeResult>();
     /**
      * Event triggered on dialog is maximized.
      * @param {*} value - Size value.
      * @group Events
      */
-    onMaximize: Observable<any> = this._onMaximize.asObservable();
+    onMaximize: Observable<MaximizeResult> = this._onMaximize.asObservable();
 
     /**
      * Event triggered on child component load.


### PR DESCRIPTION
Ports primefaces/primeng#18188.

`DynamicDialogRef<ComponentType, CloseResult, MaximizeResult>` — typed `close()`/`maximize()` payloads and events instead of `any`. `DialogService.open()` forwards the params. Defaults stay `any`, so nothing breaks.

`onClose` emits `CloseResult | undefined` (upstream omits `undefined`) because `close()` can be called with no result.

Closes #511