### PR TITLE
fix(accordion,stepper): replace transformToBoolean with booleanAttribute

### DIFF
--- a/packages/optimus-ui/src/accordion/accordion.test.ts
+++ b/packages/optimus-ui/src/accordion/accordion.test.ts
@@ -139,6 +139,36 @@ class TestPTAccordionComponent {
     @Input() pt: any;
 }
 
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: true,
+    imports: [Accordion, AccordionPanel, AccordionHeader, AccordionContent],
+    template: `
+        <p-accordion multiple selectOnFocus>
+            <p-accordion-panel value="tab1" disabled>
+                <p-accordion-header>Tab 1 Header</p-accordion-header>
+                <p-accordion-content>Tab 1 Content</p-accordion-content>
+            </p-accordion-panel>
+        </p-accordion>
+    `
+})
+class TestStaticAttributeAccordionComponent {}
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: true,
+    imports: [Accordion, AccordionPanel, AccordionHeader, AccordionContent],
+    template: `
+        <p-accordion multiple="false" selectOnFocus="false">
+            <p-accordion-panel value="tab1" disabled="false">
+                <p-accordion-header>Tab 1 Header</p-accordion-header>
+                <p-accordion-content>Tab 1 Content</p-accordion-content>
+            </p-accordion-panel>
+        </p-accordion>
+    `
+})
+class TestFalseStringAttributeAccordionComponent {}
+
 describe('Accordion', () => {
     let fixture: ComponentFixture<TestAccordionComponent>;
     let component: TestAccordionComponent;
@@ -147,7 +177,7 @@ describe('Accordion', () => {
 
     beforeEach(async () => {
         TestBed.configureTestingModule({
-            imports: [TestAccordionComponent, TestDynamicAccordionComponent, TestCustomIconAccordionComponent, TestPTAccordionComponent],
+            imports: [TestAccordionComponent, TestDynamicAccordionComponent, TestCustomIconAccordionComponent, TestPTAccordionComponent, TestStaticAttributeAccordionComponent, TestFalseStringAttributeAccordionComponent],
             providers: [provideZonelessChangeDetection()]
         });
 
@@ -1016,6 +1046,31 @@ describe('Accordion', () => {
             const accordionEl = ptFixture.debugElement.query(By.css('p-accordion'));
 
             expect(accordionEl.nativeElement.className).toContain('SETINPUT_ROOT_CLASS');
+        });
+    });
+    describe('Boolean Attribute Coercion', () => {
+        it('should treat a valueless attribute as true', async () => {
+            const staticFixture = TestBed.createComponent(TestStaticAttributeAccordionComponent);
+            await staticFixture.whenStable();
+
+            const staticAccordion: Accordion = staticFixture.debugElement.query(By.directive(Accordion)).componentInstance;
+            const staticPanel: AccordionPanel = staticFixture.debugElement.query(By.directive(AccordionPanel)).componentInstance;
+
+            expect(staticAccordion.multiple()).toBe(true);
+            expect(staticAccordion.selectOnFocus()).toBe(true);
+            expect(staticPanel.disabled()).toBe(true);
+        });
+
+        it('should treat the string "false" as false', async () => {
+            const falseFixture = TestBed.createComponent(TestFalseStringAttributeAccordionComponent);
+            await falseFixture.whenStable();
+
+            const falseAccordion: Accordion = falseFixture.debugElement.query(By.directive(Accordion)).componentInstance;
+            const falsePanel: AccordionPanel = falseFixture.debugElement.query(By.directive(AccordionPanel)).componentInstance;
+
+            expect(falseAccordion.multiple()).toBe(false);
+            expect(falseAccordion.selectOnFocus()).toBe(false);
+            expect(falsePanel.disabled()).toBe(false);
         });
     });
 });

--- a/packages/optimus-ui/src/accordion/accordion.ts
+++ b/packages/optimus-ui/src/accordion/accordion.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import {
+    booleanAttribute,
     ChangeDetectionStrategy,
     Component,
     computed,
@@ -28,7 +29,6 @@ import { ChevronDownIcon, ChevronUpIcon } from '@openng/optimus-ui/icons';
 import { MotionModule } from '@openng/optimus-ui/motion';
 import { Ripple } from '@openng/optimus-ui/ripple';
 import { AccordionContentPassThrough, AccordionHeaderPassThrough, AccordionPanelPassThrough, AccordionPassThrough } from '@openng/optimus-ui/types/accordion';
-import { transformToBoolean } from '@openng/optimus-ui/utils';
 import { AccordionStyle } from './style/accordionstyle';
 
 /**
@@ -112,7 +112,7 @@ export class AccordionPanel extends BaseComponent<AccordionPanelPassThrough> {
      * @defaultValue false
      * @group Props
      */
-    disabled: InputSignalWithTransform<any, boolean> = input(false, { transform: (v: any) => transformToBoolean(v) });
+    disabled: InputSignalWithTransform<boolean, unknown> = input(false, { transform: booleanAttribute });
 
     active = computed(() => (this.pcAccordion.multiple() ? this.valueEquals(this.pcAccordion.value(), this.value()) : this.pcAccordion.value() === this.value()));
 
@@ -432,7 +432,7 @@ export class Accordion extends BaseComponent<AccordionPassThrough> implements Bl
      * @defaultValue false
      * @group Props
      */
-    multiple = input(false, { transform: (v: any) => transformToBoolean(v) });
+    multiple = input(false, { transform: booleanAttribute });
     /**
      * Class of the element.
      * @deprecated since v20.0.0, use `class` instead.
@@ -454,7 +454,7 @@ export class Accordion extends BaseComponent<AccordionPassThrough> implements Bl
      * @defaultValue false
      * @group Props
      */
-    selectOnFocus = input(false, { transform: (v: any) => transformToBoolean(v) });
+    selectOnFocus = input(false, { transform: booleanAttribute });
     /**
      * Transition options of the animation.
      * @group Props

--- a/packages/optimus-ui/src/stepper/stepper.test.ts
+++ b/packages/optimus-ui/src/stepper/stepper.test.ts
@@ -116,6 +116,42 @@ class TestPTStepperComponent {
     @Input() pt: any;
 }
 
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <p-stepper linear [value]="1">
+            <p-step-list>
+                <p-step [value]="1">Step 1</p-step>
+                <p-step [value]="2" disabled>Step 2</p-step>
+            </p-step-list>
+            <p-step-panels>
+                <p-step-panel [value]="1">Content 1</p-step-panel>
+                <p-step-panel [value]="2">Content 2</p-step-panel>
+            </p-step-panels>
+        </p-stepper>
+    `
+})
+class TestStaticAttributeStepperComponent {}
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <p-stepper linear="false" [value]="1">
+            <p-step-list>
+                <p-step [value]="1">Step 1</p-step>
+                <p-step [value]="2" disabled="false">Step 2</p-step>
+            </p-step-list>
+            <p-step-panels>
+                <p-step-panel [value]="1">Content 1</p-step-panel>
+                <p-step-panel [value]="2">Content 2</p-step-panel>
+            </p-step-panels>
+        </p-stepper>
+    `
+})
+class TestFalseStringAttributeStepperComponent {}
+
 describe('Stepper', () => {
     let fixture: ComponentFixture<TestStepperComponent>;
     let component: TestStepperComponent;
@@ -125,7 +161,7 @@ describe('Stepper', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [Stepper, StepList, StepPanels, StepPanel, StepItem, Step],
-            declarations: [TestStepperComponent, TestVerticalStepperComponent, TestTemplateStepperComponent, TestPTStepperComponent],
+            declarations: [TestStepperComponent, TestVerticalStepperComponent, TestTemplateStepperComponent, TestPTStepperComponent, TestStaticAttributeStepperComponent, TestFalseStringAttributeStepperComponent],
             providers: [provideZonelessChangeDetection()]
         });
 
@@ -786,6 +822,29 @@ describe('Stepper', () => {
             const stepperEl = ptFixture.debugElement.query(By.css('p-stepper'));
 
             expect(stepperEl.nativeElement.className).toContain('SETINPUT_ROOT_CLASS');
+        });
+    });
+    describe('Boolean Attribute Coercion', () => {
+        it('should treat a valueless attribute as true', () => {
+            const staticFixture = TestBed.createComponent(TestStaticAttributeStepperComponent);
+            staticFixture.detectChanges();
+
+            const staticStepper: Stepper = staticFixture.debugElement.query(By.directive(Stepper)).componentInstance;
+            const steps = staticFixture.debugElement.queryAll(By.directive(Step));
+
+            expect(staticStepper.linear()).toBe(true);
+            expect((steps[1].componentInstance as Step).disabled()).toBe(true);
+        });
+
+        it('should treat the string "false" as false', () => {
+            const falseFixture = TestBed.createComponent(TestFalseStringAttributeStepperComponent);
+            falseFixture.detectChanges();
+
+            const falseStepper: Stepper = falseFixture.debugElement.query(By.directive(Stepper)).componentInstance;
+            const steps = falseFixture.debugElement.queryAll(By.directive(Step));
+
+            expect(falseStepper.linear()).toBe(false);
+            expect((steps[1].componentInstance as Step).disabled()).toBe(false);
         });
     });
 });

--- a/packages/optimus-ui/src/stepper/stepper.ts
+++ b/packages/optimus-ui/src/stepper/stepper.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import {
+    booleanAttribute,
     ChangeDetectionStrategy,
     Component,
     computed,
@@ -30,7 +31,6 @@ import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent
 import { Bind, BindModule } from '@openng/optimus-ui/bind';
 import { MotionModule } from '@openng/optimus-ui/motion';
 import { StepItemPassThrough, StepListPassThrough, StepPanelPassThrough, StepPanelsPassThrough, StepPassThrough, StepperPassThrough, StepperSeparatorPassThrough } from '@openng/optimus-ui/types/stepper';
-import { transformToBoolean } from '@openng/optimus-ui/utils';
 import { StepItemStyle } from './style/stepitemstyle';
 import { StepListStyle } from './style/stepliststyle';
 import { StepPanelsStyle } from './style/steppanelsstyle';
@@ -263,9 +263,7 @@ export class Step extends BaseComponent<StepPassThrough> {
      * @defaultValue false
      * @group Props
      */
-    disabled: InputSignalWithTransform<any, boolean> = input(false, {
-        transform: (v: any | boolean) => transformToBoolean(v)
-    });
+    disabled: InputSignalWithTransform<boolean, unknown> = input(false, { transform: booleanAttribute });
 
     active = computed(() => this.pcStepper.isStepActive(this.value()));
 
@@ -489,12 +487,9 @@ export class Stepper extends BaseComponent<StepperPassThrough> {
     /**
      * A boolean variable that captures user input.
      * @defaultValue false
-     * @type {InputSignalWithTransform<any, boolean >}
      * @group Props
      */
-    linear: InputSignalWithTransform<any, boolean> = input(false, {
-        transform: (v: any | boolean) => transformToBoolean(v)
-    });
+    linear: InputSignalWithTransform<boolean, unknown> = input(false, { transform: booleanAttribute });
     /**
      * Transition options of the animation.
      * @defaultValue 400ms cubic-bezier(0.86, 0, 0.07, 1)

--- a/packages/optimus-ui/src/utils/inpututils.ts
+++ b/packages/optimus-ui/src/utils/inpututils.ts
@@ -1,7 +1,0 @@
-export const transformToBoolean = (value: any): boolean => {
-    return !!value;
-};
-
-export const transformToNumber = (value: string | number): number => {
-    return typeof value === 'string' ? parseFloat(value) : value;
-};

--- a/packages/optimus-ui/src/utils/public_api.ts
+++ b/packages/optimus-ui/src/utils/public_api.ts
@@ -1,6 +1,5 @@
 import { ObjectUtils } from './objectutils';
 import { UniqueComponentId } from './uniquecomponentid';
 import ZIndexUtils from './zindexutils';
-import { transformToBoolean, transformToNumber } from './inpututils';
 
-export { ZIndexUtils, UniqueComponentId, ObjectUtils, transformToNumber, transformToBoolean };
+export { ZIndexUtils, UniqueComponentId, ObjectUtils };


### PR DESCRIPTION
Fixes #445

`transformToBoolean` was `!!value`, so `<p-accordion multiple>` was `false` and `multiple="false"` was `true`.

Swapped to Angular's `booleanAttribute` for `Accordion.multiple`, `Accordion.selectOnFocus`, `AccordionPanel.disabled`, `Stepper.linear`, `Step.disabled`.

`inpututils.ts` had no other users — removed, along with its `transformToBoolean` / `transformToNumber` exports from `@openng/optimus-ui/utils`.

Port of primefaces/primeng#18437.