### PR TITLE
Fix/dynamicdialog environment injector

### DIFF
--- a/apps/docs/doc/dynamicdialog/environmentinjector-doc.ts
+++ b/apps/docs/doc/dynamicdialog/environmentinjector-doc.ts
@@ -1,0 +1,39 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { Code } from '@/domain/code';
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'environment-injector-doc',
+    standalone: true,
+    imports: [AppCode, AppDocSectionText],
+    template: `
+        <app-docsectiontext>
+            <p>When dialog content depends on providers from a feature or lazy-loaded environment, pass the caller's <i>EnvironmentInjector</i> in the dialog configuration.</p>
+        </app-docsectiontext>
+        <app-code [code]="code" [hideToggleCode]="true"></app-code>
+    `
+})
+export class EnvironmentInjectorDoc {
+    code: Code = {
+        typescript: `
+import { Component, EnvironmentInjector, inject } from '@angular/core';
+import { DialogService } from '@openng/optimus-ui/dynamicdialog';
+import { FeatureDialogComponent } from './feature-dialog.component';
+
+@Component({
+    template: \`<button (click)="openDialog()">Open</button>\`,
+    providers: [DialogService]
+})
+export class FeaturePageComponent {
+    private readonly dialogService = inject(DialogService);
+    private readonly environmentInjector = inject(EnvironmentInjector);
+
+    openDialog() {
+        this.dialogService.open(FeatureDialogComponent, {
+            environmentInjector: this.environmentInjector
+        });
+    }
+}`
+    };
+}

--- a/apps/docs/pages/dynamicdialog/index.ts
+++ b/apps/docs/pages/dynamicdialog/index.ts
@@ -1,6 +1,7 @@
 import { AppDoc } from '@/components/doc/app.doc';
 import { CloseDoc } from '@/doc/dynamicdialog/close-doc';
 import { CustomizationDoc } from '@/doc/dynamicdialog/customization-doc';
+import { EnvironmentInjectorDoc } from '@/doc/dynamicdialog/environmentinjector-doc';
 import { ExampleDoc } from '@/doc/dynamicdialog/example-doc';
 import { ImportDoc } from '@/doc/dynamicdialog/import-doc';
 import { OpenDoc } from '@/doc/dynamicdialog/open-doc';
@@ -43,6 +44,11 @@ export class DynamicDialogDemo {
             id: 'open',
             label: 'Opening a Dialog',
             component: OpenDoc
+        },
+        {
+            id: 'environmentinjector',
+            label: 'Feature Providers',
+            component: EnvironmentInjectorDoc
         },
         {
             id: 'customization',

--- a/apps/docs/public/llms/components/dynamicdialog.md
+++ b/apps/docs/public/llms/components/dynamicdialog.md
@@ -10,6 +10,10 @@ Most of the time, requirement is returning a value from the dialog. DialogRef's 
 
 DynamicDialog uses the Dialog component internally, visit dialog for more information about the available props.
 
+## Feature Providers
+
+When dialog content depends on providers from a feature or lazy-loaded environment, pass the caller's EnvironmentInjector in the dialog configuration.
+
 ## Example
 
 Dynamic dialogs require an instance of a DialogService that is responsible for displaying a dialog with a component as its content. Calling open method of DialogService will display dynamic dialog. First parameter of open method is the type of component to load and the second parameter is the configuration of the Dialog such as header , width and more.

--- a/packages/optimus-ui/src/dynamicdialog/dialogservice.repro.test.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dialogservice.repro.test.ts
@@ -1,0 +1,67 @@
+import { ApplicationRef, Component, createComponent, createNgModule, EnvironmentInjector, Injectable, NgModule, provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { DialogService } from './dialogservice';
+import { DynamicDialog } from './dynamicdialog';
+import { DynamicDialogConfig } from './dynamicdialog-config';
+
+@Injectable()
+class ReproScopedService {
+    readonly value = 'provided by the feature module';
+}
+
+@Component({
+    standalone: false,
+    template: '',
+    providers: [DialogService]
+})
+class ReproFeatureHostComponent {}
+
+@Component({
+    standalone: false,
+    template: '<span>{{ scopedService.value }}</span>'
+})
+class ReproDialogContentComponent {
+    constructor(public scopedService: ReproScopedService) {}
+}
+
+@NgModule({
+    declarations: [ReproFeatureHostComponent, ReproDialogContentComponent],
+    providers: [ReproScopedService]
+})
+class ReproFeatureModule {}
+
+describe('DialogService issue #631 reproduction', () => {
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [DynamicDialog],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+    });
+
+    it('should create dialog content with the configured feature environment injector', () => {
+        const appRef = TestBed.inject(ApplicationRef);
+        const featureModule = createNgModule(ReproFeatureModule, TestBed.inject(EnvironmentInjector));
+        const hostRef = createComponent(ReproFeatureHostComponent, { environmentInjector: featureModule.injector });
+        let dialogRef: ReturnType<DialogService['open']> | undefined;
+
+        appRef.attachView(hostRef.hostView);
+        hostRef.changeDetectorRef.detectChanges();
+
+        try {
+            const dialogService = hostRef.injector.get(DialogService);
+            const config = new DynamicDialogConfig() as DynamicDialogConfig & { environmentInjector: EnvironmentInjector };
+            config.environmentInjector = featureModule.injector;
+            dialogRef = dialogService.open(ReproDialogContentComponent, config);
+
+            expect(dialogRef).toBeTruthy();
+            expect(() => appRef.tick()).not.toThrow();
+
+            const dialogInstance = dialogRef && dialogService.getInstance(dialogRef);
+            expect(dialogInstance?.componentRef?.instance.scopedService.value).toBe('provided by the feature module');
+        } finally {
+            dialogRef?.destroy();
+            hostRef.destroy();
+            featureModule.destroy();
+        }
+    });
+});

--- a/packages/optimus-ui/src/dynamicdialog/dialogservice.repro.test.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dialogservice.repro.test.ts
@@ -49,7 +49,7 @@ describe('DialogService issue #631 reproduction', () => {
 
         try {
             const dialogService = hostRef.injector.get(DialogService);
-            const config = new DynamicDialogConfig() as DynamicDialogConfig & { environmentInjector: EnvironmentInjector };
+            const config = new DynamicDialogConfig();
             config.environmentInjector = featureModule.injector;
             dialogRef = dialogService.open(ReproDialogContentComponent, config);
 

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog-config.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog-config.ts
@@ -1,4 +1,4 @@
-import { Type } from '@angular/core';
+import { EnvironmentInjector, Type } from '@angular/core';
 import type { DialogPassThrough } from '@openng/optimus-ui/types/dialog';
 
 /**
@@ -6,6 +6,11 @@ import type { DialogPassThrough } from '@openng/optimus-ui/types/dialog';
  * @group Components
  */
 export class DynamicDialogConfig<DataType = any, InputValuesType extends Record<string, any> = {}> {
+    /**
+     * Environment injector used to create the dynamically loaded component. Use the injector from the caller's feature or lazy-loaded environment when the component depends on providers scoped there.
+     * @group Props
+     */
+    environmentInjector?: EnvironmentInjector;
     /**
      * An object to pass to the component loaded inside the Dialog.
      * @group Props

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
@@ -292,7 +292,8 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
         let viewContainerRef = this.insertionPoint?.viewContainerRef;
         viewContainerRef?.clear();
 
-        this.componentRef = viewContainerRef?.createComponent(componentType);
+        const environmentInjector = this.ddconfig.environmentInjector;
+        this.componentRef = environmentInjector ? viewContainerRef?.createComponent(componentType, { environmentInjector }) : viewContainerRef?.createComponent(componentType);
 
         if (this.inputValues && this.componentRef) {
             Object.entries(this.inputValues).forEach(([key, value]) => {


### PR DESCRIPTION
## Description

  Fixes DynamicDialog dependency injection for content that depends on providers scoped to a feature or lazy-loaded
  environment.

  Before this change, DynamicDialog created its content without the caller’s `EnvironmentInjector`, so feature-scoped
  providers could fail with `NG0201: No provider found`.

  This adds the optional `DynamicDialogConfig.environmentInjector` property and uses it when creating dialog content.
  Existing behavior is unchanged when the option is omitted.

  ## Related issues

  Fixes #631

  ## Type of change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that changes the public API)
  - [ ] Documentation only
  - [ ] Refactor, test, or chore (no user-facing change)

  ## Breaking changes

  None.

  ## Test plan

  - [x] Focused regression test:
    `pnpm --filter @openng/optimus-ui exec ng run optimus-ui:test-vitest --watch=false --include=src/dynamicdialog/
    dialogservice.repro.test.ts`
  - [x] Existing DynamicDialog suite: 51 tests passed.
  - [x] Documentation LLM generation and demo-code checks passed.
  - [x] Documentation app build completed successfully.
  - [ ] `pnpm run lint` — attempted, but the repository’s ESLint 9 flat-config setup rejects the configured `--ignore-
  path` option before linting begins.
  - [ ] `pnpm run test:unit` — attempted; the new regression passed, but two unrelated tests failed locally: Toast’s
  non-sticky timeout test and an OrderList performance threshold. OrderList passed when rerun in isolation; Toast
  reproduced independently.
  - [ ] Verified in the demo app manually.

  ## Checklist

  - [x] Issue discussed or bug clearly described (link issue when applicable)
  - [x] Tests added or updated for behavioral changes
  - [x] Documentation updated (README, JSDoc, migration notes as needed)
  - [x] Public API changes documented; breaking changes called out
  - [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  - [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/
  main/CODE_OF_CONDUCT.md)

  ## Additional context

  The first commit intentionally adds the regression test before the implementation, demonstrating the failing
  `NG0201` behavior. The following fix commit makes that test pass.

  AI assistance was used for initial investigation and drafting. I reviewed, edited, and validated the final changes
  myself. No AI co-author trailer was added to commits.