### PR TITLE
fix(menu): hide submenu label when visible is false

### DIFF
--- a/packages/optimus-ui/src/menu/menu.test.ts
+++ b/packages/optimus-ui/src/menu/menu.test.ts
@@ -561,6 +561,33 @@ describe('Menu', () => {
             expect(submenuInstance.model[0].items.length).toBe(2); // File has 2 items
             expect(submenuInstance.model[1].items.length).toBe(2); // Edit has 2 items
         });
+
+        it('should not render submenu header when visible is false', async () => {
+            const submenuFixture = TestBed.createComponent(TestSubmenuMenuComponent);
+            submenuFixture.componentInstance.submenuModel = [
+                { label: 'Should be invisible', visible: false, items: [] },
+                { label: 'Visible', items: [] }
+            ];
+            submenuFixture.detectChanges();
+            await submenuFixture.whenStable();
+
+            const submenuHeaders = submenuFixture.debugElement.queryAll(By.css('li[data-pc-section="submenulabel"]'));
+            expect(submenuHeaders.length).toBe(1);
+            expect(submenuHeaders[0].nativeElement.textContent.trim()).toBe('Visible');
+        });
+
+        it('should not render submenu separator when visible is false', async () => {
+            const submenuFixture = TestBed.createComponent(TestSubmenuMenuComponent);
+            submenuFixture.componentInstance.submenuModel = [
+                { separator: true, visible: false },
+                { label: 'Visible', items: [] }
+            ];
+            submenuFixture.detectChanges();
+            await submenuFixture.whenStable();
+
+            const separators = submenuFixture.debugElement.queryAll(By.css('li[data-pc-section="separator"]'));
+            expect(separators.length).toBe(0);
+        });
     });
 
     describe('Item Interaction Tests', () => {

--- a/packages/optimus-ui/src/menu/menu.ts
+++ b/packages/optimus-ui/src/menu/menu.ts
@@ -213,30 +213,33 @@ export class MenuItemContent extends BaseComponent {
                 >
                     @if (hasSubMenu()) {
                         @for (submenu of model; track submenu; let i = $index) {
-                            @if (submenu.separator && submenu.visible !== false) {
-                                <li [class]="cx('separator')" [pBind]="ptm('separator')" role="separator" [attr.data-pc-section]="'separator'"></li>
-                            }
-                            @if (!submenu.separator) {
-                                <li
-                                    [class]="cx('submenuLabel')"
-                                    [pBind]="ptm('submenuLabel')"
-                                    [attr.data-automationid]="submenu.automationId"
-                                    pTooltip
-                                    [tooltipOptions]="submenu.tooltipOptions"
-                                    [pTooltipUnstyled]="unstyled()"
-                                    role="none"
-                                    [attr.id]="menuitemId(submenu, id, i)"
-                                    [attr.data-pc-section]="'submenulabel'"
-                                >
-                                    @if (!submenuHeaderTemplate && !_submenuHeaderTemplate) {
-                                        @if (submenu.escape !== false) {
-                                            <span>{{ submenu.label }}</span>
+                            @if (submenu.visible !== false) {
+                                @if (submenu.separator) {
+                                    <li [class]="cx('separator')" [pBind]="ptm('separator')" role="separator" [attr.data-pc-section]="'separator'"></li>
+                                } @else {
+                                    <li
+                                        [class]="cx('submenuLabel')"
+                                        [pBind]="ptm('submenuLabel')"
+                                        [attr.data-automationid]="submenu.automationId"
+                                        pTooltip
+                                        [tooltipOptions]="submenu.tooltipOptions"
+                                        [pTooltipUnstyled]="unstyled()"
+                                        role="none"
+                                        [attr.id]="menuitemId(submenu, id, i)"
+                                        [attr.data-pc-section]="'submenulabel'"
+                                    >
+                                        @let submenuHeader = submenuHeaderTemplate ?? _submenuHeaderTemplate;
+                                        @if (submenuHeader) {
+                                            <ng-container *ngTemplateOutlet="submenuHeader; context: { $implicit: submenu }"></ng-container>
                                         } @else {
-                                            <span [innerHTML]="submenu.label | safeHtml"></span>
+                                            @if (submenu.escape !== false) {
+                                                <span>{{ submenu.label }}</span>
+                                            } @else {
+                                                <span [innerHTML]="submenu.label ?? '' | safeHtml"></span>
+                                            }
                                         }
-                                    }
-                                    <ng-container *ngTemplateOutlet="submenuHeaderTemplate ?? _submenuHeaderTemplate; context: { $implicit: submenu }"></ng-container>
-                                </li>
+                                    </li>
+                                }
                             }
                             @for (item of submenu.items; track item; let j = $index) {
                                 @if (item.separator && (item.visible !== false || submenu.visible !== false)) {


### PR DESCRIPTION
Fixes #414

Submenu labels ignored `visible: false` and always rendered.

Wrapped separator + label in a single `@if (submenu.visible !== false)`.

Added test.