### PR TITLE
fix(button): respect iconPos for custom icons

### DIFF
--- a/apps/docs/doc/button/directive-doc.ts
+++ b/apps/docs/doc/button/directive-doc.ts
@@ -10,6 +10,7 @@ import { ButtonModule } from '@openng/optimus-ui/button';
     template: `
         <app-docsectiontext>
             <p>Button can also be used as directive using <i>pButton</i> along with <i>pButtonLabel</i> and <i>pButtonIcon</i> helper directives.</p>
+            <p>Apply <i>pButtonIcon</i> to custom icon elements so they follow the button's <i>iconPos</i> layout.</p>
         </app-docsectiontext>
         <div class="card flex justify-center">
             <button pButton>

--- a/packages/optimus-ui/src/button/button.test.ts
+++ b/packages/optimus-ui/src/button/button.test.ts
@@ -185,6 +185,19 @@ class TestButtonDirectiveComponent {
 })
 class TestButtonWithIconLabelDirectiveComponent {}
 
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <p-button label="Custom icon" [iconPos]="iconPos">
+            <span pButtonIcon class="custom-icon"></span>
+        </p-button>
+    `
+})
+class TestButtonWithPositionedIconDirectiveComponent {
+    iconPos: 'left' | 'right' | 'top' | 'bottom' = 'right';
+}
+
 // Loading Button Test
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -282,6 +295,7 @@ describe('Button', () => {
                 TestContentTemplateButtonComponent,
                 TestButtonDirectiveComponent,
                 TestButtonWithIconLabelDirectiveComponent,
+                TestButtonWithPositionedIconDirectiveComponent,
                 TestLoadingButtonComponent,
                 TestSeverityButtonComponent,
                 TestButtonVariantsComponent,
@@ -1488,7 +1502,7 @@ describe('ButtonDirective', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [TestButtonDirectiveComponent, TestButtonWithIconLabelDirectiveComponent],
+            declarations: [TestButtonDirectiveComponent, TestButtonWithIconLabelDirectiveComponent, TestButtonWithPositionedIconDirectiveComponent],
             imports: [Button, ButtonDirective, ButtonIcon, ButtonLabel],
             providers: [provideZonelessChangeDetection()]
         }).compileComponents();
@@ -1562,6 +1576,23 @@ describe('ButtonDirective', () => {
 
             expect(iconNativeElement.classList.contains('p-button-icon')).toBe(true);
             expect(labelNativeElement.classList.contains('p-button-label')).toBe(true);
+        });
+
+        it('should apply icon position classes to custom icons', async () => {
+            const positionedIconFixture = TestBed.createComponent(TestButtonWithPositionedIconDirectiveComponent);
+            const positionedIconComponent = positionedIconFixture.componentInstance;
+            positionedIconFixture.detectChanges();
+            await positionedIconFixture.whenStable();
+
+            const iconElement = positionedIconFixture.debugElement.query(By.directive(ButtonIcon)).nativeElement as HTMLElement;
+            expect(iconElement.classList.contains('p-button-icon-right')).toBe(true);
+
+            positionedIconComponent.iconPos = 'bottom';
+            positionedIconFixture.changeDetectorRef.markForCheck();
+            await positionedIconFixture.whenStable();
+            positionedIconFixture.detectChanges();
+
+            expect(iconElement.classList.contains('p-button-icon-bottom')).toBe(true);
         });
     });
 

--- a/packages/optimus-ui/src/button/button.ts
+++ b/packages/optimus-ui/src/button/button.ts
@@ -110,12 +110,20 @@ export class ButtonLabel extends BaseComponent {
     providers: [ButtonStyle, { provide: BUTTON_ICON_INSTANCE, useExisting: ButtonIcon }, { provide: PARENT_INSTANCE, useExisting: ButtonIcon }],
     standalone: true,
     host: {
-        '[class.p-button-icon]': '!$unstyled() && true'
+        '[class.p-button-icon]': '!$unstyled() && true',
+        '[class.p-button-icon-left]': "!$unstyled() && iconPos === 'left'",
+        '[class.p-button-icon-right]': "!$unstyled() && iconPos === 'right'",
+        '[class.p-button-icon-top]': "!$unstyled() && iconPos === 'top'",
+        '[class.p-button-icon-bottom]': "!$unstyled() && iconPos === 'bottom'"
     },
     hostDirectives: [Bind]
 })
 export class ButtonIcon extends BaseComponent {
     componentName = 'ButtonIcon';
+
+    get iconPos(): ButtonIconPosition | undefined {
+        return (this.$parentInstance as Button | undefined)?.iconPos;
+    }
 
     /**
      * Used to pass attributes to DOM elements inside the pButtonIcon.


### PR DESCRIPTION
## Description

Fixes custom `pButtonIcon` elements ignoring a button's `iconPos` setting. Custom icons now receive the same positional classes as built-in icons, so right, bottom, and other configured layouts work as expected. Existing built-in icon behavior and the public API are unchanged.

## Related issues

Fixes #344

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking changes

None

## Test plan

- [x] Added a regression test for `pButtonIcon` with `right` and `bottom` positions
- [x] `pnpm --filter @openng/optimus-ui exec ng run optimus-ui:test-vitest --watch=false --include src/button/button.test.ts` — 83 tests passing
- [x] `pnpm --filter docs build` — passed (118 routes prerendered; existing SSR `document`/`window` diagnostics were emitted)
- [x] `pnpm run build:lib` — passed
- [ ] `pnpm run test:unit` — completed with 3 unrelated failures: OrderList large-dataset performance, Rating frequent-value-change performance, and Toast non-sticky timeout initialization
- [ ] `pnpm --filter @openng/optimus-ui lint` — blocked before linting because `@angular-eslint/builder:lint` is not installed
- [ ] Verified in the demo app (not applicable; browser-backed component test covers the regression)

## Checklist

- [x] Issue discussed or bug clearly described (Fixes #344)
- [x] Tests added or updated for behavioral changes
- [x] Documentation updated
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Commits are intentionally split so the regression is independently reviewable:

1. `test(button): cover custom icon positions`
2. `fix(button): position custom icons`
3. `docs(button): explain custom icon positioning`
