### PR TITLE
fix(table): preserve expanded row footer border

### DIFF
--- a/packages/optimus-ui-styles/src/datatable/index.ts
+++ b/packages/optimus-ui-styles/src/datatable/index.ts
@@ -501,12 +501,20 @@ export const style = /*css*/ `
         border-width: 0 1px 1px 1px;
     }
 
-    .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
+    .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:not(.p-datatable-row-expansion):last-child > td {
         border-width: 0 0 0 1px;
     }
 
-    .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
+    .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:not(.p-datatable-row-expansion):last-child > td:last-child {
         border-width: 0 1px 0 1px;
+    }
+
+    .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr.p-datatable-row-expansion > td {
+        border-width: 1px 0 1px 1px !important;
+    }
+
+    .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr.p-datatable-row-expansion > td:last-child {
+        border-width: 1px !important;
     }
 
     .p-datatable.p-datatable-striped .p-datatable-tbody > tr.p-row-odd {

--- a/packages/optimus-ui/src/table/style/tablestyle.ts
+++ b/packages/optimus-ui/src/table/style/tablestyle.ts
@@ -5,6 +5,15 @@ import { BaseStyle } from '@openng/optimus-ui/base';
 const style = /*css*/ `
 ${datatable_style}
 
+/* Keep the final expanded row separated from the footer when gridlines are enabled. */
+.p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr.p-datatable-row-expansion > td {
+    border-width: 1px 0 1px 1px !important;
+}
+
+.p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr.p-datatable-row-expansion > td:last-child {
+    border-width: 1px !important;
+}
+
 /* For Optimus */
 .p-datatable-scrollable-table > .p-datatable-thead {
     top: 0;

--- a/packages/optimus-ui/src/table/table.test.ts
+++ b/packages/optimus-ui/src/table/table.test.ts
@@ -377,6 +377,39 @@ describe('Table', () => {
         ];
     }
 
+    @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
+        standalone: false,
+        template: `
+            <p-table [value]="products" [dataKey]="'id'" [showGridlines]="true" [expandedRowKeys]="expandedRowKeys">
+                <ng-template #header
+                    ><tr>
+                        <th>Name</th>
+                    </tr></ng-template
+                >
+                <ng-template #body let-product
+                    ><tr>
+                        <td>{{ product.name }}</td>
+                    </tr></ng-template
+                >
+                <ng-template #expandedrow let-product
+                    ><tr class="p-datatable-row-expansion">
+                        <td>Details for {{ product.name }}</td>
+                    </tr></ng-template
+                >
+                <ng-template #footer
+                    ><tr>
+                        <td>Footer</td>
+                    </tr></ng-template
+                >
+            </p-table>
+        `
+    })
+    class TestExpandedRowFooterTableComponent {
+        products = [{ id: '1', name: 'Product' }];
+        expandedRowKeys = { '1': true };
+    }
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             declarations: [
@@ -391,7 +424,8 @@ describe('Table', () => {
                 TestScrollableNonVirtualTableComponent,
                 TestVirtualScrollFlexHeightTableComponent,
                 TestLazyLoadTableComponent,
-                TestTemplatesTableComponent
+                TestTemplatesTableComponent,
+                TestExpandedRowFooterTableComponent
             ],
             imports: [CommonModule, FormsModule, TableModule, SharedModule, Select],
             providers: [TableService, provideZonelessChangeDetection()]
@@ -676,6 +710,20 @@ describe('Table', () => {
         it('should display correct product count in summary', () => {
             const summaryText = testFixture.nativeElement.textContent;
             expect(summaryText).toContain('Total Products: 2');
+        });
+    });
+
+    describe('Row Expansion and Gridlines', () => {
+        it('should keep the bottom border on the last expanded row before the footer', async () => {
+            const testFixture = TestBed.createComponent(TestExpandedRowFooterTableComponent);
+            testFixture.detectChanges();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const expansionCell = testFixture.nativeElement.querySelector('.p-datatable-row-expansion > td');
+
+            expect(expansionCell).toBeTruthy();
+            expect(getComputedStyle(expansionCell).borderBottomWidth).toBe('1px');
         });
     });
 


### PR DESCRIPTION
## Description

Fixes the missing bottom border on the final expanded row in `p-table` when gridlines and a footer are enabled.

The gridline spacing rule now excludes expansion rows, and expanded rows receive an explicit complete border so the detail content remains visually separated from the footer. Tables without expanded rows retain their existing footer spacing.

## Related issues

Fixes #951

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [x] Added or updated a regression test for the expanded-row footer border
- [x] `pnpm --filter @openng/optimus-ui exec ng run optimus-ui:test-vitest --watch=false --include src/table/table.test.ts` — 73 tests passing
- [ ] Documentation build — not applicable; no documentation changes
- [x] `pnpm run build:lib` — passed
- [ ] Full unit suite — not run
- [ ] `pnpm --filter @openng/optimus-ui lint` — blocked because `@angular-eslint/builder:lint` is missing from the repository dependencies
- [x] Verified in the browser-backed component test

## Checklist

- [x] Issue discussed or bug clearly described (Fixes #951)
- [x] Tests added or updated for behavioral changes
- [ ] Documentation updated (not needed for this CSS fix)
- [x] Public API changes documented; breaking changes called out (no public API changes)
- [ ] CHANGELOG updated (not maintained for this change)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Commits are intentionally split so the regression is independently reviewable:

1. `test(table): cover expanded row footer border`
2. `fix(table): preserve expanded row footer border`
