### PR TITLE
fix(inputnumber): style spinner buttons when disabled

### DIFF
--- a/packages/optimus-ui/src/inputnumber/inputnumber.test.ts
+++ b/packages/optimus-ui/src/inputnumber/inputnumber.test.ts
@@ -545,6 +545,18 @@ describe('InputNumber', () => {
             expect(_decrementBtn.nativeElement.hasAttribute('disabled')).toBe(true);
         });
 
+        it('should apply disabled styling to buttons when component is disabled', async () => {
+            testComponent.disabled = true;
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            const incrementBtn = testFixture.debugElement.query(By.css('[data-pc-section="incrementbutton"]'));
+            const decrementBtn = testFixture.debugElement.query(By.css('[data-pc-section="decrementbutton"]'));
+
+            expect(incrementBtn.nativeElement.classList.contains('p-disabled')).toBe(true);
+            expect(decrementBtn.nativeElement.classList.contains('p-disabled')).toBe(true);
+        });
+
         it('should handle different button layouts', async () => {
             testComponent.buttonLayout = 'horizontal';
             testFixture.changeDetectorRef.markForCheck();

--- a/packages/optimus-ui/src/inputnumber/style/inputnumberstyle.ts
+++ b/packages/optimus-ui/src/inputnumber/style/inputnumberstyle.ts
@@ -43,13 +43,13 @@ const classes = {
     incrementButton: ({ instance }) => [
         'p-inputnumber-button p-inputnumber-increment-button',
         {
-            'p-disabled': instance.showButtons && instance.max() != null && instance.maxlength()
+            'p-disabled': instance.$disabled() || (instance.showButtons && instance.max() != null && instance.maxlength())
         }
     ],
     decrementButton: ({ instance }) => [
         'p-inputnumber-button p-inputnumber-decrement-button',
         {
-            'p-disabled': instance.showButtons && instance.min() != null && instance.minlength()
+            'p-disabled': instance.$disabled() || (instance.showButtons && instance.min() != null && instance.minlength())
         }
     ],
     clearIcon: 'p-inputnumber-clear-icon'


### PR DESCRIPTION
## Description

Fixes missing disabled styling on InputNumber increment/decrement buttons when the component is disabled and `showButtons` is enabled.

Both spinner buttons now receive the shared `p-disabled` styling, including reduced opacity, disabled pointer interaction, and the default cursor. Existing enabled and boundary behavior remains unchanged.

## Related issues

Fixes #653

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [x] Added or updated a regression test for disabled spinner button styling
- [x] `pnpm --filter @openng/optimus-ui exec ng run optimus-ui:test-vitest --watch=false --include src/inputnumber/inputnumber.test.ts` — 83 tests passing
- [ ] Documentation build — not applicable; no documentation changes
- [x] `pnpm run build:lib` — passed
- [ ] Full unit suite — not run
- [ ] `pnpm --filter @openng/optimus-ui lint` — blocked because `@angular-eslint/builder:lint` is missing from the repository dependencies
- [ ] Verified in the demo app — not applicable; covered by the browser-backed component test

## Checklist

- [x] Issue discussed or bug clearly described (Fixes #653)
- [x] Tests added or updated for behavioral changes
- [ ] Documentation updated (not needed for this styling fix)
- [x] Public API changes documented; breaking changes called out (no public API changes)
- [ ] CHANGELOG updated (not maintained for this change)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Commits are intentionally split so the regression is independently reviewable:

1. `test(inputnumber): cover disabled spinner button styling`
2. `fix(inputnumber): style spinner buttons when disabled`
