### PR TITLE
fix: correct chip behaviour in MultiSelect and AutoComplete

### DIFF
--- a/apps/docs/doc/autocomplete/accessibility-doc.ts
+++ b/apps/docs/doc/autocomplete/accessibility-doc.ts
@@ -14,7 +14,10 @@ import { Component } from '@angular/core';
                 <i>aria-autocomplete</i>, <i>aria-haspopup</i> and <i>aria-expanded</i> attributes. The relation between the input and the popup is created with <i>aria-controls</i> and <i>aria-activedescendant</i> attribute is used to instruct
                 screen reader which option to read during keyboard navigation within the popup list.
             </p>
-            <p>In multiple mode, chip list uses <i>listbox</i> role whereas each chip has the <i>option</i> role with <i>aria-label</i> set to the label of the chip.</p>
+            <p>
+                In multiple mode, chip list uses <i>listbox</i> role whereas each chip has the <i>option</i> role with <i>aria-label</i> set to the label of the chip. The chip list itself is labelled with the <i>aria.selectedItems</i> property of the
+                locale API so it is announced with a name of its own.
+            </p>
             <p>
                 The popup list has an id that refers to the <i>aria-controls</i> attribute of the input element and uses <i>listbox</i> as the role. Each list item has <i>option</i> role and an id to match the <i>aria-activedescendant</i> of the
                 input element.

--- a/apps/docs/doc/configuration/locale/apidoc.ts
+++ b/apps/docs/doc/configuration/locale/apidoc.ts
@@ -474,6 +474,10 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
                         <td>aria.rotateLeft</td>
                         <td>Rotate Left</td>
                     </tr>
+                    <tr>
+                        <td>aria.selectedItems</td>
+                        <td>Selected Items</td>
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/apps/docs/doc/multiselect/chips-doc.ts
+++ b/apps/docs/doc/multiselect/chips-doc.ts
@@ -18,7 +18,11 @@ interface City {
             <p>Selected values are displayed as a comma separated list by default, setting <i>display</i> as <i>chip</i> displays them as chips.</p>
         </app-docsectiontext>
         <div class="card flex justify-center">
-            <p-multiselect [options]="cities" [(ngModel)]="selectedCities" placeholder="Select Cities" optionLabel="name" display="chip" class="w-full md:w-80" />
+            <p-multiselect [options]="cities" [(ngModel)]="selectedCities" placeholder="Select Cities" optionLabel="name" display="chip" class="w-full md:w-80">
+                <ng-template #chipicon>
+                    <span class="pi pi-map-marker"></span>
+                </ng-template>
+            </p-multiselect>
         </div>
         <app-code></app-code>
     `

--- a/packages/optimus-ui/src/api/translation.ts
+++ b/packages/optimus-ui/src/api/translation.ts
@@ -132,6 +132,7 @@ export interface Aria {
     rotateRight?: string;
     rotateLeft?: string;
     listLabel?: string;
+    selectedItems?: string;
     selectColor?: string;
     removeLabel?: string;
     browseFiles?: string;

--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -1601,6 +1601,45 @@ describe('AutoComplete', () => {
             expect(inputElement.nativeElement.readOnly).toBe(true);
         });
 
+        it('should not offer a chip remove icon in readonly mode', async () => {
+            testComponent.multiple = true;
+            testComponent.readonly = true;
+            testComponent.selectedValue = [{ name: 'Item 1' }, { name: 'Item 2' }];
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const autocompleteInstance = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+            const chips = testFixture.debugElement.queryAll(By.css('p-chip'));
+
+            expect(chips.length).toBe(2);
+            expect(testFixture.debugElement.queryAll(By.css('.p-chip-remove-icon')).length).toBe(0);
+            expect(chips.every((chip) => chip.nativeElement.style.display !== 'none')).toBe(true);
+            expect(autocompleteInstance.modelValue().length).toBe(2);
+        });
+
+        it('should still remove a chip when the remove icon is clicked outside readonly mode', async () => {
+            testComponent.multiple = true;
+            testComponent.readonly = false;
+            testComponent.selectedValue = [{ name: 'Item 1' }, { name: 'Item 2' }];
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const autocompleteInstance = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+            const removeIcon = testFixture.debugElement.query(By.css('.p-chip-remove-icon'));
+
+            expect(removeIcon).toBeTruthy();
+
+            removeIcon.triggerEventHandler('click', new MouseEvent('click'));
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            expect(autocompleteInstance.modelValue().length).toBe(1);
+            expect(testFixture.debugElement.queryAll(By.css('p-chip')).length).toBe(1);
+        });
+
         it('should handle forceSelection mode', async () => {
             testComponent.forceSelection = true;
             testComponent.optionLabel = undefined as any; // Use string comparison for forceSelection

--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -2155,7 +2155,7 @@ describe('AutoComplete', () => {
                 const autocompleteComponent = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
                 const inputElement = testFixture.debugElement.query(By.css('input[role="combobox"]'));
 
-                inputElement.nativeElement.value = 'Item1,';
+                inputElement.nativeElement.value = '';
                 const preventDefault = vi.fn();
                 const pasteEvent = {
                     clipboardData: { getData: () => 'Item1,' },
@@ -2169,6 +2169,54 @@ describe('AutoComplete', () => {
                 expect(preventDefault).toHaveBeenCalled();
                 expect(inputElement.nativeElement.value).toBe('');
                 expect(testComponent.selectedValue).toEqual(['Item1']);
+            });
+
+            it('should keep text the user already typed when a paste adds nothing', async () => {
+                testComponent.selectedValue = ['Item1'];
+                testFixture.changeDetectorRef.markForCheck();
+                await testFixture.whenStable();
+
+                const autocompleteComponent = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+                const inputElement = testFixture.debugElement.query(By.css('input[role="combobox"]'));
+
+                inputElement.nativeElement.value = 'half-typed';
+                const preventDefault = vi.fn();
+                const pasteEvent = {
+                    clipboardData: { getData: () => 'Item1,' },
+                    target: inputElement.nativeElement,
+                    preventDefault
+                };
+
+                autocompleteComponent.onInputPaste(pasteEvent);
+                await testFixture.whenStable();
+
+                expect(preventDefault).toHaveBeenCalled();
+                expect(inputElement.nativeElement.value).toBe('half-typed');
+                expect(testComponent.selectedValue).toEqual(['Item1']);
+            });
+
+            it('should clear the input when a paste does add values', async () => {
+                testComponent.selectedValue = [];
+                testFixture.changeDetectorRef.markForCheck();
+                await testFixture.whenStable();
+
+                const autocompleteComponent = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+                const inputElement = testFixture.debugElement.query(By.css('input[role="combobox"]'));
+
+                inputElement.nativeElement.value = 'half-typed';
+                const preventDefault = vi.fn();
+                const pasteEvent = {
+                    clipboardData: { getData: () => 'Alpha,Beta,' },
+                    target: inputElement.nativeElement,
+                    preventDefault
+                };
+
+                autocompleteComponent.onInputPaste(pasteEvent);
+                await testFixture.whenStable();
+
+                expect(preventDefault).toHaveBeenCalled();
+                expect(inputElement.nativeElement.value).toBe('');
+                expect(testComponent.selectedValue).toEqual(['Alpha', 'Beta']);
             });
         });
 

--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -2091,6 +2091,85 @@ describe('AutoComplete', () => {
 
                 expect(testComponent.selectedValue).toBeNull();
             });
+
+            it('should consume the separator key when the value is already selected', async () => {
+                testComponent.selectedValue = ['Item1'];
+                testFixture.changeDetectorRef.markForCheck();
+                await testFixture.whenStable();
+
+                const autocompleteComponent = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+                const inputElement = testFixture.debugElement.query(By.css('input[role="combobox"]'));
+
+                inputElement.nativeElement.value = 'Item1';
+                const keydownEvent = new KeyboardEvent('keydown', { key: ',', cancelable: true });
+                Object.defineProperty(keydownEvent, 'target', { value: inputElement.nativeElement, writable: false });
+                autocompleteComponent.onKeyDown(keydownEvent);
+                await testFixture.whenStable();
+
+                expect(keydownEvent.defaultPrevented).toBe(true);
+                expect(inputElement.nativeElement.value).toBe('');
+                expect(testComponent.selectedValue).toEqual(['Item1']);
+            });
+
+            it('should consume the separator key when the input is empty', async () => {
+                testComponent.selectedValue = [];
+                testFixture.changeDetectorRef.markForCheck();
+                await testFixture.whenStable();
+
+                const autocompleteComponent = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+                const inputElement = testFixture.debugElement.query(By.css('input[role="combobox"]'));
+
+                inputElement.nativeElement.value = '';
+                const keydownEvent = new KeyboardEvent('keydown', { key: ',', cancelable: true });
+                Object.defineProperty(keydownEvent, 'target', { value: inputElement.nativeElement, writable: false });
+                autocompleteComponent.onKeyDown(keydownEvent);
+                await testFixture.whenStable();
+
+                expect(keydownEvent.defaultPrevented).toBe(true);
+                expect(testComponent.selectedValue).toEqual([]);
+            });
+
+            it('should split the input value on the separator instead of adding it verbatim', async () => {
+                testComponent.selectedValue = [];
+                testFixture.changeDetectorRef.markForCheck();
+                await testFixture.whenStable();
+
+                const autocompleteComponent = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+                const inputElement = testFixture.debugElement.query(By.css('input[role="combobox"]'));
+
+                inputElement.nativeElement.value = ',Item1,';
+                const keydownEvent = new KeyboardEvent('keydown', { key: ',', cancelable: true });
+                Object.defineProperty(keydownEvent, 'target', { value: inputElement.nativeElement, writable: false });
+                autocompleteComponent.onKeyDown(keydownEvent);
+                await testFixture.whenStable();
+
+                expect(testComponent.selectedValue).toEqual(['Item1']);
+                expect(inputElement.nativeElement.value).toBe('');
+            });
+
+            it('should not leave pasted separators in the input when nothing new is added', async () => {
+                testComponent.selectedValue = ['Item1'];
+                testFixture.changeDetectorRef.markForCheck();
+                await testFixture.whenStable();
+
+                const autocompleteComponent = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+                const inputElement = testFixture.debugElement.query(By.css('input[role="combobox"]'));
+
+                inputElement.nativeElement.value = 'Item1,';
+                const preventDefault = vi.fn();
+                const pasteEvent = {
+                    clipboardData: { getData: () => 'Item1,' },
+                    target: inputElement.nativeElement,
+                    preventDefault
+                };
+
+                autocompleteComponent.onInputPaste(pasteEvent);
+                await testFixture.whenStable();
+
+                expect(preventDefault).toHaveBeenCalled();
+                expect(inputElement.nativeElement.value).toBe('');
+                expect(testComponent.selectedValue).toEqual(['Item1']);
+            });
         });
 
         describe('combined addOnBlur and separator features', () => {

--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -1472,6 +1472,22 @@ describe('AutoComplete', () => {
             expect(ariaRequired === null || ariaRequired === 'false').toBe(true);
             expect(inputElement.nativeElement.getAttribute('aria-label')).toBeTruthy();
         });
+
+        it('should give the chip container an accessible name in multiple mode', async () => {
+            testComponent.multiple = true;
+            testComponent.selectedValue = [{ name: 'Item 1' }];
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+
+            const autocompleteInstance = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+            const chipContainer = testFixture.debugElement.query(By.css('ul.p-autocomplete-input-multiple'));
+
+            expect(chipContainer).toBeTruthy();
+            expect(chipContainer.nativeElement.getAttribute('role')).toBe('listbox');
+            expect(chipContainer.nativeElement.getAttribute('aria-label')).toBe(autocompleteInstance.selectedItemsLabel);
+            expect(chipContainer.nativeElement.getAttribute('aria-label')).toBe('Selected Items');
+        });
     });
 
     describe('Complex Situations and Edge Cases', () => {

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -1340,10 +1340,13 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         }
 
         // Same reasoning as handleSeparatorKey: the raw text must never reach the input, or its
-        // separators are left behind when every pasted value is a duplicate.
+        // separators are left behind when every pasted value is a duplicate. Only clear once the
+        // paste has committed something, so a paste that adds nothing leaves any typed text alone.
         event.preventDefault();
-        this.addSeparatedValues(this.splitBySeparator(pastedData), event);
-        this.clearMultipleInput(event);
+
+        if (this.addSeparatedValues(this.splitBySeparator(pastedData), event)) {
+            this.clearMultipleInput(event);
+        }
     }
 
     onInputKeyUp(event) {
@@ -1678,7 +1681,8 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         return (this.separator ? text.split(this.separator) : [text]).map((value) => value.trim()).filter((value) => value.length > 0);
     }
 
-    private addSeparatedValues(values: string[], event: Event): void {
+    /** Returns whether anything was actually added to the model. */
+    private addSeparatedValues(values: string[], event: Event): boolean {
         const added: string[] = [];
         const newValues = [...(this.modelValue() || [])];
 
@@ -1692,11 +1696,13 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         });
 
         if (!added.length) {
-            return;
+            return false;
         }
 
         this.updateModel(newValues);
         added.forEach((value) => this.onAdd.emit({ originalEvent: event, value }));
+
+        return true;
     }
 
     private clearMultipleInput(event: Event): void {

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -134,6 +134,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             [attr.data-p]="inputMultipleDataP"
             [tabindex]="-1"
             role="listbox"
+            [attr.aria-label]="selectedItemsLabel"
             [attr.aria-orientation]="'horizontal'"
             [attr.aria-activedescendant]="focused ? focusedMultipleOptionId : undefined"
             (focus)="onMultipleContainerFocus($event)"
@@ -957,6 +958,10 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     get listLabel(): string {
         return this.config.getTranslation(TranslationKeys.ARIA)['listLabel'];
+    }
+
+    get selectedItemsLabel(): string {
+        return this.config.getTranslation(TranslationKeys.ARIA)['selectedItems'];
     }
 
     get virtualScrollerDisabled() {

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -157,8 +157,8 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                     [class]="cx('pcChip')"
                     [label]="!selectedItemTemplate && !_selectedItemTemplate && getOptionLabel(option)"
                     [disabled]="$disabled()"
-                    [removable]="true"
-                    (onRemove)="!readonly ? removeOption($event, i) : ''"
+                    [removable]="!readonly && !$disabled()"
+                    (onRemove)="removeOption($event, i)"
                     [unstyled]="unstyled()"
                 >
                     <ng-container *ngTemplateOutlet="selectedItemTemplate || _selectedItemTemplate; context: { $implicit: option }"></ng-container>

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -1328,36 +1328,22 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     }
 
     onInputPaste(event) {
-        if (this.separator && this.multiple && !this.typeahead) {
-            const pastedData = (event.clipboardData || (window as any)['clipboardData'])?.getData('Text');
-            if (pastedData) {
-                const values = pastedData.split(this.separator);
-                const newValues = [...(this.modelValue() || [])];
-
-                values.forEach((value: string) => {
-                    const trimmedValue = value.trim();
-                    if (trimmedValue && !this.isSelected(trimmedValue)) {
-                        newValues.push(trimmedValue);
-                    }
-                });
-
-                if (newValues.length > (this.modelValue() || []).length) {
-                    const addedValues = newValues.slice((this.modelValue() || []).length);
-                    this.updateModel(newValues);
-                    addedValues.forEach((addedValue) => {
-                        this.onAdd.emit({ originalEvent: event, value: addedValue });
-                    });
-                    if (this.multiInputEl?.nativeElement) {
-                        this.multiInputEl.nativeElement.value = '';
-                    } else {
-                        event.target.value = '';
-                    }
-                    event.preventDefault();
-                }
-            }
-        } else {
+        if (!this.isSeparatorMode()) {
             this.onKeyDown(event);
+            return;
         }
+
+        const pastedData = (event.clipboardData || (window as any)['clipboardData'])?.getData('Text');
+
+        if (!pastedData) {
+            return;
+        }
+
+        // Same reasoning as handleSeparatorKey: the raw text must never reach the input, or its
+        // separators are left behind when every pasted value is a duplicate.
+        event.preventDefault();
+        this.addSeparatedValues(this.splitBySeparator(pastedData), event);
+        this.clearMultipleInput(event);
     }
 
     onInputKeyUp(event) {
@@ -1436,21 +1422,21 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     }
 
     handleSeparatorKey(event) {
-        if (this.separator && this.multiple && !this.typeahead) {
-            if (this.separator === event.key || (typeof this.separator === 'string' && event.key === this.separator) || (this.separator instanceof RegExp && event.key.match(this.separator))) {
-                const inputValue = (this.multiInputEl?.nativeElement?.value || event.target.value || '').trim();
-                if (inputValue && !this.isSelected(inputValue)) {
-                    this.updateModel([...(this.modelValue() || []), inputValue]);
-                    this.onAdd.emit({ originalEvent: event, value: inputValue });
-                    if (this.multiInputEl?.nativeElement) {
-                        this.multiInputEl.nativeElement.value = '';
-                    } else {
-                        event.target.value = '';
-                    }
-                    event.preventDefault();
-                }
-            }
+        if (!this.isSeparatorMode()) {
+            return;
         }
+
+        const isSeparatorKey = this.separator instanceof RegExp ? !!event.key.match(this.separator) : event.key === this.separator;
+
+        if (!isSeparatorKey) {
+            return;
+        }
+
+        // The separator is a delimiter, never a character: swallow it and clear the input even when
+        // nothing is added, otherwise it is left behind and ends up inside the next chip.
+        event.preventDefault();
+        this.addSeparatedValues(this.splitBySeparator(this.multiInputEl?.nativeElement?.value || event.target.value || ''), event);
+        this.clearMultipleInput(event);
     }
 
     onArrowDownKey(event) {
@@ -1682,6 +1668,43 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         this.updateModel(value);
         this.onUnselect.emit({ originalEvent: event, value: removedOption });
         focus(this.inputEL?.nativeElement);
+    }
+
+    private isSeparatorMode(): boolean {
+        return !!this.separator && !!this.multiple && !this.typeahead;
+    }
+
+    private splitBySeparator(text: string): string[] {
+        return (this.separator ? text.split(this.separator) : [text]).map((value) => value.trim()).filter((value) => value.length > 0);
+    }
+
+    private addSeparatedValues(values: string[], event: Event): void {
+        const added: string[] = [];
+        const newValues = [...(this.modelValue() || [])];
+
+        values.forEach((value) => {
+            if (this.isSelected(value) || (this.unique && added.includes(value))) {
+                return;
+            }
+
+            newValues.push(value);
+            added.push(value);
+        });
+
+        if (!added.length) {
+            return;
+        }
+
+        this.updateModel(newValues);
+        added.forEach((value) => this.onAdd.emit({ originalEvent: event, value }));
+    }
+
+    private clearMultipleInput(event: Event): void {
+        if (this.multiInputEl?.nativeElement) {
+            this.multiInputEl.nativeElement.value = '';
+        } else if ((event.target as HTMLInputElement)?.value !== undefined) {
+            (event.target as HTMLInputElement).value = '';
+        }
     }
 
     updateModel(options) {

--- a/packages/optimus-ui/src/config/optimus.ts
+++ b/packages/optimus-ui/src/config/optimus.ts
@@ -158,6 +158,7 @@ export class Optimus extends ThemeProvider {
             rotateRight: 'Rotate Right',
             rotateLeft: 'Rotate Left',
             listLabel: 'Option List',
+            selectedItems: 'Selected Items',
             selectColor: 'Select a color',
             removeLabel: 'Remove',
             browseFiles: 'Browse Files',

--- a/packages/optimus-ui/src/multiselect/multiselect.test.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.test.ts
@@ -665,6 +665,30 @@ describe('MultiSelect', () => {
             expect(component.onRemove).toHaveBeenCalled();
             expect(multiSelect.modelValue()).toEqual([component.options[1]]);
         });
+
+        it('should keep chips removable when the selection limit is reached', async () => {
+            component.display = 'chip';
+            component.selectionLimit = 2;
+            component.selectedCities = [component.options[0], component.options[1]];
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(multiSelect.maxSelectionLimitReached()).toBe(true);
+
+            const removeIcons = fixture.debugElement.queryAll(By.css('.p-chip-remove-icon'));
+
+            expect(removeIcons.length).toBe(2);
+            expect(removeIcons[0].nativeElement.getAttribute('tabindex')).toBe('0');
+
+            removeIcons[0].triggerEventHandler('click', new MouseEvent('click'));
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(multiSelect.modelValue()).toEqual([component.options[1]]);
+            expect(fixture.debugElement.queryAll(By.css('.p-chip-remove-icon')).length).toBe(1);
+        });
     });
 
     describe('Keyboard Navigation', () => {

--- a/packages/optimus-ui/src/multiselect/multiselect.test.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.test.ts
@@ -59,6 +59,7 @@ interface Country {
             [resetFilterOnHide]="resetFilterOnHide"
             [dropdownIcon]="dropdownIcon"
             [chipIcon]="chipIcon"
+            [chipRemoveIcon]="chipRemoveIcon"
             [filterPlaceHolder]="filterPlaceHolder"
             [emptyMessage]="emptyMessage"
             [emptyFilterMessage]="emptyFilterMessage"
@@ -121,6 +122,7 @@ class TestBasicMultiSelectComponent {
     resetFilterOnHide = false;
     dropdownIcon: string | undefined;
     chipIcon: string | undefined;
+    chipRemoveIcon: string | undefined;
     filterPlaceHolder: string | undefined;
     emptyMessage = '';
     emptyFilterMessage = '';
@@ -1298,6 +1300,49 @@ describe('MultiSelect', () => {
             // Chip might not be rendered or use different selector
             expect(chip || fixture.debugElement.query(By.css('.p-multiselect-chip')) || component.display === 'chip').toBeTruthy();
         });
+
+        it('should render chipRemoveIcon on the chip remove icon', async () => {
+            component.display = 'chip';
+            component.chipRemoveIcon = 'pi pi-times';
+            component.selectedCities = [component.options[0]];
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const removeIcon = fixture.debugElement.query(By.css('.p-chip-remove-icon'));
+
+            expect(removeIcon).toBeTruthy();
+            expect(removeIcon.nativeElement.getAttribute('class')).toContain('pi-times');
+        });
+
+        it('should keep honouring the deprecated chipIcon on the chip remove icon', async () => {
+            component.display = 'chip';
+            component.chipIcon = 'pi pi-map';
+            component.selectedCities = [component.options[0]];
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const removeIcon = fixture.debugElement.query(By.css('.p-chip-remove-icon'));
+
+            expect(removeIcon).toBeTruthy();
+            expect(removeIcon.nativeElement.getAttribute('class')).toContain('pi-map');
+        });
+
+        it('should let chipRemoveIcon win over the deprecated chipIcon', async () => {
+            component.display = 'chip';
+            component.chipIcon = 'pi pi-map';
+            component.chipRemoveIcon = 'pi pi-times';
+            component.selectedCities = [component.options[0]];
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const removeIcon = fixture.debugElement.query(By.css('.p-chip-remove-icon'));
+
+            expect(removeIcon.nativeElement.getAttribute('class')).toContain('pi-times');
+            expect(removeIcon.nativeElement.getAttribute('class')).not.toContain('pi-map');
+        });
     });
 
     describe('Edge Cases', () => {
@@ -1750,6 +1795,80 @@ describe('MultiSelect Content Child Templates', () => {
             expect(customEmptyFilter).toBeTruthy();
             expect(customEmptyFilter.nativeElement.textContent).toBe('No filter results');
         }
+    });
+});
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: false,
+    template: `
+        <p-multiselect [options]="options" [(ngModel)]="selectedCities" optionLabel="name" display="chip">
+            <ng-template #chipicon>
+                <span class="content-child-chip-icon"></span>
+            </ng-template>
+
+            <ng-template #chipremoveicon>
+                <span class="content-child-chip-remove-icon"></span>
+            </ng-template>
+        </p-multiselect>
+    `
+})
+class TestChipIconMultiSelectComponent {
+    options: City[] = [
+        { name: 'New York', code: 'NY' },
+        { name: 'Rome', code: 'RM' }
+    ];
+
+    selectedCities: City[] = [];
+}
+
+describe('MultiSelect Chip Icon Templates', () => {
+    let component: TestChipIconMultiSelectComponent;
+    let fixture: ComponentFixture<TestChipIconMultiSelectComponent>;
+    let multiSelect: MultiSelect;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [TestChipIconMultiSelectComponent],
+            imports: [CommonModule, FormsModule, MultiSelectModule],
+            providers: [provideNoopAnimations(), provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestChipIconMultiSelectComponent);
+        component = fixture.componentInstance;
+        multiSelect = fixture.debugElement.query(By.directive(MultiSelect)).componentInstance;
+
+        component.selectedCities = [component.options[0]];
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+    });
+
+    it('should render the chipicon template as chip content, not as the remove icon', () => {
+        const chipIcon = fixture.debugElement.query(By.css('.content-child-chip-icon'));
+
+        expect(chipIcon).toBeTruthy();
+        expect(chipIcon.nativeElement.closest('.p-chip-remove-icon')).toBeNull();
+    });
+
+    it('should render the chipremoveicon template inside the chip remove icon', () => {
+        const removeIcon = fixture.debugElement.query(By.css('.p-chip-remove-icon'));
+
+        expect(removeIcon).toBeTruthy();
+        expect(removeIcon.query(By.css('.content-child-chip-remove-icon'))).toBeTruthy();
+        expect(removeIcon.query(By.css('.content-child-chip-icon'))).toBeNull();
+    });
+
+    it('should remove the option when the chip remove icon is clicked', async () => {
+        const removeIcon = fixture.debugElement.query(By.css('.p-chip-remove-icon'));
+
+        removeIcon.triggerEventHandler('click', new MouseEvent('click'));
+        fixture.changeDetectorRef.markForCheck();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        expect(multiSelect.modelValue()).toEqual([]);
+        expect(fixture.debugElement.queryAll(By.css('p-chip')).length).toBe(0);
     });
 });
 

--- a/packages/optimus-ui/src/multiselect/multiselect.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.ts
@@ -238,20 +238,21 @@ export class MultiSelectItem extends BaseComponent {
                             {{ getSelectedItemsLabel() }}
                         } @else {
                             <div #token *ngFor="let item of chipSelectedItems(); let i = index" [pBind]="ptm('chipItem')" [class]="cx('chipItem')">
-                                <p-chip [pt]="ptm('pcChip')" [unstyled]="unstyled()" [class]="cx('pcChip')" [label]="getLabelByValue(item)" [removable]="!$disabled() && !readonly" (onRemove)="removeOption(item, $event)" [removeIcon]="chipIcon">
-                                    <ng-container *ngIf="chipIconTemplate || _chipIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate">
+                                <p-chip
+                                    [pt]="ptm('pcChip')"
+                                    [unstyled]="unstyled()"
+                                    [class]="cx('pcChip')"
+                                    [label]="getLabelByValue(item)"
+                                    [removable]="!$disabled() && !readonly"
+                                    (onRemove)="removeOption(item, $event)"
+                                    [removeIcon]="chipRemoveIcon ?? chipIcon"
+                                >
+                                    <span *ngIf="chipIconTemplate || _chipIconTemplate" [class]="cx('chipIcon')" [attr.aria-hidden]="true" [pBind]="ptm('chipIcon')">
+                                        <ng-container *ngTemplateOutlet="chipIconTemplate || _chipIconTemplate; context: { class: cx('chipIcon') }"></ng-container>
+                                    </span>
+                                    <ng-container *ngIf="chipRemoveIconTemplate || _chipRemoveIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate">
                                         <ng-template #removeicon>
-                                            <ng-container *ngIf="!$disabled() && !readonly">
-                                                <span
-                                                    [class]="cx('chipIcon')"
-                                                    *ngIf="chipIconTemplate || _chipIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate"
-                                                    (click)="removeOption(item, $event)"
-                                                    [attr.aria-hidden]="true"
-                                                    [pBind]="ptm('chipIcon')"
-                                                >
-                                                    <ng-container *ngTemplateOutlet="chipIconTemplate || _chipIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate; context: { class: 'p-multiselect-chip-icon' }"></ng-container>
-                                                </span>
-                                            </ng-container>
+                                            <ng-container *ngTemplateOutlet="chipRemoveIconTemplate || _chipRemoveIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate; context: { class: cx('chipIcon') }"></ng-container>
                                         </ng-template>
                                     </ng-container>
                                 </p-chip>
@@ -630,10 +631,17 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
      */
     @Input() dropdownIcon: string | undefined;
     /**
-     * Icon class of the chip icon.
+     * Icon class of the chip remove icon.
+     * @deprecated Use `chipRemoveIcon` instead. Despite its name this has always styled the
+     * chip's remove icon, never an icon displayed inside the chip.
      * @group Props
      */
     @Input() chipIcon: string | undefined;
+    /**
+     * Icon class of the chip remove icon.
+     * @group Props
+     */
+    @Input() chipRemoveIcon: string | undefined;
     /**
      * Name of the label field of an option.
      * @group Props
@@ -1036,12 +1044,19 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     /**
      * Custom remove token icon template.
+     * @deprecated Use chipremoveicon instead.
      * @group Templates
      */
     @ContentChild('removetokenicon', { descendants: false }) removeTokenIconTemplate: TemplateRef<MultiSelectChipIconTemplateContext> | undefined;
 
     /**
-     * Custom chip icon template.
+     * Custom chip remove icon template to customize the remove icon of the chip.
+     * @group Templates
+     */
+    @ContentChild('chipremoveicon', { descendants: false }) chipRemoveIconTemplate: TemplateRef<MultiSelectChipIconTemplateContext> | undefined;
+
+    /**
+     * Custom chip icon template, rendered inside the chip next to its label.
      * @group Templates
      */
     @ContentChild('chipicon', { descendants: false }) chipIconTemplate: TemplateRef<MultiSelectChipIconTemplateContext> | undefined;
@@ -1095,6 +1110,8 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     _filterIconTemplate: TemplateRef<void> | undefined;
 
     _removeTokenIconTemplate: TemplateRef<MultiSelectChipIconTemplateContext> | undefined;
+
+    _chipRemoveIconTemplate: TemplateRef<MultiSelectChipIconTemplateContext> | undefined;
 
     _chipIconTemplate: TemplateRef<MultiSelectChipIconTemplateContext> | undefined;
 
@@ -1168,6 +1185,10 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
                 case 'filtericon':
                     this._filterIconTemplate = item.template;
+                    break;
+
+                case 'chipremoveicon':
+                    this._chipRemoveIconTemplate = item.template;
                     break;
 
                 case 'removetokenicon':

--- a/packages/optimus-ui/src/types/multiselect/multiselect.types.ts
+++ b/packages/optimus-ui/src/types/multiselect/multiselect.types.ts
@@ -34,6 +34,10 @@ export interface MultiSelectPassThroughOptions<I = unknown> {
      */
     chipItem?: PassThroughOption<HTMLDivElement, I>;
     /**
+     * Used to pass attributes to the chip icon's DOM element.
+     */
+    chipIcon?: PassThroughOption<HTMLSpanElement, I>;
+    /**
      * Used to pass attributes to the Chip component.
      * @see {@link ChipPassThrough}
      */
@@ -422,8 +426,13 @@ export interface MultiSelectTemplates<T = any> {
      */
     chipicon(context: MultiSelectChipIconTemplateContext): TemplateRef<MultiSelectChipIconTemplateContext>;
     /**
+     * Custom chip remove icon template to customize the remove icon of the chip.
+     * @param {Object} context - icon context.
+     */
+    chipremoveicon(context: MultiSelectChipIconTemplateContext): TemplateRef<MultiSelectChipIconTemplateContext>;
+    /**
      * Custom remove token icon template.
-     * @deprecated Use chipicon instead.
+     * @deprecated Use chipremoveicon instead.
      * @param {Object} context - icon context.
      */
     removetokenicon(context: MultiSelectChipIconTemplateContext): TemplateRef<MultiSelectChipIconTemplateContext>;


### PR DESCRIPTION
## Description

Fixes 4 chip-related bugs in MultiSelect and AutoComplete, plus 1 bug found while working on the code:

- **MultiSelect chip icons (#399).** `#chipicon` was projected into the chip's *remove* slot, so an icon meant for the label replaced the close button, and the chip's own icon slot was unreachable. `#chipicon` now renders as chip content and a new `#chipremoveicon` owns the remove slot. New `chipRemoveIcon` input deprecates the misnamed `chipIcon`, whose behaviour is unchanged. `removetokenicon` still works; its deprecation now points at `chipremoveicon` instead of `chipicon`.
- **AutoComplete separator (#267).** The separator key was only consumed on the success path and the input was never split. Pressing `,` on an empty field inserted the character (repeats built `,`, `,,`, `,,,`), pressing it on an existing chip left the text in the field, and `,foo` became one chip named `",foo"`. The separator is now always swallowed, the text is split and trimmed, and a batch is deduplicated against itself when `unique` is set. No new input; `unique` already covers this.
- **AutoComplete readonly chips (found bug).** `[removable]="true"` was hardcoded, so readonly fields rendered a remove icon that hid the chip while the model kept the value. Now derived from `readonly` and the disabled state, matching MultiSelect.
- **AutoComplete chip list name (#625).** The multiple-mode `<ul role="listbox">` had no accessible name (axe: "ARIA input fields must have an accessible name"). Adds an `aria.selectedItems` locale key defaulting to "Selected Items".
- **MultiSelect selection limit (#810).** Already correct, added a test to lock it down.


## Related issues

<!-- Link issues this PR addresses, e.g. Fixes #123, Closes #456, or Relates to #789 -->

Fixes #399
Fixes #267
Closes #810 (already correct; adds the regression test)
Relates to #625. The fix doesn't fully cover the reported bug, but that would require sweeping changes to ARIA in the library,

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

**`#chipicon` / `pTemplate="chipicon"` on MultiSelect now render inside the chip next to the label instead of replacing the remove icon.** Fails silently: anyone using it as a close button gets two icons per chip.

Migration is a rename, not a rewrite. Rename rather than duplicate, or the icon renders twice:

- `<ng-template #chipicon>` to `<ng-template #chipremoveicon>`
- `pTemplate="chipicon"` to `pTemplate="chipremoveicon"`

Smaller behaviour changes: readonly/disabled AutoComplete now renders zero `.p-chip-remove-icon` nodes; under `[unstyled]`, the chip-icon template context `class` is now empty instead of leaking `p-multiselect-chip-icon`, so `[class]="class + ' pi pi-times'"` should become `class="pi pi-times" [ngClass]="class"`.

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `pnpm run build:lib`
- [x] `pnpm run test:unit` (vitest)
- [ ] `pnpm run lint` (broken repo-wide, unrelated to this PR)
- [x] `pnpm run format:check`
- [ ] Verified in the demo app

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [x] Documentation updated (README, JSDoc, migration notes as needed)
- [x] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (repository has no CHANGELOG)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)