### PR TITLE
fix(table): resolve aria labels for selection checkboxes and radios

### DIFF
--- a/packages/optimus-ui/src/table/table.test.ts
+++ b/packages/optimus-ui/src/table/table.test.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { SharedModule, SortMeta } from '@openng/optimus-ui/api';
+import { Optimus } from '@openng/optimus-ui/config';
 import { Select } from '@openng/optimus-ui/select';
 import { Table, TableModule, TableService } from './table';
 
@@ -1672,6 +1673,137 @@ describe('Table', () => {
 
             // Verify the editing cell has the correct data attribute
             expect(editingCell.querySelector('[data-p-cell-editing="true"]') || editingCell.getAttribute('data-p-cell-editing')).toBeTruthy();
+        });
+    });
+    describe('Selection Aria Labels', () => {
+        @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
+            standalone: false,
+            template: `
+                <p-table [value]="products" [(selection)]="selectedProducts" [selectionMode]="'multiple'" [dataKey]="'id'">
+                    <ng-template #header>
+                        <tr>
+                            <th><p-tableHeaderCheckbox [ariaLabel]="headerLabel()"></p-tableHeaderCheckbox></th>
+                            <th>Name</th>
+                        </tr>
+                    </ng-template>
+                    <ng-template #body let-product>
+                        <tr>
+                            <td><p-tableCheckbox [value]="product" [ariaLabel]="rowLabel()"></p-tableCheckbox></td>
+                            <td>{{ product.name }}</td>
+                        </tr>
+                    </ng-template>
+                </p-table>
+            `
+        })
+        class TestAriaLabelTableComponent {
+            products = [
+                { id: '1001', name: 'Gaming Laptop' },
+                { id: '1002', name: 'Wireless Mouse' }
+            ];
+            selectedProducts: any[] = [];
+            headerLabel = signal<string | undefined>('select all items');
+            rowLabel = signal<string | undefined>('select item');
+        }
+
+        @Component({
+            changeDetection: ChangeDetectionStrategy.Eager,
+            standalone: false,
+            template: `
+                <p-table [value]="products" [(selection)]="selectedProduct" [selectionMode]="'single'" [dataKey]="'id'">
+                    <ng-template #body let-product>
+                        <tr>
+                            <td><p-tableRadioButton [value]="product" ariaLabel="select item"></p-tableRadioButton></td>
+                            <td>{{ product.name }}</td>
+                        </tr>
+                    </ng-template>
+                </p-table>
+            `
+        })
+        class TestAriaLabelRadioTableComponent {
+            products = [
+                { id: '1001', name: 'Gaming Laptop' },
+                { id: '1002', name: 'Wireless Mouse' }
+            ];
+            selectedProduct: any = null;
+        }
+
+        let testFixture: ComponentFixture<TestAriaLabelTableComponent>;
+
+        const ariaLabels = (fixtureRef: ComponentFixture<unknown>, selector: string) => fixtureRef.debugElement.queryAll(By.css(`${selector} input`)).map((input) => input.nativeElement.getAttribute('aria-label'));
+
+        beforeEach(async () => {
+            TestBed.resetTestingModule();
+
+            await TestBed.configureTestingModule({
+                imports: [CommonModule, FormsModule, TableModule, SharedModule],
+                declarations: [TestAriaLabelTableComponent, TestAriaLabelRadioTableComponent],
+                providers: [provideZonelessChangeDetection()]
+            }).compileComponents();
+
+            testFixture = TestBed.createComponent(TestAriaLabelTableComponent);
+            await testFixture.whenStable();
+        });
+
+        it('should apply the ariaLabel input to the header checkbox', () => {
+            expect(ariaLabels(testFixture, 'p-tableHeaderCheckbox')).toEqual(['select all items']);
+        });
+
+        it('should apply the ariaLabel input to the row checkboxes', () => {
+            expect(ariaLabels(testFixture, 'p-tableCheckbox')).toEqual(['select item', 'select item']);
+        });
+
+        it('should apply the ariaLabel input to the row radio buttons', async () => {
+            const radioFixture = TestBed.createComponent(TestAriaLabelRadioTableComponent);
+            await radioFixture.whenStable();
+
+            expect(ariaLabels(radioFixture, 'p-tableRadioButton')).toEqual(['select item', 'select item']);
+        });
+
+        it('should keep the ariaLabel input after a selection change', async () => {
+            testFixture.debugElement.queryAll(By.css('p-tableCheckbox input'))[0].nativeElement.click();
+            await testFixture.whenStable();
+
+            expect(ariaLabels(testFixture, 'p-tableHeaderCheckbox')).toEqual(['select all items']);
+            expect(ariaLabels(testFixture, 'p-tableCheckbox')).toEqual(['select item', 'select item']);
+        });
+
+        it('should react to ariaLabel input changes', async () => {
+            testFixture.componentInstance.headerLabel.set('updated header label');
+            testFixture.componentInstance.rowLabel.set('updated row label');
+            await testFixture.whenStable();
+
+            expect(ariaLabels(testFixture, 'p-tableHeaderCheckbox')).toEqual(['updated header label']);
+            expect(ariaLabels(testFixture, 'p-tableCheckbox')).toEqual(['updated row label', 'updated row label']);
+        });
+
+        it('should fall back to the translated aria labels without an ariaLabel input', async () => {
+            const aria = TestBed.inject(Optimus).translation.aria!;
+
+            testFixture.componentInstance.headerLabel.set(undefined);
+            testFixture.componentInstance.rowLabel.set(undefined);
+            await testFixture.whenStable();
+
+            expect(ariaLabels(testFixture, 'p-tableHeaderCheckbox')).toEqual([aria.unselectAll]);
+            expect(ariaLabels(testFixture, 'p-tableCheckbox')).toEqual([aria.unselectRow, aria.unselectRow]);
+        });
+
+        it('should update the fallback aria label when the selection changes', async () => {
+            const aria = TestBed.inject(Optimus).translation.aria!;
+
+            testFixture.componentInstance.headerLabel.set(undefined);
+            testFixture.componentInstance.rowLabel.set(undefined);
+            await testFixture.whenStable();
+
+            testFixture.debugElement.queryAll(By.css('p-tableCheckbox input'))[0].nativeElement.click();
+            await testFixture.whenStable();
+
+            expect(ariaLabels(testFixture, 'p-tableCheckbox')).toEqual([aria.selectRow, aria.unselectRow]);
+
+            testFixture.debugElement.queryAll(By.css('p-tableCheckbox input'))[0].nativeElement.click();
+            await testFixture.whenStable();
+
+            expect(ariaLabels(testFixture, 'p-tableCheckbox')).toEqual([aria.unselectRow, aria.unselectRow]);
         });
     });
 });

--- a/packages/optimus-ui/src/table/table.ts
+++ b/packages/optimus-ui/src/table/table.ts
@@ -5047,7 +5047,7 @@ export class CellEditor extends BaseComponent {
         [disabled]="disabled()"
         [inputId]="inputId()"
         [name]="name()"
-        [ariaLabel]="ariaLabel"
+        [ariaLabel]="resolvedAriaLabel()"
         [binary]="true"
         [value]="value"
         (onClick)="onClick($event)"
@@ -5064,11 +5064,23 @@ export class TableRadioButton extends BaseComponent {
     readonly inputId = input<string | undefined>();
     readonly name = input<string | undefined>();
 
-    @Input() ariaLabel: string | undefined;
+    readonly ariaLabel = input<string | undefined>();
+
+    readonly resolvedAriaLabel = computed(() => {
+        const ariaLabel = this.ariaLabel();
+
+        if (ariaLabel) {
+            return ariaLabel;
+        }
+
+        const aria = this.dataTable.config.translation.aria;
+
+        return (this.checked() ? aria?.selectRow : aria?.unselectRow) ?? null;
+    });
 
     @ViewChild('rb') inputViewChild: Nullable<RadioButton>;
 
-    checked: boolean | undefined;
+    checked = signal<boolean | undefined>(undefined);
 
     subscription: Subscription;
 
@@ -5078,15 +5090,13 @@ export class TableRadioButton extends BaseComponent {
     ) {
         super();
         this.subscription = this.dataTable.tableService.selectionSource$.subscribe(() => {
-            this.checked = this.dataTable.isSelected(this.value);
-
-            this.ariaLabel = this.ariaLabel || (this.dataTable.config.translation.aria ? (this.checked ? this.dataTable.config.translation.aria.selectRow : this.dataTable.config.translation.aria.unselectRow) : undefined);
+            this.checked.set(this.dataTable.isSelected(this.value));
             this.cd.markForCheck();
         });
     }
 
     onInit() {
-        this.checked = this.dataTable.isSelected(this.value);
+        this.checked.set(this.dataTable.isSelected(this.value));
     }
 
     onClick(event: RadioButtonClickEvent) {
@@ -5124,12 +5134,12 @@ export class TableRadioButton extends BaseComponent {
             [disabled]="disabled()"
             [inputId]="inputId()"
             [name]="name()"
-            [ariaLabel]="ariaLabel"
+            [ariaLabel]="resolvedAriaLabel()"
             [unstyled]="unstyled()"
         >
             @if (dataTable.checkboxIconTemplate || dataTable._checkboxIconTemplate; as template) {
                 <ng-template pTemplate="icon">
-                    <ng-template *ngTemplateOutlet="template; context: { $implicit: checked }" />
+                    <ng-template *ngTemplateOutlet="template; context: { $implicit: checked() }" />
                 </ng-template>
             }
         </p-checkbox>
@@ -5146,9 +5156,21 @@ export class TableCheckbox extends BaseComponent {
     readonly inputId = input<string | undefined>();
     readonly name = input<string | undefined>();
 
-    @Input() ariaLabel: string | undefined;
+    readonly ariaLabel = input<string | undefined>();
 
-    checked: boolean | undefined;
+    readonly resolvedAriaLabel = computed(() => {
+        const ariaLabel = this.ariaLabel();
+
+        if (ariaLabel) {
+            return ariaLabel;
+        }
+
+        const aria = this.dataTable.config.translation.aria;
+
+        return (this.checked() ? aria?.selectRow : aria?.unselectRow) ?? null;
+    });
+
+    checked = signal<boolean | undefined>(undefined);
 
     subscription: Subscription;
 
@@ -5158,14 +5180,13 @@ export class TableCheckbox extends BaseComponent {
     ) {
         super();
         this.subscription = this.dataTable.tableService.selectionSource$.subscribe(() => {
-            this.checked = this.dataTable.isSelected(this.value);
-            this.ariaLabel = this.ariaLabel || (this.dataTable.config.translation.aria ? (this.checked ? this.dataTable.config.translation.aria.selectRow : this.dataTable.config.translation.aria.unselectRow) : undefined);
+            this.checked.set(this.dataTable.isSelected(this.value));
             this.cd.markForCheck();
         });
     }
 
     onInit() {
-        this.checked = this.dataTable.isSelected(this.value);
+        this.checked.set(this.dataTable.isSelected(this.value));
     }
 
     onClick({ originalEvent }: CheckboxChangeEvent) {
@@ -5201,12 +5222,12 @@ export class TableCheckbox extends BaseComponent {
             [disabled]="isDisabled()"
             [inputId]="inputId()"
             [name]="name()"
-            [ariaLabel]="ariaLabel"
+            [ariaLabel]="resolvedAriaLabel()"
             [unstyled]="unstyled()"
         >
             @if (dataTable.headerCheckboxIconTemplate || dataTable._headerCheckboxIconTemplate; as template) {
                 <ng-template pTemplate="icon">
-                    <ng-template *ngTemplateOutlet="template; context: { $implicit: checked }" />
+                    <ng-template *ngTemplateOutlet="template; context: { $implicit: checked() }" />
                 </ng-template>
             }
         </p-checkbox>
@@ -5228,9 +5249,21 @@ export class TableHeaderCheckbox extends BaseComponent {
     readonly inputId = input<string | undefined>();
     readonly name = input<string | undefined>();
 
-    @Input() ariaLabel: string | undefined;
+    readonly ariaLabel = input<string | undefined>();
 
-    checked: boolean | undefined;
+    readonly resolvedAriaLabel = computed(() => {
+        const ariaLabel = this.ariaLabel();
+
+        if (ariaLabel) {
+            return ariaLabel;
+        }
+
+        const aria = this.dataTable.config.translation.aria;
+
+        return (this.checked() ? aria?.selectAll : aria?.unselectAll) ?? null;
+    });
+
+    checked = signal<boolean | undefined>(undefined);
 
     selectionChangeSubscription: Subscription;
 
@@ -5242,23 +5275,22 @@ export class TableHeaderCheckbox extends BaseComponent {
     ) {
         super();
         this.valueChangeSubscription = this.dataTable.tableService.valueSource$.subscribe(() => {
-            this.checked = this.updateCheckedState();
-            this.ariaLabel = this.ariaLabel || (this.dataTable.config.translation.aria ? (this.checked ? this.dataTable.config.translation.aria.selectAll : this.dataTable.config.translation.aria.unselectAll) : undefined);
+            this.checked.set(this.updateCheckedState());
         });
 
         this.selectionChangeSubscription = this.dataTable.tableService.selectionSource$.subscribe(() => {
-            this.checked = this.updateCheckedState();
+            this.checked.set(this.updateCheckedState());
         });
     }
 
     onInit() {
-        this.checked = this.updateCheckedState();
+        this.checked.set(this.updateCheckedState());
     }
 
     onClick(event: CheckboxChangeEvent) {
         if (!this.disabled()) {
             if (this.dataTable.value && this.dataTable.value.length > 0) {
-                this.dataTable.toggleRowsWithCheckbox(event, this.checked || false);
+                this.dataTable.toggleRowsWithCheckbox(event, this.checked() ?? false);
             }
         }
 


### PR DESCRIPTION
Fixes #397

`ariaLabel` is now a signal input, and the rendered label is a computed that falls back to the translated `selectRow`/`unselectRow`/`selectAll`/`unselectAll`.

Before, the fallback was written into the field inside a subscription: missing on first render, then stuck at its first value.

Tests added in `table.test.ts`.