### PR TITLE
fix(dialog): drop dangling aria-labelledby without a header

### DIFF
--- a/packages/optimus-ui/src/dialog/dialog.test.ts
+++ b/packages/optimus-ui/src/dialog/dialog.test.ts
@@ -756,6 +756,17 @@ describe('Dialog', () => {
             expect(titleElement.nativeElement.getAttribute('id')).toBe(dialogInstance.headerId());
         });
 
+        it('should not set aria-labelledby when the header is hidden', async () => {
+            component.showHeader = false;
+            component.visible = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            const dialogElement = fixture.debugElement.query(By.css('[role="dialog"]'));
+            expect(dialogElement.nativeElement.getAttribute('aria-labelledby')).toBeNull();
+        });
+
         it('should use ariaLabelledBy input over the generated header id', async () => {
             component.ariaLabelledBy = 'custom-label-id';
             fixture.changeDetectorRef.markForCheck();
@@ -1083,6 +1094,16 @@ describe('Dialog', () => {
                 await new Promise((resolve) => setTimeout(resolve, 0));
 
                 expect(headlessComponent.visible).toBe(false);
+            });
+
+            it('should not set aria-labelledby when the headless template is used', async () => {
+                headlessComponent.visible = true;
+                headlessFixture.changeDetectorRef.markForCheck();
+                await headlessFixture.whenStable();
+                await new Promise((resolve) => setTimeout(resolve, 0));
+
+                const dialogElement = headlessFixture.debugElement.query(By.css('[role="dialog"]'));
+                expect(dialogElement.nativeElement.getAttribute('aria-labelledby')).toBeNull();
             });
         });
 

--- a/packages/optimus-ui/src/dialog/dialog.ts
+++ b/packages/optimus-ui/src/dialog/dialog.ts
@@ -89,8 +89,8 @@ const DIALOG_INSTANCE = new InjectionToken<Dialog>('DIALOG_INSTANCE');
                         [attr.aria-modal]="true"
                         [attr.data-p]="dataP"
                     >
-                        <ng-container *ngIf="_headlessTemplate || headlessTemplate || headlessT; else notHeadless">
-                            <ng-container *ngTemplateOutlet="_headlessTemplate || headlessTemplate || headlessT"></ng-container>
+                        <ng-container *ngIf="$headlessTemplate(); else notHeadless">
+                            <ng-container *ngTemplateOutlet="$headlessTemplate()"></ng-container>
                         </ng-container>
 
                         <ng-template #notHeadless>
@@ -565,7 +565,17 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
 
     headerId = computed<string | null>(() => (this.header() !== null ? this.id + '_header' : null));
 
-    computedAriaLabelledBy = computed<string | null>(() => this.ariaLabelledBy() ?? this.headerId());
+    /**
+     * Resolved headless template of any of the supported sources, kept in sync in `onAfterContentChecked`.
+     */
+    $headlessTemplate = signal<TemplateRef<void> | undefined>(undefined);
+
+    /**
+     * Mirror of the `showHeader` input, kept in sync in `onAfterContentChecked`.
+     */
+    $showHeader = signal<boolean>(true);
+
+    computedAriaLabelledBy = computed<string | null>(() => this.ariaLabelledBy() ?? (this.$headlessTemplate() || !this.$showHeader() ? null : this.headerId()));
 
     documentDragListener: VoidListener;
 
@@ -695,6 +705,12 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
                     break;
             }
         });
+    }
+
+    onAfterContentChecked() {
+        // the template sources are plain fields, so they are mirrored into signals to keep `computedAriaLabelledBy` in sync
+        this.$headlessTemplate.set(this._headlessTemplate || this.headlessTemplate || this.headlessT);
+        this.$showHeader.set(this.showHeader);
     }
 
     parseDurationToMilliseconds(durationString: string): number | undefined {


### PR DESCRIPTION
Closes #429

The dialog always set `aria-labelledby` to the generated header id, even when no header element is rendered — with a `#headless` template or `showHeader="false"`. The reference pointed to nothing, which accessibility checkers (e.g. WAVE) flag.

Now `aria-labelledby` is omitted in those cases. An explicit `ariaLabelledBy` input still wins.

Tests added for both cases.