### PR TITLE
fix(chart): type data select events

### DIFF
--- a/apps/docs/doc/chart/props-doc.ts
+++ b/apps/docs/doc/chart/props-doc.ts
@@ -59,7 +59,7 @@ import { Component } from '@angular/core';
                     </tr>
                     <tr>
                         <td>onDataSelect</td>
-                        <td>function</td>
+                        <td>(event: ChartDataSelectEvent) =&gt; void</td>
                         <td>null</td>
                         <td>Callback to execute when an element on chart is clicked.</td>
                     </tr>

--- a/packages/optimus-ui/src/chart/chart.test.ts
+++ b/packages/optimus-ui/src/chart/chart.test.ts
@@ -1,0 +1,15 @@
+import type { ActiveElement, ChartDataset } from 'chart.js';
+import { describe, expect, it } from 'vitest';
+import type { ChartDataSelectEvent } from '@openng/optimus-ui/types/chart';
+
+describe('ChartDataSelectEvent', () => {
+    it('should expose the typed Chart.js selection payload', () => {
+        const event: ChartDataSelectEvent<'bar'> = {
+            originalEvent: new MouseEvent('click'),
+            element: {} as ActiveElement,
+            dataset: {} as ChartDataset<'bar'>
+        };
+
+        expect(event.dataset).toBeDefined();
+    });
+});

--- a/packages/optimus-ui/src/chart/chart.ts
+++ b/packages/optimus-ui/src/chart/chart.ts
@@ -5,7 +5,7 @@ import { SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent } from '@openng/optimus-ui/basecomponent';
 import { ChartStyle } from './style/chartstyle';
 import { Bind, BindModule } from '@openng/optimus-ui/bind';
-import type { ChartPassThrough } from '@openng/optimus-ui/types/chart';
+import type { ChartDataSelectEvent, ChartPassThrough } from '@openng/optimus-ui/types/chart';
 
 const CHART_INSTANCE = new InjectionToken<UIChart>('CHART_INSTANCE');
 
@@ -109,7 +109,7 @@ export class UIChart extends BaseComponent<ChartPassThrough> {
      * Callback to execute when an element on chart is clicked.
      * @group Emits
      */
-    @Output() onDataSelect: EventEmitter<any> = new EventEmitter<any>();
+    @Output() onDataSelect: EventEmitter<ChartDataSelectEvent> = new EventEmitter<ChartDataSelectEvent>();
 
     isBrowser: boolean = false;
 
@@ -135,7 +135,7 @@ export class UIChart extends BaseComponent<ChartPassThrough> {
         this.initialized = true;
     }
 
-    onCanvasClick(event: Event) {
+    onCanvasClick(event: MouseEvent) {
         if (this.chart) {
             const element = this.chart.getElementsAtEventForMode(event, 'nearest', { intersect: true }, false);
             const dataset = this.chart.getElementsAtEventForMode(event, 'dataset', { intersect: true }, false);

--- a/packages/optimus-ui/src/chart/public_api.ts
+++ b/packages/optimus-ui/src/chart/public_api.ts
@@ -1,2 +1,3 @@
 export * from './chart';
 export * from './style/chartstyle';
+export * from '@openng/optimus-ui/types/chart';

--- a/packages/optimus-ui/src/types/chart/chart.types.ts
+++ b/packages/optimus-ui/src/types/chart/chart.types.ts
@@ -1,4 +1,26 @@
 import type { PassThrough, PassThroughOption } from '@openng/optimus-ui/api';
+import type { ActiveElement, ChartDataset, ChartTypeRegistry } from 'chart.js';
+
+/**
+ * Data selection event emitted when a chart element is clicked.
+ *
+ * @template T Chart.js chart type.
+ * @group Events
+ */
+export interface ChartDataSelectEvent<T extends keyof ChartTypeRegistry = keyof ChartTypeRegistry> {
+    /**
+     * Browser click event.
+     */
+    originalEvent: MouseEvent;
+    /**
+     * Selected chart element.
+     */
+    element: ActiveElement;
+    /**
+     * Selected dataset.
+     */
+    dataset: ChartDataset<T>;
+}
 
 /**
  * Custom pass-through(pt) options.


### PR DESCRIPTION
## Description

Fixes the untyped `onDataSelect` output in `p-chart`. Consumers now receive the generic `ChartDataSelectEvent<T>` payload, including the browser event, selected element, and Chart.js dataset. Existing runtime behavior is unchanged.

## Related issues

Fixes #394

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Breaking changes

None

## Test plan

- [x] Added a type-level regression test for `ChartDataSelectEvent<'bar'>`
- [x] `pnpm --filter @openng/optimus-ui exec ng run optimus-ui:test-vitest --watch=false --include src/chart/chart.test.ts` — 1 test passing
- [x] `pnpm exec prettier --check packages/optimus-ui/src/chart/chart.ts packages/optimus-ui/src/chart/chart.test.ts packages/optimus-ui/src/chart/public_api.ts packages/optimus-ui/src/types/chart/chart.types.ts apps/docs/doc/chart/props-doc.ts` — passed
- [x] `pnpm --filter docs build` — passed (118 routes prerendered; existing SSR `document`/`window` diagnostics were emitted)
- [x] `pnpm run build:lib` — passed
- [ ] `pnpm run test:unit` — 7,275 tests passed; 2 unrelated baseline failures remain in OrderList performance and Toast timeout timing
- [ ] `pnpm --filter @openng/optimus-ui lint` — blocked before linting because `@angular-eslint/builder:lint` is not installed
- [ ] Verified in the demo app (not applicable; this is a public type contract)

## Checklist

- [x] Issue discussed or bug clearly described (Fixes #394)
- [x] Tests added or updated for behavioral changes
- [x] Documentation updated
- [x] Public API changes documented; breaking changes called out
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Commits are intentionally split so the regression is independently reviewable:

1. `test(chart): cover typed data select events`
2. `fix(chart): type data select events`
3. `docs(chart): describe data select event type`
