### PR TITLE
Fix/autocomplete null option label

### DIFF
--- a/apps/docs/doc/autocomplete/objects-doc.ts
+++ b/apps/docs/doc/autocomplete/objects-doc.ts
@@ -19,6 +19,7 @@ interface AutoCompleteCompleteEvent {
                 AutoComplete can also work with objects using the <i>optionLabel</i> property that defines the label to display as a suggestion. The value passed to the model would still be the object instance of a suggestion. Here is an example with
                 a Country object that has name and code fields such as <i>&#123;name: "United States", code:"USA"&#125;</i>.
             </p>
+            <p>When <i>optionLabel</i> resolves to <i>null</i> or <i>undefined</i> for a selected object, the input is displayed empty.</p>
         </app-docsectiontext>
         <div class="card flex justify-center">
             <p-autocomplete [(ngModel)]="selectedCountry" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" optionLabel="name" />

--- a/apps/docs/public/llms/components/autocomplete.md
+++ b/apps/docs/public/llms/components/autocomplete.md
@@ -640,7 +640,7 @@ export class AutocompleteMultipleDemo {
 
 ## Objects
 
-AutoComplete can also work with objects using the optionLabel property that defines the label to display as a suggestion. The value passed to the model would still be the object instance of a suggestion. Here is an example with a Country object that has name and code fields such as &#123;name: "United States", code:"USA"&#125; .
+AutoComplete can also work with objects using the optionLabel property that defines the label to display as a suggestion. The value passed to the model would still be the object instance of a suggestion. Here is an example with a Country object that has name and code fields such as &#123;name: "United States", code:"USA"&#125; . When optionLabel resolves to null or undefined for a selected object, the input is displayed empty.
 
 ```typescript
 import { Component, OnInit, inject } from '@angular/core';

--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -662,9 +662,9 @@ describe('AutoComplete', () => {
             expect(labelResult).toBe('Custom Afghanistan');
         });
 
-        it('should render an empty input when optionLabel resolves to null', async () => {
+        it.each([null, undefined])('should render an empty input when optionLabel resolves to %s', async (name) => {
             fixture.componentRef.setInput('optionLabel', 'name');
-            component.writeValue({ name: null, code: null });
+            component.writeValue({ name, code: null });
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 

--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -662,6 +662,16 @@ describe('AutoComplete', () => {
             expect(labelResult).toBe('Custom Afghanistan');
         });
 
+        it('should render an empty input when optionLabel resolves to null', async () => {
+            fixture.componentRef.setInput('optionLabel', 'name');
+            component.writeValue({ name: null, code: null });
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+
+            const inputElement = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+            expect(inputElement.value).toBe('');
+        });
+
         it('should work with optionValue as string', async () => {
             testComponent.optionValue = 'code';
             testComponent.suggestions = testComponent.objectOptions;

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -910,7 +910,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
                 const label = this.getOptionLabel(selectedOption);
 
-                return label != null ? label : modelValue;
+                return label != null ? label : typeof modelValue === 'object' ? '' : modelValue;
             } else {
                 return modelValue;
             }

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -583,7 +583,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     }
 
     /**
-     * Property name or getter function to use as the label of an option.
+     * Property name or getter function to use as the label of an option. If it resolves to null or undefined for a selected object, the input is rendered empty.
      * @group Props
      */
     @Input() optionLabel: string | ((item: T) => string) | undefined;


### PR DESCRIPTION
## Description

  Fixes Autocomplete rendering `[object Object]` when a selected object’s `optionLabel` resolves to `null` or `undefined`.

  Selected objects with a missing label now render as an empty input. Valid labels and primitive model values retain their
  existing behavior.

  ## Related issues

  Fixes #901

  ## Type of change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that changes the public API)
  - [ ] Documentation only
  - [ ] Refactor, test, or chore (no user-facing change)

  ## Breaking changes

  None

  ## Test plan

  - [x] Added browser regression coverage for `null` and `undefined` `optionLabel` values
  - [x] Ran the focused Autocomplete test suite: 136 tests passing
  - [x] Ran documentation checks and documentation build
  - [ ] `npm run build` — this repository uses pnpm workspace commands
  - [ ] `npm test` — full suite has 3 unrelated existing failures in Toast/Tooltip
  - [ ] `npm run lint` — currently blocked by the repository ESLint flat-config incompatibility
  - [ ] Verified in the demo app (not applicable)

  ## Checklist

  - [x] Issue discussed or bug clearly described (Fixes #901)
  - [x] Tests added or updated for behavioral changes
  - [x] Documentation updated (README, JSDoc, migration notes as needed)
  - [x] Public API changes documented; breaking changes called out
  - [ ] CHANGELOG updated (not maintained for this change)
  - [x] Commit messages follow Conventional Commits
  - [x] I agree to follow the OpenNG Foundation Code of Conduct

  ## Additional context

  The commits are intentionally split into a failing regression test, the implementation, and documentation:

  1. `test(autocomplete): cover null option labels`
  2. `fix(autocomplete): avoid rendering null option labels`
  3. `docs(autocomplete): clarify missing option labels`

  AI assistance was used for investigation and implementation; all changes were reviewed and tested by the contributor.