### PR TITLE
Fix/dialog append to target

### DIFF
--- a/packages/optimus-ui/src/dialog/dialog.test.ts
+++ b/packages/optimus-ui/src/dialog/dialog.test.ts
@@ -273,6 +273,19 @@ class TestAccessibilityDialogComponent {
     focusTrap = true;
 }
 
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <div class="append-target" #appendTarget>
+            <p-dialog [(visible)]="visible" [appendTo]="appendTarget" [modal]="true">Dialog content</p-dialog>
+        </div>
+    `
+})
+class TestAppendToDialogComponent {
+    visible = true;
+}
+
 describe('Dialog', () => {
     let component: TestBasicDialogComponent;
     let fixture: ComponentFixture<TestBasicDialogComponent>;
@@ -280,7 +293,16 @@ describe('Dialog', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [TestBasicDialogComponent, TestPTemplateDialogComponent, TestHashTemplateDialogComponent, TestHeadlessDialogComponent, TestPositionDialogComponent, TestMaximizableDialogComponent, TestAccessibilityDialogComponent],
+            declarations: [
+                TestBasicDialogComponent,
+                TestPTemplateDialogComponent,
+                TestHashTemplateDialogComponent,
+                TestHeadlessDialogComponent,
+                TestPositionDialogComponent,
+                TestMaximizableDialogComponent,
+                TestAccessibilityDialogComponent,
+                TestAppendToDialogComponent
+            ],
             imports: [Dialog, ButtonModule, FocusTrap],
             providers: [provideZonelessChangeDetection()]
         }).compileComponents();
@@ -333,6 +355,18 @@ describe('Dialog', () => {
             expect(dialogInstance.draggable).toBe(false);
             expect(dialogInstance.maximizable).toBe(true);
             expect(dialogInstance.position).toBe('top');
+        });
+    });
+
+    describe('Append Target', () => {
+        it('should append the dialog mask to an element target', async () => {
+            const appendToFixture = TestBed.createComponent(TestAppendToDialogComponent);
+            await appendToFixture.whenStable();
+
+            const target = appendToFixture.nativeElement.querySelector('.append-target') as HTMLElement;
+            const mask = target.querySelector('.p-dialog-mask');
+
+            expect(mask).toBeTruthy();
         });
     });
 

--- a/packages/optimus-ui/src/dialog/dialog.ts
+++ b/packages/optimus-ui/src/dialog/dialog.ts
@@ -1076,8 +1076,12 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
     }
 
     appendContainer() {
-        if (this.$appendTo() !== 'self') {
-            appendChild(this.document.body, this.wrapper as HTMLElement);
+        if (this.$appendTo() && this.$appendTo() !== 'self') {
+            if (this.$appendTo() === 'body') {
+                appendChild(this.document.body, this.wrapper as HTMLElement);
+            } else {
+                appendChild(this.$appendTo(), this.wrapper as HTMLElement);
+            }
         }
     }
 


### PR DESCRIPTION
 ## Description

  Fixes `p-dialog` ignoring an element passed to `appendTo` and always appending its mask to `document.body`.

  The dialog now appends to the supplied element target, while existing `body` and `self` behavior remains unchanged.

  ## Related issues

  Fixes #1613

  ## Type of change

  - [x] Bug fix (non-breaking change that fixes an issue)

  ## Breaking changes

  None

  ## Test plan

  - [x] Added a browser-backed regression test for element `appendTo` targets
  - [x] `pnpm --filter @openng/optimus-ui exec ng run optimus-ui:test-vitest --watch=false --include src/dialog/dialog.test.ts` — 80 tests passing
  - [x] `pnpm run build:lib` — passed
  - [ ] `pnpm run test:unit` — unrelated failures in Toast, OrderList, and Tooltip (7 failures total)
  - [ ] `pnpm --filter @openng/optimus-ui lint` — blocked because `@angular-eslint/builder` is unavailable in the workspace
  - [ ] Verified in the demo app (not applicable)

  ## Checklist

  - [x] Issue clearly described (Fixes #1613)
  - [x] Tests added for the behavioral change
  - [x] Commit messages follow Conventional Commits
  - [ ] CHANGELOG updated (not maintained for this change)
