### PR TITLE
fix(editor): Update empty string

### DIFF
--- a/packages/optimus-ui/src/editor/editor.ts
+++ b/packages/optimus-ui/src/editor/editor.ts
@@ -330,7 +330,7 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
             if (source === 'user') {
                 let html = isQuill2 ? this.quill.getSemanticHTML() : findSingle(editorElement, '.ql-editor')?.innerHTML;
                 let text = this.quill.getText().trim();
-                if (html === '<p><br></p>') {
+                if (html === '<p></p>') {
                     html = null;
                 }
 


### PR DESCRIPTION
## Description

Updated the string that quill returns when the editor is empty

## Related issues

Fixes #42

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [ ] `npm run build`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context
