### PR TITLE
refactor: signal queries migration

### DIFF
--- a/packages/optimus-ui/src/accordion/accordion.ts
+++ b/packages/optimus-ui/src/accordion/accordion.ts
@@ -3,7 +3,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
     EventEmitter,
     forwardRef,
     HostListener,
@@ -17,7 +16,8 @@ import {
     Output,
     signal,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild
 } from '@angular/core';
 import { MotionOptions } from '@openng/optimus-ui-motion';
 import { findSingle, focus, getAttribute, uuid } from '@openng/optimus-ui-utils';
@@ -135,8 +135,8 @@ export class AccordionPanel extends BaseComponent<AccordionPanelPassThrough> {
     standalone: true,
     template: `
         <ng-content />
-        @if (toggleicon) {
-            <ng-template *ngTemplateOutlet="toggleicon; context: { active: active() }"></ng-template>
+        @if (toggleicon()) {
+            <ng-template *ngTemplateOutlet="toggleicon(); context: { active: active() }"></ng-template>
         } @else {
             @if (active()) {
                 @if (pcAccordion.collapseIcon) {
@@ -206,7 +206,7 @@ export class AccordionHeader extends BaseComponent<AccordionHeaderPassThrough> {
      * @see {@link AccordionToggleIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('toggleicon') toggleicon: TemplateRef<AccordionToggleIconTemplateContext> | undefined;
+    readonly toggleicon = contentChild<TemplateRef<AccordionToggleIconTemplateContext>>('toggleicon');
 
     @HostListener('click', ['$event']) onClick(event?: MouseEvent | KeyboardEvent) {
         if (this.disabled()) {

--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -8,6 +8,7 @@ import { BehaviorSubject } from 'rxjs';
 import type { Mock } from 'vitest';
 import { AUTOCOMPLETE_VALUE_ACCESSOR, AutoComplete, AutoCompleteModule } from './autocomplete';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 const mockCountries = [
     { name: 'Afghanistan', code: 'AF' },
     { name: 'Albania', code: 'AL' },
@@ -2773,5 +2774,40 @@ describe('AutoComplete generic typing', () => {
         typedComponent.onAdd.emit({ originalEvent: new Event('blur'), value: ' Afghanistan ' });
 
         expect(addedValue).toBe('Afghanistan');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [AutoComplete, SharedModule],
+    template: `
+        <p-autocomplete [suggestions]="suggestions">
+            <ng-template #removeicon>ri</ng-template>
+        </p-autocomplete>
+    `
+})
+class AutoCompleteQueryApiHostComponent {
+    suggestions = [];
+}
+
+describe('AutoComplete Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [AutoCompleteQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(AutoCompleteQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+
+        expect(instance.removeIconTemplate()).toBeDefined();
+        expect(instance.itemsViewChild()).toBeUndefined();
+        expect(instance.scroller()).toBeUndefined();
     });
 });

--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -2350,8 +2350,9 @@ describe('AutoComplete', () => {
                 await testFixture.whenStable();
 
                 // Set the multiInputEl value directly since we're in multiple mode
-                if (autocompleteComponent.multiInputEl) {
-                    autocompleteComponent.multiInputEl.nativeElement.value = 'Test Item';
+                const multiInputEl = autocompleteComponent.multiInputEl();
+                if (multiInputEl) {
+                    multiInputEl.nativeElement.value = 'Test Item';
                 } else {
                     inputElement.value = 'Test Item';
                 }

--- a/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.test.ts
@@ -994,11 +994,11 @@ describe('AutoComplete', () => {
                 { getType: () => 'group', template: {} }
             ];
 
-            autocompleteInstance.templates = {
+            autocompleteInstance.templates = (() => ({
                 forEach: (callback: (template: any) => void) => {
                     mockTemplates.forEach(callback);
                 }
-            } as any;
+            })) as any;
 
             autocompleteInstance.ngAfterContentInit();
 

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -1041,13 +1041,10 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     onAfterViewChecked() {
         this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
         //Use timeouts as since Angular 4.2, AfterViewChecked is broken and not called after panel is updated
-        if (this.suggestionsUpdated && this.overlayViewChild()) {
+        if (this.suggestionsUpdated) {
             this.zone.runOutsideAngular(() => {
                 setTimeout(() => {
-                    const overlayViewChild = this.overlayViewChild();
-                    if (overlayViewChild) {
-                        overlayViewChild.alignOverlay();
-                    }
+                    this.overlayViewChild().alignOverlay();
                 }, 1);
                 this.suggestionsUpdated = false;
             });
@@ -1179,8 +1176,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
             return;
         }
 
-        const overlayViewChild = this.overlayViewChild();
-        if (!overlayViewChild || !overlayViewChild.overlayViewChild()?.nativeElement.contains(event.target)) {
+        if (!this.overlayViewChild().overlayViewChild()?.nativeElement.contains(event.target)) {
             focus(this.inputEL()?.nativeElement);
         }
     }

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     EmbeddedViewRef,
     ElementRef,
     EventEmitter,
@@ -22,8 +20,10 @@ import {
     QueryList,
     signal,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionOptions } from '@openng/optimus-ui-motion';
@@ -120,9 +120,9 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             [pInputTextUnstyled]="unstyled()"
         />
         <ng-container *ngIf="$filled() && !$disabled() && showClear && !loading">
-            <svg data-p-icon="times" *ngIf="!clearIconTemplate && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true" />
-            <span *ngIf="clearIconTemplate || _clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true">
-                <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
+            <svg data-p-icon="times" *ngIf="!clearIconTemplate() && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true" />
+            <span *ngIf="clearIconTemplate() || _clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true">
+                <ng-template *ngTemplateOutlet="clearIconTemplate() || _clearIconTemplate"></ng-template>
             </span>
         </ng-container>
 
@@ -155,19 +155,19 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                 <p-chip
                     [pt]="ptm('pcChip')"
                     [class]="cx('pcChip')"
-                    [label]="!selectedItemTemplate && !_selectedItemTemplate && getOptionLabel(option)"
+                    [label]="!selectedItemTemplate() && !_selectedItemTemplate && getOptionLabel(option)"
                     [disabled]="$disabled()"
                     [removable]="true"
                     (onRemove)="!readonly ? removeOption($event, i) : ''"
                     [unstyled]="unstyled()"
                 >
-                    <ng-container *ngTemplateOutlet="selectedItemTemplate || _selectedItemTemplate; context: { $implicit: option }"></ng-container>
+                    <ng-container *ngTemplateOutlet="selectedItemTemplate() || _selectedItemTemplate; context: { $implicit: option }"></ng-container>
                     <ng-template #removeicon>
-                        <span *ngIf="!removeIconTemplate && !_removeIconTemplate" [pBind]="ptm('chipIcon')" [class]="cx('chipIcon')" (click)="!readonly && !$disabled() ? removeOption($event, i) : ''">
+                        <span *ngIf="!removeIconTemplate() && !_removeIconTemplate" [pBind]="ptm('chipIcon')" [class]="cx('chipIcon')" (click)="!readonly && !$disabled() ? removeOption($event, i) : ''">
                             <svg data-p-icon="times-circle" [class]="cx('chipIcon')" [attr.aria-hidden]="true" />
                         </span>
-                        <span *ngIf="removeIconTemplate || _removeIconTemplate" [pBind]="ptm('chipIcon')" [attr.aria-hidden]="true">
-                            <ng-template *ngTemplateOutlet="removeIconTemplate || _removeIconTemplate; context: { removeCallback: removeOption.bind(this), index: i, class: cx('chipIcon') }"></ng-template>
+                        <span *ngIf="removeIconTemplate() || _removeIconTemplate" [pBind]="ptm('chipIcon')" [attr.aria-hidden]="true">
+                            <ng-template *ngTemplateOutlet="removeIconTemplate() || _removeIconTemplate; context: { removeCallback: removeOption.bind(this), index: i, class: cx('chipIcon') }"></ng-template>
                         </span>
                     </ng-template>
                 </p-chip>
@@ -214,16 +214,16 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             </li>
         </ul>
         <ng-container *ngIf="loading">
-            <svg data-p-icon="spinner" *ngIf="!loadingIconTemplate && !_loadingIconTemplate" [pBind]="ptm('loader')" [class]="cx('loader')" [spin]="true" [attr.aria-hidden]="true" />
-            <span *ngIf="loadingIconTemplate || _loadingIconTemplate" [pBind]="ptm('loader')" [class]="cx('loader')" [attr.aria-hidden]="true">
-                <ng-template *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate"></ng-template>
+            <svg data-p-icon="spinner" *ngIf="!loadingIconTemplate() && !_loadingIconTemplate" [pBind]="ptm('loader')" [class]="cx('loader')" [spin]="true" [attr.aria-hidden]="true" />
+            <span *ngIf="loadingIconTemplate() || _loadingIconTemplate" [pBind]="ptm('loader')" [class]="cx('loader')" [attr.aria-hidden]="true">
+                <ng-template *ngTemplateOutlet="loadingIconTemplate() || _loadingIconTemplate"></ng-template>
             </span>
         </ng-container>
         <button #ddBtn type="button" [pBind]="ptm('dropdown')" [attr.aria-label]="dropdownAriaLabel" [class]="cx('dropdown')" [disabled]="$disabled()" pRipple (click)="handleDropdownClick($event)" *ngIf="dropdown" [attr.tabindex]="tabindex">
             <span *ngIf="dropdownIcon" [ngClass]="dropdownIcon" [attr.aria-hidden]="true"></span>
             <ng-container *ngIf="!dropdownIcon">
-                <svg data-p-icon="chevron-down" [pBind]="ptm('dropdown')" *ngIf="!dropdownIconTemplate && !_dropdownIconTemplate" />
-                <ng-template *ngTemplateOutlet="dropdownIconTemplate || _dropdownIconTemplate"></ng-template>
+                <svg data-p-icon="chevron-down" [pBind]="ptm('dropdown')" *ngIf="!dropdownIconTemplate() && !_dropdownIconTemplate" />
+                <ng-template *ngTemplateOutlet="dropdownIconTemplate() || _dropdownIconTemplate"></ng-template>
             </ng-container>
         </button>
         <p-overlay
@@ -242,7 +242,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
         >
             <ng-template #content>
                 <div [pBind]="ptm('overlay')" [class]="cn(cx('overlay'), panelStyleClass)" [ngStyle]="panelStyle">
-                    <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
                     <div [pBind]="ptm('listContainer')" [class]="cx('listContainer')" [style.max-height]="virtualScroll ? 'auto' : scrollHeight" [tabindex]="-1">
                         <p-scroller
                             *ngIf="virtualScroll"
@@ -260,9 +260,9 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                             <ng-template #content let-items let-scrollerOptions="options">
                                 <ng-container *ngTemplateOutlet="buildInItems; context: { $implicit: items, options: scrollerOptions }"></ng-container>
                             </ng-template>
-                            <ng-container *ngIf="loaderTemplate || _loaderTemplate">
+                            <ng-container *ngIf="loaderTemplate() || _loaderTemplate">
                                 <ng-template #loader let-scrollerOptions="options">
-                                    <ng-container *ngTemplateOutlet="loaderTemplate || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
+                                    <ng-container *ngTemplateOutlet="loaderTemplate() || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
                                 </ng-template>
                             </ng-container>
                         </p-scroller>
@@ -276,8 +276,8 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                             <ng-template ngFor let-option [ngForOf]="items" let-i="index">
                                 <ng-container *ngIf="isOptionGroup(option)">
                                     <li [pBind]="ptm('optionGroup')" [attr.id]="id + '_' + getOptionIndex(i, scrollerOptions)" [class]="cx('optionGroup')" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option">
-                                        <span *ngIf="!groupTemplate">{{ getOptionGroupLabel(option.optionGroup) }}</span>
-                                        <ng-container *ngTemplateOutlet="groupTemplate; context: { $implicit: option.optionGroup }"></ng-container>
+                                        <span *ngIf="!groupTemplate()">{{ getOptionGroupLabel(option.optionGroup) }}</span>
+                                        <ng-container *ngTemplateOutlet="groupTemplate(); context: { $implicit: option.optionGroup }"></ng-container>
                                     </li>
                                 </ng-container>
                                 <ng-container *ngIf="!isOptionGroup(option)">
@@ -298,10 +298,10 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                                         (click)="onOptionSelect($event, option)"
                                         (mouseenter)="onOptionMouseEnter($event, getOptionIndex(i, scrollerOptions))"
                                     >
-                                        <span *ngIf="!itemTemplate && !_itemTemplate">{{ getOptionLabel(option) }}</span>
+                                        <span *ngIf="!itemTemplate() && !_itemTemplate">{{ getOptionLabel(option) }}</span>
                                         <ng-container
                                             *ngTemplateOutlet="
-                                                itemTemplate || _itemTemplate;
+                                                itemTemplate() || _itemTemplate;
                                                 context: {
                                                     $implicit: option,
                                                     index: scrollerOptions.getOptions ? scrollerOptions.getOptions(i) : i
@@ -312,14 +312,14 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                                 </ng-container>
                             </ng-template>
                             <li *ngIf="!items || (items && items.length === 0 && showEmptyMessage)" [pBind]="ptm('emptyMessage')" [class]="cx('emptyMessage')" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option">
-                                <ng-container *ngIf="!emptyTemplate && !_emptyTemplate; else empty">
+                                <ng-container *ngIf="!emptyTemplate() && !_emptyTemplate; else empty">
                                     {{ searchResultMessageText }}
                                 </ng-container>
-                                <ng-container #empty *ngTemplateOutlet="emptyTemplate || _emptyTemplate"></ng-container>
+                                <ng-container #empty *ngTemplateOutlet="emptyTemplate() || _emptyTemplate"></ng-container>
                             </li>
                         </ul>
                     </ng-template>
-                    <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
                 </div>
                 <span role="status" aria-live="polite" class="p-hidden-accessible">
                     {{ selectedMessageText }}
@@ -750,19 +750,19 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
      */
     @Output() onLazyLoad: EventEmitter<AutoCompleteLazyLoadEvent> = new EventEmitter<AutoCompleteLazyLoadEvent>();
 
-    @ViewChild('focusInput') inputEL: Nullable<ElementRef>;
+    readonly inputEL = viewChild<Nullable<ElementRef>>('focusInput');
 
-    @ViewChild('multiIn') multiInputEl: Nullable<ElementRef>;
+    readonly multiInputEl = viewChild<Nullable<ElementRef>>('multiIn');
 
-    @ViewChild('multiContainer') multiContainerEL: Nullable<ElementRef>;
+    readonly multiContainerEL = viewChild<Nullable<ElementRef>>('multiContainer');
 
-    @ViewChild('ddBtn') dropdownButton: Nullable<ElementRef>;
+    readonly dropdownButton = viewChild<Nullable<ElementRef>>('ddBtn');
 
-    @ViewChild('items') itemsViewChild: Nullable<ElementRef>;
+    readonly itemsViewChild = viewChild<Nullable<ElementRef>>('items');
 
-    @ViewChild('scroller') scroller: Nullable<Scroller>;
+    readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
-    @ViewChild('overlay') overlayViewChild!: Overlay;
+    readonly overlayViewChild = viewChild.required<Overlay>('overlay');
 
     itemsWrapper: Nullable<HTMLDivElement>;
 
@@ -770,67 +770,67 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
      * Custom item template.
      * @group Templates
      */
-    @ContentChild('item') itemTemplate: Nullable<TemplateRef<AutoCompleteItemTemplateContext>>;
+    readonly itemTemplate = contentChild<Nullable<TemplateRef<AutoCompleteItemTemplateContext>>>('item');
 
     /**
      * Custom empty message template.
      * @group Templates
      */
-    @ContentChild('empty') emptyTemplate: Nullable<TemplateRef<void>>;
+    readonly emptyTemplate = contentChild<Nullable<TemplateRef<void>>>('empty');
 
     /**
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header') headerTemplate: Nullable<TemplateRef<void>>;
+    readonly headerTemplate = contentChild<Nullable<TemplateRef<void>>>('header');
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer') footerTemplate: Nullable<TemplateRef<void>>;
+    readonly footerTemplate = contentChild<Nullable<TemplateRef<void>>>('footer');
 
     /**
      * Custom selected item template.
      * @group Templates
      */
-    @ContentChild('selecteditem') selectedItemTemplate: Nullable<TemplateRef<AutoCompleteSelectedItemTemplateContext>>;
+    readonly selectedItemTemplate = contentChild<Nullable<TemplateRef<AutoCompleteSelectedItemTemplateContext>>>('selecteditem');
 
     /**
      * Custom group template.
      * @group Templates
      */
-    @ContentChild('group') groupTemplate: Nullable<TemplateRef<AutoCompleteGroupTemplateContext>>;
+    readonly groupTemplate = contentChild<Nullable<TemplateRef<AutoCompleteGroupTemplateContext>>>('group');
 
     /**
      * Custom loader template.
      * @group Templates
      */
-    @ContentChild('loader') loaderTemplate: Nullable<TemplateRef<AutoCompleteLoaderTemplateContext>>;
+    readonly loaderTemplate = contentChild<Nullable<TemplateRef<AutoCompleteLoaderTemplateContext>>>('loader');
 
     /**
      * Custom remove icon template.
      * @group Templates
      */
-    @ContentChild('removeicon') removeIconTemplate: Nullable<TemplateRef<AutoCompleteRemoveIconTemplateContext>>;
+    readonly removeIconTemplate = contentChild<Nullable<TemplateRef<AutoCompleteRemoveIconTemplateContext>>>('removeicon');
 
     /**
      * Custom loading icon template.
      * @group Templates
      */
-    @ContentChild('loadingicon') loadingIconTemplate: Nullable<TemplateRef<void>>;
+    readonly loadingIconTemplate = contentChild<Nullable<TemplateRef<void>>>('loadingicon');
 
     /**
      * Custom clear icon template.
      * @group Templates
      */
-    @ContentChild('clearicon') clearIconTemplate: Nullable<TemplateRef<void>>;
+    readonly clearIconTemplate = contentChild<Nullable<TemplateRef<void>>>('clearicon');
 
     /**
      * Custom dropdown icon template.
      * @group Templates
      */
-    @ContentChild('dropdownicon') dropdownIconTemplate: Nullable<TemplateRef<void>>;
+    readonly dropdownIconTemplate = contentChild<Nullable<TemplateRef<void>>>('dropdownicon');
 
     @HostListener('click', ['$event'])
     onHostClick(event: MouseEvent) {
@@ -979,10 +979,10 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         this.cd.detectChanges();
     }
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -1042,11 +1042,12 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     onAfterViewChecked() {
         this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
         //Use timeouts as since Angular 4.2, AfterViewChecked is broken and not called after panel is updated
-        if (this.suggestionsUpdated && this.overlayViewChild) {
+        if (this.suggestionsUpdated && this.overlayViewChild()) {
             this.zone.runOutsideAngular(() => {
                 setTimeout(() => {
-                    if (this.overlayViewChild) {
-                        this.overlayViewChild.alignOverlay();
+                    const overlayViewChild = this.overlayViewChild();
+                    if (overlayViewChild) {
+                        overlayViewChild.alignOverlay();
                     }
                 }, 1);
                 this.suggestionsUpdated = false;
@@ -1056,7 +1057,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     handleSuggestionsChange() {
         if (this.loading) {
-            this._suggestions()?.length > 0 || this.showEmptyMessage || !!this.emptyTemplate ? this.show() : this.hide();
+            this._suggestions()?.length > 0 || this.showEmptyMessage || !!this.emptyTemplate() ? this.show() : this.hide();
             const focusedOptionIndex = this.overlayVisible && this.autoOptionFocus ? this.findFirstFocusedOptionIndex() : -1;
             this.focusedOptionIndex.set(focusedOptionIndex);
             this.suggestionsUpdated = true;
@@ -1162,11 +1163,12 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     }
 
     isInputClicked(event) {
-        return event.target === this.inputEL?.nativeElement;
+        return event.target === this.inputEL()?.nativeElement;
     }
 
     isDropdownClicked(event) {
-        return this.dropdownButton?.nativeElement ? event.target === this.dropdownButton.nativeElement || this.dropdownButton.nativeElement.contains(event.target) : false;
+        const dropdownButton = this.dropdownButton();
+        return dropdownButton?.nativeElement ? event.target === dropdownButton.nativeElement || dropdownButton.nativeElement.contains(event.target) : false;
     }
 
     equalityKey() {
@@ -1178,8 +1180,9 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
             return;
         }
 
-        if (!this.overlayViewChild || !this.overlayViewChild.overlayViewChild?.nativeElement.contains(event.target)) {
-            focus(this.inputEL?.nativeElement);
+        const overlayViewChild = this.overlayViewChild();
+        if (!overlayViewChild || !overlayViewChild.overlayViewChild()?.nativeElement.contains(event.target)) {
+            focus(this.inputEL()?.nativeElement);
         }
     }
 
@@ -1189,8 +1192,9 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         if (this.overlayVisible) {
             this.hide(true);
         } else {
-            focus(this.inputEL?.nativeElement);
-            query = this.inputEL?.nativeElement?.value as string;
+            const inputEL = this.inputEL();
+            focus(inputEL?.nativeElement);
+            query = inputEL?.nativeElement?.value as string;
 
             if (this.dropdownMode === 'blank') this.search(event, '', 'dropdown');
             else if (this.dropdownMode === 'current') this.search(event, query, 'dropdown');
@@ -1302,12 +1306,13 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         this.focusedOptionIndex.set(-1);
 
         if (this.addOnBlur && this.multiple && !this.typeahead) {
-            const inputValue = (this.multiInputEl?.nativeElement?.value || event.target.value || '').trim();
+            const inputValue = (this.multiInputEl()?.nativeElement?.value || event.target.value || '').trim();
             if (inputValue && !this.isSelected(inputValue)) {
                 this.updateModel([...(this.modelValue() || []), inputValue]);
                 this.onAdd.emit({ originalEvent: event, value: inputValue });
-                if (this.multiInputEl?.nativeElement) {
-                    this.multiInputEl.nativeElement.value = '';
+                const multiInputEl = this.multiInputEl();
+                if (multiInputEl?.nativeElement) {
+                    multiInputEl.nativeElement.value = '';
                 } else {
                     event.target.value = '';
                 }
@@ -1338,8 +1343,9 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
                     addedValues.forEach((addedValue) => {
                         this.onAdd.emit({ originalEvent: event, value: addedValue });
                     });
-                    if (this.multiInputEl?.nativeElement) {
-                        this.multiInputEl.nativeElement.value = '';
+                    const multiInputEl = this.multiInputEl();
+                    if (multiInputEl?.nativeElement) {
+                        multiInputEl.nativeElement.value = '';
                     } else {
                         event.target.value = '';
                     }
@@ -1429,12 +1435,13 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     handleSeparatorKey(event) {
         if (this.separator && this.multiple && !this.typeahead) {
             if (this.separator === event.key || (typeof this.separator === 'string' && event.key === this.separator) || (this.separator instanceof RegExp && event.key.match(this.separator))) {
-                const inputValue = (this.multiInputEl?.nativeElement?.value || event.target.value || '').trim();
+                const inputValue = (this.multiInputEl()?.nativeElement?.value || event.target.value || '').trim();
                 if (inputValue && !this.isSelected(inputValue)) {
                     this.updateModel([...(this.modelValue() || []), inputValue]);
                     this.onAdd.emit({ originalEvent: event, value: inputValue });
-                    if (this.multiInputEl?.nativeElement) {
-                        this.multiInputEl.nativeElement.value = '';
+                    const multiInputEl = this.multiInputEl();
+                    if (multiInputEl?.nativeElement) {
+                        multiInputEl.nativeElement.value = '';
                     } else {
                         event.target.value = '';
                     }
@@ -1484,7 +1491,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         this.focusedOptionIndex.set(-1);
         if (this.multiple) {
             if (isEmpty(target.value) && this.hasSelectedOption()) {
-                focus(this.multiContainerEL?.nativeElement);
+                focus(this.multiContainerEL()?.nativeElement);
                 this.focusedMultipleOptionIndex.set(this.modelValue().length);
             } else {
                 event.stopPropagation(); // To prevent onArrowLeftKeyOnMultiple method
@@ -1535,7 +1542,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
                 if (inputValue && !this.isSelected(inputValue)) {
                     this.updateModel([...(this.modelValue() || []), inputValue]);
                     this.onAdd.emit({ originalEvent: event, value: inputValue });
-                    this.inputEL?.nativeElement && (this.inputEL.nativeElement.value = '');
+                    inputEL?.nativeElement && (inputEL.nativeElement.value = '');
                 }
             }
         }
@@ -1566,17 +1573,19 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
         // Handle tab key behavior for multiple mode without typeahead
         if (this.multiple && !this.typeahead) {
-            const inputValue = (this.multiInputEl?.nativeElement?.value || this.inputEL?.nativeElement?.value || '').trim();
+            const inputValue = (this.multiInputEl()?.nativeElement?.value || this.inputEL()?.nativeElement?.value || '').trim();
 
             if (this.addOnTab) {
                 if (inputValue && !this.isSelected(inputValue)) {
                     // Add the value and keep focus
                     this.updateModel([...(this.modelValue() || []), inputValue]);
                     this.onAdd.emit({ originalEvent: event, value: inputValue });
-                    if (this.multiInputEl?.nativeElement) {
-                        this.multiInputEl.nativeElement.value = '';
-                    } else if (this.inputEL?.nativeElement) {
-                        this.inputEL.nativeElement.value = '';
+                    const inputEL = this.inputEL();
+                    const multiInputEl = this.multiInputEl();
+                    if (multiInputEl?.nativeElement) {
+                        multiInputEl.nativeElement.value = '';
+                    } else if (inputEL?.nativeElement) {
+                        inputEL.nativeElement.value = '';
                     }
 
                     this.updateInputValue();
@@ -1595,7 +1604,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     onBackspaceKey(event) {
         if (this.multiple) {
-            if (isNotEmpty(this.modelValue()) && !this.inputEL?.nativeElement?.value) {
+            if (isNotEmpty(this.modelValue()) && !this.inputEL()?.nativeElement?.value) {
                 const removedValue = this.modelValue()[this.modelValue().length - 1];
                 const newValue = this.modelValue().slice(0, -1);
                 this.updateModel(newValue);
@@ -1618,7 +1627,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         this.focusedMultipleOptionIndex.set(optionIndex);
         if (optionIndex > this.modelValue().length - 1) {
             this.focusedMultipleOptionIndex.set(-1);
-            focus(this.inputEL?.nativeElement);
+            focus(this.inputEL()?.nativeElement);
         }
     }
 
@@ -1630,7 +1639,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     onOptionSelect(event, option, isHide = true) {
         if (this.multiple) {
-            this.inputEL?.nativeElement && (this.inputEL.nativeElement.value = '');
+            inputEL?.nativeElement && (inputEL.nativeElement.value = '');
 
             if (!this.isSelected(option)) {
                 this.updateModel([...(this.modelValue() || []), option]);
@@ -1672,7 +1681,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
         this.updateModel(value);
         this.onUnselect.emit({ originalEvent: event, value: removedOption });
-        focus(this.inputEL?.nativeElement);
+        focus(this.inputEL()?.nativeElement);
     }
 
     updateModel(options) {
@@ -1690,17 +1699,18 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     }
 
     updateInputValue() {
-        if (this.inputEL && this.inputEL.nativeElement) {
+        const inputEL = this.inputEL();
+        if (inputEL && inputEL.nativeElement) {
             if (!this.multiple) {
-                this.inputEL.nativeElement.value = this.inputValue();
+                inputEL.nativeElement.value = this.inputValue();
             } else {
-                this.inputEL.nativeElement.value = '';
+                inputEL.nativeElement.value = '';
             }
         }
     }
 
     updateInputWithForceSelection(event: any) {
-        const input = this.inputEL?.nativeElement;
+        const input = this.inputEL()?.nativeElement;
         const inputCleared = !input?.value && isNotEmpty(this.modelValue());
 
         if (!this.forceSelection || this.overlayVisible || (!input?.value && !inputCleared)) {
@@ -1738,13 +1748,14 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     scrollInView(index = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
-        if (this.itemsViewChild && this.itemsViewChild.nativeElement) {
-            const element = findSingle(this.itemsViewChild.nativeElement, `li[id="${id}"]`);
+        const itemsViewChild = this.itemsViewChild();
+        if (itemsViewChild && itemsViewChild.nativeElement) {
+            const element = findSingle(itemsViewChild.nativeElement, `li[id="${id}"]`);
             if (element) {
                 element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
             } else if (!this.virtualScrollerDisabled) {
                 setTimeout(() => {
-                    this.virtualScroll && this.scroller?.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex());
+                    this.virtualScroll && this.scroller()?.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex());
                 }, 0);
             }
         }
@@ -1766,9 +1777,9 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
         this.overlayVisible = true;
         const focusedOptionIndex = this.focusedOptionIndex() !== -1 ? this.focusedOptionIndex() : this.autoOptionFocus ? this.findFirstFocusedOptionIndex() : -1;
         this.focusedOptionIndex.set(focusedOptionIndex);
-        isFocus && focus(this.inputEL?.nativeElement);
+        isFocus && focus(this.inputEL()?.nativeElement);
         if (isFocus) {
-            focus(this.inputEL?.nativeElement);
+            focus(this.inputEL()?.nativeElement);
         }
         this.onShow.emit();
         this.cd.markForCheck();
@@ -1779,7 +1790,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
             this.dirty = isFocus;
             this.overlayVisible = false;
             this.focusedOptionIndex.set(-1);
-            isFocus && focus(this.inputEL?.nativeElement);
+            isFocus && focus(this.inputEL()?.nativeElement);
             this.onHide.emit();
             this.updateInputWithForceSelection(null);
             this.cd.markForCheck();
@@ -1792,7 +1803,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     clear() {
         this.updateModel(null);
-        this.inputEL?.nativeElement && (this.inputEL.nativeElement.value = '');
+        inputEL?.nativeElement && (inputEL.nativeElement.value = '');
         this.onClear.emit();
     }
 
@@ -1816,7 +1827,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     }
 
     getSelectedItemTemplateLabel(option: any) {
-        const template = this.selectedItemTemplate || this._selectedItemTemplate;
+        const template = this.selectedItemTemplate() || this._selectedItemTemplate;
 
         if (!template || option == null) {
             return null;
@@ -1870,18 +1881,19 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     }
 
     onOverlayBeforeEnter() {
-        this.itemsWrapper = <any>findSingle(this.overlayViewChild.overlayViewChild?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-name="pcoverlay"]');
+        this.itemsWrapper = <any>findSingle(this.overlayViewChild().overlayViewChild()?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-name="pcoverlay"]');
 
+        const scroller = this.scroller();
         if (this.virtualScroll) {
-            this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
-            this.scroller?.viewInit();
+            scroller?.setContentEl(this.itemsViewChild()?.nativeElement);
+            scroller?.viewInit();
         }
         if (this.visibleOptions() && this.visibleOptions().length) {
             if (this.virtualScroll) {
                 const selectedIndex = this.modelValue() ? this.focusedOptionIndex() : -1;
 
                 if (selectedIndex !== -1) {
-                    this.scroller?.scrollToIndex(selectedIndex);
+                    scroller?.scrollToIndex(selectedIndex);
                 }
             } else {
                 let selectedListItem = findSingle(this.itemsWrapper as HTMLElement, '[data-pc-section="option"][data-p-selected="true"]');

--- a/packages/optimus-ui/src/autocomplete/autocomplete.ts
+++ b/packages/optimus-ui/src/autocomplete/autocomplete.ts
@@ -17,7 +17,6 @@ import {
     NgZone,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     TemplateRef,
     ViewEncapsulation,
@@ -982,7 +981,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
     readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -1542,6 +1541,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
                 if (inputValue && !this.isSelected(inputValue)) {
                     this.updateModel([...(this.modelValue() || []), inputValue]);
                     this.onAdd.emit({ originalEvent: event, value: inputValue });
+                    const inputEL = this.inputEL();
                     inputEL?.nativeElement && (inputEL.nativeElement.value = '');
                 }
             }
@@ -1639,6 +1639,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     onOptionSelect(event, option, isHide = true) {
         if (this.multiple) {
+            const inputEL = this.inputEL();
             inputEL?.nativeElement && (inputEL.nativeElement.value = '');
 
             if (!this.isSelected(option)) {
@@ -1803,6 +1804,7 @@ export class AutoComplete<T = any> extends BaseInput<AutoCompletePassThrough> {
 
     clear() {
         this.updateModel(null);
+        const inputEL = this.inputEL();
         inputEL?.nativeElement && (inputEL.nativeElement.value = '');
         this.onClear.emit();
     }

--- a/packages/optimus-ui/src/badge/badge.test.ts
+++ b/packages/optimus-ui/src/badge/badge.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DebugElement, ElementRef, input, provideZonelessChangeDetection, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, ElementRef, input, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SharedModule } from '@openng/optimus-ui/api';
@@ -69,7 +69,7 @@ class TestStyleClassBadgeComponent {
     template: `<button #button pBadge [value]="value">Button</button>`
 })
 class TestDirectiveBadgeComponent {
-    @ViewChild('button', { static: true }) button!: ElementRef;
+    readonly button = viewChild.required<ElementRef>('button');
     value: string | number | undefined = '5';
 }
 

--- a/packages/optimus-ui/src/blockui/blockui.test.ts
+++ b/packages/optimus-ui/src/blockui/blockui.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, input, provideZonelessChangeDetection, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, input, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -88,7 +88,7 @@ class TestTemplateBlockUIComponent {
     `
 })
 class TestTargetBlockUIComponent {
-    @ViewChild('targetElement', { static: true }) targetElement!: ElementRef;
+    readonly targetElement = viewChild.required<ElementRef>('targetElement');
     blocked = false;
 }
 
@@ -100,10 +100,10 @@ class TestTargetBlockUIComponent {
     template: `<div #blockableElement class="blockable-content"><ng-content></ng-content></div>`
 })
 class MockBlockableComponent {
-    @ViewChild('blockableElement', { static: true }) blockableElement!: ElementRef;
+    readonly blockableElement = viewChild.required<ElementRef>('blockableElement');
 
     getBlockableElement() {
-        return this.blockableElement.nativeElement;
+        return this.blockableElement().nativeElement;
     }
 }
 
@@ -119,7 +119,7 @@ class MockBlockableComponent {
     `
 })
 class TestBlockableTargetBlockUIComponent {
-    @ViewChild('blockableTarget', { static: true }) blockableTarget!: MockBlockableComponent;
+    readonly blockableTarget = viewChild.required<MockBlockableComponent>('blockableTarget');
     blocked = false;
 }
 
@@ -133,7 +133,7 @@ class TestBlockableTargetBlockUIComponent {
     `
 })
 class TestInvalidTargetBlockUIComponent {
-    @ViewChild('invalidTarget', { static: true }) invalidTarget!: ElementRef;
+    readonly invalidTarget = viewChild.required<ElementRef>('invalidTarget');
     blocked = false;
 }
 
@@ -465,8 +465,8 @@ describe('BlockUI', () => {
         });
 
         it('should have blockable target reference', () => {
-            expect(component.blockableTarget).toBeTruthy();
-            expect(blockUIComponent.target).toBe(component.blockableTarget);
+            expect(component.blockableTarget()).toBeTruthy();
+            expect(blockUIComponent.target).toBe(component.blockableTarget());
         });
 
         it('should block target component', async () => {

--- a/packages/optimus-ui/src/blockui/blockui.test.ts
+++ b/packages/optimus-ui/src/blockui/blockui.test.ts
@@ -5,6 +5,8 @@ import { By } from '@angular/platform-browser';
 import { SharedModule } from '@openng/optimus-ui/api';
 import { BlockUI, BlockUIModule } from './blockui';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1063,5 +1065,41 @@ describe('BlockUI', () => {
                 expect(hookCalled).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [BlockUI, PrimeTemplate],
+    template: `
+        <p-blockui>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-blockui>
+    `
+})
+class BlockUIQueryApiHostComponent {}
+
+describe('BlockUI Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [BlockUIQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(BlockUIQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(BlockUI)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/blockui/blockui.ts
+++ b/packages/optimus-ui/src/blockui/blockui.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ContentChild, ContentChildren, ElementRef, inject, InjectionToken, Input, NgModule, numberAttribute, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, inject, InjectionToken, Input, NgModule, numberAttribute, QueryList, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { blockBodyScroll, unblockBodyScroll } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -20,7 +20,7 @@ const BLOCKUI_INSTANCE = new InjectionToken<BlockUI>('BLOCKUI_INSTANCE');
     imports: [CommonModule, SharedModule],
     template: `
         <ng-content></ng-content>
-        <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate"></ng-container>
+        <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate"></ng-container>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
@@ -85,7 +85,7 @@ export class BlockUI extends BaseComponent<BlockUIPassThrough> {
      * template of the content
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<any> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<any>>('content', { descendants: false });
 
     _blocked: boolean = false;
 
@@ -103,10 +103,10 @@ export class BlockUI extends BaseComponent<BlockUIPassThrough> {
 
     _contentTemplate: TemplateRef<any> | undefined;
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this.contentTemplate = item.template;

--- a/packages/optimus-ui/src/blockui/blockui.ts
+++ b/packages/optimus-ui/src/blockui/blockui.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, inject, InjectionToken, Input, NgModule, numberAttribute, QueryList, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, inject, InjectionToken, Input, NgModule, numberAttribute, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { blockBodyScroll, unblockBodyScroll } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -106,14 +106,14 @@ export class BlockUI extends BaseComponent<BlockUIPassThrough> {
     readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'content':
-                    this.contentTemplate = item.template;
+                    this._contentTemplate = item.template;
                     break;
 
                 default:
-                    this.contentTemplate = item.template;
+                    this._contentTemplate = item.template;
                     break;
             }
         });

--- a/packages/optimus-ui/src/breadcrumb/breadcrumb.test.ts
+++ b/packages/optimus-ui/src/breadcrumb/breadcrumb.test.ts
@@ -266,11 +266,11 @@ describe('Breadcrumb', () => {
         });
 
         it('should initialize templates properties', () => {
-            expect(breadcrumbInstance.templates).toBeDefined();
+            expect(breadcrumbInstance.templates()).toBeDefined();
             expect(breadcrumbInstance._itemTemplate).toBeUndefined();
             expect(breadcrumbInstance._separatorTemplate).toBeUndefined();
-            expect(breadcrumbInstance.itemTemplate).toBeUndefined();
-            expect(breadcrumbInstance.separatorTemplate).toBeUndefined();
+            expect(breadcrumbInstance.itemTemplate()).toBeUndefined();
+            expect(breadcrumbInstance.separatorTemplate()).toBeUndefined();
         });
 
         it('should have onItemClick output emitter', () => {

--- a/packages/optimus-ui/src/breadcrumb/breadcrumb.ts
+++ b/packages/optimus-ui/src/breadcrumb/breadcrumb.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ContentChild, ContentChildren, EventEmitter, inject, InjectionToken, Input, NgModule, Output, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, inject, InjectionToken, Input, NgModule, Output, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, RouterModule } from '@angular/router';
 import { MenuItem, PrimeTemplate, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { Badge } from '@openng/optimus-ui/badge';
@@ -25,8 +25,8 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
             <ol [class]="cx('list')" [pBind]="ptm('list')">
                 @if (home && home.visible !== false) {
                     <li [attr.id]="home.id" [class]="cn(cx('homeItem'), home.styleClass)" [ngStyle]="home.style" pTooltip [tooltipOptions]="home.tooltipOptions" [pBind]="ptm('homeItem')" [unstyled]="unstyled()">
-                        @if (itemTemplate || _itemTemplate) {
-                            <ng-template *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: home }"></ng-template>
+                        @if (itemTemplate() || _itemTemplate) {
+                            <ng-template *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: home }"></ng-template>
                         } @else {
                             @if (!home.routerLink) {
                                 <a
@@ -104,10 +104,10 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                 }
                 @if (model && home) {
                     <li [class]="cx('separator')" [pBind]="ptm('separator')" aria-hidden="true">
-                        @if (!separatorTemplate && !_separatorTemplate) {
+                        @if (!separatorTemplate() && !_separatorTemplate) {
                             <svg data-p-icon="chevron-right" [pBind]="ptm('separatorIcon')" />
                         }
-                        <ng-template *ngTemplateOutlet="separatorTemplate || _separatorTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="separatorTemplate() || _separatorTemplate"></ng-template>
                     </li>
                 }
                 @for (menuitem of model; track menuitem; let end = $last; let i = $index) {
@@ -121,8 +121,8 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                             [pBind]="getPTOptions(menuitem, i, 'item')"
                             [pTooltipUnstyled]="unstyled()"
                         >
-                            @if (itemTemplate || _itemTemplate) {
-                                <ng-template *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: menuitem }"></ng-template>
+                            @if (itemTemplate() || _itemTemplate) {
+                                <ng-template *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: menuitem }"></ng-template>
                             } @else {
                                 @if (!menuitem?.routerLink) {
                                     <a
@@ -137,7 +137,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                                         [attr.aria-current]="isCurrentPage(i) ? 'page' : undefined"
                                         [pBind]="getPTOptions(menuitem, i, 'itemLink')"
                                     >
-                                        @if (!itemTemplate && !_itemTemplate) {
+                                        @if (!itemTemplate() && !_itemTemplate) {
                                             @if (menuitem?.icon) {
                                                 <span [class]="cn(cx('itemIcon'), menuitem?.icon, menuitem?.iconClass)" [ngStyle]="menuitem?.iconStyle" [pBind]="getPTOptions(menuitem, i, 'itemIcon')"></span>
                                             }
@@ -196,10 +196,10 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                     }
                     @if (!end && menuitem.visible !== false) {
                         <li [class]="cx('separator')" [pBind]="ptm('separator')" aria-hidden="true">
-                            @if (!separatorTemplate && !_separatorTemplate) {
+                            @if (!separatorTemplate() && !_separatorTemplate) {
                                 <svg data-p-icon="chevron-right" [pBind]="ptm('separatorIcon')" />
                             }
-                            <ng-template *ngTemplateOutlet="separatorTemplate || _separatorTemplate"></ng-template>
+                            <ng-template *ngTemplateOutlet="separatorTemplate() || _separatorTemplate"></ng-template>
                         </li>
                     }
                 }
@@ -287,22 +287,22 @@ export class Breadcrumb extends BaseComponent<BreadcrumbPassThrough> {
      * Custom item template.
      * @group Templates
      */
-    @ContentChild('item') itemTemplate: TemplateRef<BreadcrumbItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<BreadcrumbItemTemplateContext>>('item');
 
     /**
      * Custom separator template.
      * @group Templates
      */
-    @ContentChild('separator') separatorTemplate: TemplateRef<void> | undefined;
+    readonly separatorTemplate = contentChild<TemplateRef<void>>('separator');
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _separatorTemplate: TemplateRef<void> | undefined;
 
     _itemTemplate: TemplateRef<BreadcrumbItemTemplateContext> | undefined;
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'separator':
                     this._separatorTemplate = item.template;

--- a/packages/optimus-ui/src/button/button.test.ts
+++ b/packages/optimus-ui/src/button/button.test.ts
@@ -4,6 +4,8 @@ import { By } from '@angular/platform-browser';
 
 import { Button, ButtonDirective, ButtonIcon, ButtonLabel } from './button';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 // Basic Button Component Test
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1582,5 +1584,40 @@ describe('ButtonDirective', () => {
             buttonDirective.raised = true;
             expect(buttonDirective.raised).toBe(true);
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [ButtonDirective, ButtonIcon, ButtonLabel, SharedModule],
+    template: `
+        <button pButton>
+            <span pButtonIcon>I</span>
+            <span pButtonLabel>L</span>
+        </button>
+    `
+})
+class ButtonQueryApiHostComponent {}
+
+describe('ButtonDirective Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ButtonQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ButtonQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(ButtonDirective)).injector.get(ButtonDirective);
+
+        // iconSignal/labelSignal are private; their resolution is observable via the public computeds
+        expect(instance.isIconOnly()).toBe(false);
+        expect((instance as any).iconSignal()).toBeDefined();
+        expect((instance as any).labelSignal()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/button/button.test.ts
+++ b/packages/optimus-ui/src/button/button.test.ts
@@ -833,7 +833,7 @@ describe('Button', () => {
                 expect(() => buttonInstance.ngAfterContentInit()).not.toThrow();
 
                 // Test that contentTemplate property exists (ContentChild)
-                expect(buttonInstance.contentTemplate).toBeDefined();
+                expect(buttonInstance.contentTemplate()).toBeDefined();
 
                 // Verify content container is rendered
                 const buttonElement = contentTemplateFixture.debugElement.query(By.css('button'));
@@ -849,8 +849,8 @@ describe('Button', () => {
                 const buttonInstance = contentTemplateFixture.debugElement.query(By.directive(Button)).componentInstance;
 
                 // @ContentChild('content') should set contentTemplate
-                expect(buttonInstance.contentTemplate).toBeDefined();
-                expect(buttonInstance.contentTemplate?.constructor.name).toBe('TemplateRef');
+                expect(buttonInstance.contentTemplate()).toBeDefined();
+                expect(buttonInstance.contentTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process loadingIconTemplate from @ContentChild('loadingicon')", async () => {
@@ -858,7 +858,7 @@ describe('Button', () => {
                 const buttonInstance = fixture.debugElement.query(By.directive(Button)).componentInstance;
 
                 // loadingIconTemplate should be undefined when not provided
-                expect(buttonInstance.loadingIconTemplate).toBeUndefined();
+                expect(buttonInstance.loadingIconTemplate()).toBeUndefined();
             });
 
             it("should process iconTemplate from @ContentChild('icon')", async () => {
@@ -866,7 +866,7 @@ describe('Button', () => {
                 const buttonInstance = fixture.debugElement.query(By.directive(Button)).componentInstance;
 
                 // iconTemplate should be undefined when not provided
-                expect(buttonInstance.iconTemplate).toBeUndefined();
+                expect(buttonInstance.iconTemplate()).toBeUndefined();
             });
         });
 
@@ -892,7 +892,7 @@ describe('Button', () => {
                 await fixture.whenStable();
 
                 const contentTemplateButton = contentTemplateFixture.debugElement.query(By.directive(Button)).componentInstance;
-                expect(contentTemplateButton.contentTemplate).toBeDefined();
+                expect(contentTemplateButton.contentTemplate()).toBeDefined();
             });
 
             it('should use default templates when custom ones are not provided', () => {

--- a/packages/optimus-ui/src/button/button.ts
+++ b/packages/optimus-ui/src/button/button.ts
@@ -4,9 +4,7 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
     contentChild,
-    ContentChildren,
     Directive,
     effect,
     EventEmitter,
@@ -17,9 +15,9 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChildren
 } from '@angular/core';
 import { addClass, createElement, findSingle, isEmpty } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
@@ -596,9 +594,9 @@ export class ButtonDirective extends BaseComponent {
             [attr.data-p-severity]="severity || buttonProps?.severity"
         >
             <ng-content></ng-content>
-            <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate"></ng-container>
+            <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate"></ng-container>
             @if (loading || buttonProps?.loading) {
-                @if (!loadingIconTemplate && !_loadingIconTemplate) {
+                @if (!loadingIconTemplate() && !_loadingIconTemplate) {
                     @if (loadingIcon || buttonProps?.loadingIcon) {
                         <span [class]="cn(cx('loadingIcon'), 'pi-spin', loadingIcon || buttonProps?.loadingIcon)" [pBind]="ptm('loadingIcon')" [attr.aria-hidden]="true"></span>
                     }
@@ -606,22 +604,22 @@ export class ButtonDirective extends BaseComponent {
                         <svg data-p-icon="spinner" [class]="cn(cx('loadingIcon'), cx('spinnerIcon'))" [pBind]="ptm('loadingIcon')" [spin]="true" [attr.aria-hidden]="true" />
                     }
                 }
-                @if (loadingIconTemplate || _loadingIconTemplate) {
-                    <ng-template *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate; context: { class: cx('loadingIcon'), pt: ptm('loadingIcon') }"></ng-template>
+                @if (loadingIconTemplate() || _loadingIconTemplate) {
+                    <ng-template *ngTemplateOutlet="loadingIconTemplate() || _loadingIconTemplate; context: { class: cx('loadingIcon'), pt: ptm('loadingIcon') }"></ng-template>
                 }
             }
             @if (!(loading || buttonProps?.loading)) {
-                @if ((icon || buttonProps?.icon) && !iconTemplate && !_iconTemplate) {
+                @if ((icon || buttonProps?.icon) && !iconTemplate() && !_iconTemplate) {
                     <span [class]="cn(cx('icon'), icon || buttonProps?.icon)" [pBind]="ptm('icon')" [attr.data-p]="dataIconP"></span>
                 }
-                @if (!icon && (iconTemplate || _iconTemplate)) {
-                    <ng-template *ngTemplateOutlet="iconTemplate || _iconTemplate; context: { class: cx('icon'), pt: ptm('icon') }"></ng-template>
+                @if (!icon && (iconTemplate() || _iconTemplate)) {
+                    <ng-template *ngTemplateOutlet="iconTemplate() || _iconTemplate; context: { class: cx('icon'), pt: ptm('icon') }"></ng-template>
                 }
             }
-            @if (!contentTemplate && !_contentTemplate && (label || buttonProps?.label)) {
+            @if (!contentTemplate() && !_contentTemplate && (label || buttonProps?.label)) {
                 <span [class]="cx('label')" [attr.aria-hidden]="(icon || buttonProps?.icon) && !(label || buttonProps?.label)" [pBind]="ptm('label')" [attr.data-p]="dataLabelP">{{ label || buttonProps?.label }}</span>
             }
-            @if (!contentTemplate && !_contentTemplate && (badge || buttonProps?.badge)) {
+            @if (!contentTemplate() && !_contentTemplate && (badge || buttonProps?.badge)) {
                 <p-badge [value]="badge || buttonProps?.badge" [severity]="badgeSeverity || buttonProps?.badgeSeverity" [pt]="ptm('pcBadge')" [unstyled]="unstyled()"></p-badge>
             }
         </button>
@@ -833,21 +831,21 @@ export class Button extends BaseComponent<ButtonPassThrough> {
      * Custom content template.
      * @group Templates
      **/
-    @ContentChild('content') contentTemplate: TemplateRef<void> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<void>>('content');
 
     /**
      * Custom loading icon template.
      * @group Templates
      **/
-    @ContentChild('loadingicon') loadingIconTemplate: TemplateRef<ButtonLoadingIconTemplateContext> | undefined;
+    readonly loadingIconTemplate = contentChild<TemplateRef<ButtonLoadingIconTemplateContext>>('loadingicon');
 
     /**
      * Custom icon template.
      * @group Templates
      **/
-    @ContentChild('icon') iconTemplate: TemplateRef<ButtonIconTemplateContext> | undefined;
+    readonly iconTemplate = contentChild<TemplateRef<ButtonIconTemplateContext>>('icon');
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     pcFluid: Fluid | null = inject(Fluid, { optional: true, host: true, skipSelf: true });
 
@@ -856,7 +854,7 @@ export class Button extends BaseComponent<ButtonPassThrough> {
     }
 
     get hasIcon() {
-        return this.icon || this.buttonProps?.icon || this.iconTemplate || this._iconTemplate || this.loadingIcon || this.loadingIconTemplate || this._loadingIconTemplate;
+        return this.icon || this.buttonProps?.icon || this.iconTemplate() || this._iconTemplate || this.loadingIcon || this.loadingIconTemplate() || this._loadingIconTemplate;
     }
 
     _contentTemplate: TemplateRef<void> | undefined;
@@ -866,7 +864,7 @@ export class Button extends BaseComponent<ButtonPassThrough> {
     _loadingIconTemplate: TemplateRef<ButtonLoadingIconTemplateContext> | undefined;
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/card/card.test.ts
+++ b/packages/optimus-ui/src/card/card.test.ts
@@ -4,6 +4,8 @@ import { By } from '@angular/platform-browser';
 
 import { Card, CardModule } from './card';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1793,5 +1795,45 @@ describe('Card', () => {
                 expect(titleEl.nativeElement.getAttribute('aria-level')).toBe('2');
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Card, SharedModule],
+    template: `
+        <p-card>
+            <p-header>H</p-header>
+            <p-footer>F</p-footer>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-card>
+    `
+})
+class CardQueryApiHostComponent {}
+
+describe('Card Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [CardQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(CardQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Card)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
+        expect(instance.headerFacet()).toBeDefined();
+        expect(instance.footerFacet()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/card/card.test.ts
+++ b/packages/optimus-ui/src/card/card.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DebugElement, provideZonelessChangeDetection, TemplateRef, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, provideZonelessChangeDetection, TemplateRef, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -93,11 +93,11 @@ class TestFacetCardComponent {}
     `
 })
 class TestContentChildCardComponent {
-    @ViewChild('header') headerTemplate!: TemplateRef<any>;
-    @ViewChild('title') titleTemplate!: TemplateRef<any>;
-    @ViewChild('subtitle') subtitleTemplate!: TemplateRef<any>;
-    @ViewChild('content') contentTemplate!: TemplateRef<any>;
-    @ViewChild('footer') footerTemplate!: TemplateRef<any>;
+    readonly headerTemplate = viewChild.required<TemplateRef<any>>('header');
+    readonly titleTemplate = viewChild.required<TemplateRef<any>>('title');
+    readonly subtitleTemplate = viewChild.required<TemplateRef<any>>('subtitle');
+    readonly contentTemplate = viewChild.required<TemplateRef<any>>('content');
+    readonly footerTemplate = viewChild.required<TemplateRef<any>>('footer');
 }
 
 @Component({
@@ -588,11 +588,11 @@ describe('Card', () => {
         });
 
         it('should have correct template references in component', () => {
-            expect(contentChildComponent.headerTemplate).toBeDefined();
-            expect(contentChildComponent.titleTemplate).toBeDefined();
-            expect(contentChildComponent.subtitleTemplate).toBeDefined();
-            expect(contentChildComponent.contentTemplate).toBeDefined();
-            expect(contentChildComponent.footerTemplate).toBeDefined();
+            expect(contentChildComponent.headerTemplate()).toBeDefined();
+            expect(contentChildComponent.titleTemplate()).toBeDefined();
+            expect(contentChildComponent.subtitleTemplate()).toBeDefined();
+            expect(contentChildComponent.contentTemplate()).toBeDefined();
+            expect(contentChildComponent.footerTemplate()).toBeDefined();
         });
     });
 

--- a/packages/optimus-ui/src/card/card.ts
+++ b/packages/optimus-ui/src/card/card.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, QueryList, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { equals } from '@openng/optimus-ui-utils';
 import { BlockableUI, Footer, Header, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -165,7 +165,7 @@ export class Card extends BaseComponent<CardPassThrough> implements BlockableUI 
     readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;

--- a/packages/optimus-ui/src/card/card.ts
+++ b/packages/optimus-ui/src/card/card.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ContentChild, ContentChildren, inject, InjectionToken, Input, NgModule, QueryList, signal, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, QueryList, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { equals } from '@openng/optimus-ui-utils';
 import { BlockableUI, Footer, Header, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -18,37 +18,37 @@ const CARD_INSTANCE = new InjectionToken<Card>('CARD_INSTANCE');
     standalone: true,
     imports: [CommonModule, SharedModule, BindModule],
     template: `
-        @if (headerFacet || headerTemplate || _headerTemplate) {
+        @if (headerFacet() || headerTemplate() || _headerTemplate) {
             <div [pBind]="ptm('header')" [class]="cx('header')">
                 <ng-content select="p-header"></ng-content>
-                <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
             </div>
         }
         <div [pBind]="ptm('body')" [class]="cx('body')">
-            @if (header || titleTemplate || _titleTemplate) {
+            @if (header || titleTemplate() || _titleTemplate) {
                 <div [pBind]="ptm('title')" [class]="cx('title')">
-                    @if (header && !_titleTemplate && !titleTemplate) {
+                    @if (header && !_titleTemplate && !titleTemplate()) {
                         {{ header }}
                     }
-                    <ng-container *ngTemplateOutlet="titleTemplate || _titleTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="titleTemplate() || _titleTemplate"></ng-container>
                 </div>
             }
-            @if (subheader || subtitleTemplate || _subtitleTemplate) {
+            @if (subheader || subtitleTemplate() || _subtitleTemplate) {
                 <div [pBind]="ptm('subtitle')" [class]="cx('subtitle')">
-                    @if (subheader && !_subtitleTemplate && !subtitleTemplate) {
+                    @if (subheader && !_subtitleTemplate && !subtitleTemplate()) {
                         {{ subheader }}
                     }
-                    <ng-container *ngTemplateOutlet="subtitleTemplate || _subtitleTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="subtitleTemplate() || _subtitleTemplate"></ng-container>
                 </div>
             }
             <div [pBind]="ptm('content')" [class]="cx('content')">
                 <ng-content></ng-content>
-                <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate"></ng-container>
             </div>
-            @if (footerFacet || footerTemplate || _footerTemplate) {
+            @if (footerFacet() || footerTemplate() || _footerTemplate) {
                 <div [pBind]="ptm('footer')" [class]="cx('footer')">
                     <ng-content select="p-footer"></ng-content>
-                    <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
                 </div>
             }
         </div>
@@ -112,39 +112,39 @@ export class Card extends BaseComponent<CardPassThrough> implements BlockableUI 
      */
     @Input() styleClass: string | undefined;
 
-    @ContentChild(Header) headerFacet: TemplateRef<any> | undefined;
+    readonly headerFacet = contentChild(Header);
 
-    @ContentChild(Footer) footerFacet: TemplateRef<any> | undefined;
+    readonly footerFacet = contentChild(Footer);
 
     /**
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
 
     /**
      * Custom title template.
      * @group Templates
      */
-    @ContentChild('title', { descendants: false }) titleTemplate: TemplateRef<void> | undefined;
+    readonly titleTemplate = contentChild<TemplateRef<void>>('title', { descendants: false });
 
     /**
      * Custom subtitle template.
      * @group Templates
      */
-    @ContentChild('subtitle', { descendants: false }) subtitleTemplate: TemplateRef<void> | undefined;
+    readonly subtitleTemplate = contentChild<TemplateRef<void>>('subtitle', { descendants: false });
 
     /**
      * Custom content template.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<void> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<void>>('content', { descendants: false });
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: TemplateRef<void> | undefined;
+    readonly footerTemplate = contentChild<TemplateRef<void>>('footer', { descendants: false });
 
     _headerTemplate: TemplateRef<void> | undefined;
 
@@ -162,10 +162,10 @@ export class Card extends BaseComponent<CardPassThrough> implements BlockableUI 
         return this.el.nativeElement;
     }
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;

--- a/packages/optimus-ui/src/carousel/carousel.test.ts
+++ b/packages/optimus-ui/src/carousel/carousel.test.ts
@@ -9,6 +9,7 @@ import { provideOptimus } from '@openng/optimus-ui/config';
 import type { CarouselPageEvent, CarouselResponsiveOptions } from '@openng/optimus-ui/types/carousel';
 import { Carousel } from './carousel';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 // Mock data for testing
 const mockProducts = [
     { id: '1', name: 'Product 1', image: 'product1.jpg', price: 100, inventoryStatus: 'INSTOCK' },
@@ -1368,5 +1369,45 @@ describe('Carousel', () => {
                 }
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Carousel, SharedModule],
+    template: `
+        <p-carousel [value]="items" [numVisible]="1" [numScroll]="1">
+            <ng-template #item let-item>{{ item }}</ng-template>
+            <ng-template #previousicon>p</ng-template>
+            <ng-template #nexticon>n</ng-template>
+            <ng-template pTemplate="footer">f</ng-template>
+        </p-carousel>
+    `
+})
+class CarouselQueryApiHostComponent {
+    items = [1, 2, 3];
+}
+
+describe('Carousel Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [CarouselQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(CarouselQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Carousel)).componentInstance;
+
+        expect(instance.previousIconTemplate()).toBeDefined();
+        expect(instance.nextIconTemplate()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'footer')).toBe(true);
+        expect(instance.itemsContainer()).toBeDefined();
+        expect(instance.indicatorContent()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/carousel/carousel.test.ts
+++ b/packages/optimus-ui/src/carousel/carousel.test.ts
@@ -968,7 +968,7 @@ describe('Carousel', () => {
             });
 
             it('should apply string class to header', () => {
-                carouselInstance.headerTemplate = {} as any;
+                (carouselInstance as any).headerFacet = () => ({}) as any;
                 fixture.componentRef.setInput('pt', { header: 'HEADER_CLASS' });
                 fixture.detectChanges();
 
@@ -979,7 +979,7 @@ describe('Carousel', () => {
             });
 
             it('should apply string class to footer', () => {
-                carouselInstance.footerTemplate = {} as any;
+                (carouselInstance as any).footerFacet = () => ({}) as any;
                 fixture.componentRef.setInput('pt', { footer: 'FOOTER_CLASS' });
                 fixture.detectChanges();
 
@@ -1115,7 +1115,7 @@ describe('Carousel', () => {
             });
 
             it('should apply mixed PT values', () => {
-                carouselInstance.headerTemplate = {} as any;
+                (carouselInstance as any).headerFacet = () => ({}) as any;
                 fixture.componentRef.setInput('pt', {
                     root: {
                         class: 'ROOT_MIXED_CLASS'

--- a/packages/optimus-ui/src/carousel/carousel.ts
+++ b/packages/optimus-ui/src/carousel/carousel.ts
@@ -3,8 +3,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -13,11 +11,12 @@ import {
     NgZone,
     numberAttribute,
     Output,
-    QueryList,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { addClass, find, findSingle, getAttribute, removeClass, setAttribute, uuid } from '@openng/optimus-ui-utils';
 import { Footer, Header, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
@@ -37,9 +36,9 @@ import { CarouselStyle } from './style/carouselstyle';
     standalone: true,
     imports: [CommonModule, ChevronRightIcon, ButtonModule, ChevronLeftIcon, ChevronDownIcon, ChevronUpIcon, SharedModule, BindModule],
     template: `
-        <div [class]="cx('header')" *ngIf="headerFacet || headerTemplate" [pBind]="ptm('header')">
+        <div [class]="cx('header')" *ngIf="headerFacet() || headerTemplate()" [pBind]="ptm('header')">
             <ng-content select="p-header"></ng-content>
-            <ng-container *ngTemplateOutlet="headerTemplate"></ng-container>
+            <ng-container *ngTemplateOutlet="headerTemplate()"></ng-container>
         </div>
         <div [class]="contentClass" [ngClass]="cx('contentContainer')" [pBind]="ptm('contentContainer')">
             <div [class]="cx('content')" [attr.aria-live]="allowAutoplay ? 'polite' : 'off'" [pBind]="ptm('content')">
@@ -55,12 +54,12 @@ import { CarouselStyle } from './style/carouselstyle';
                     attr.data-pc-group-section="navigator"
                 >
                     <ng-template #icon>
-                        <ng-container *ngIf="!previousIconTemplate && !_previousIconTemplate && !prevButtonProps?.icon">
+                        <ng-container *ngIf="!previousIconTemplate() && !_previousIconTemplate && !prevButtonProps?.icon">
                             <svg data-p-icon="chevron-left" *ngIf="!isVertical()" />
                             <svg data-p-icon="chevron-up" *ngIf="isVertical()" />
                         </ng-container>
-                        <ng-container *ngIf="(previousIconTemplate || _previousIconTemplate) && !prevButtonProps?.icon">
-                            <ng-template *ngTemplateOutlet="previousIconTemplate || _previousIconTemplate"></ng-template>
+                        <ng-container *ngIf="(previousIconTemplate() || _previousIconTemplate) && !prevButtonProps?.icon">
+                            <ng-template *ngTemplateOutlet="previousIconTemplate() || _previousIconTemplate"></ng-template>
                         </ng-container>
                     </ng-template>
                 </p-button>
@@ -77,7 +76,7 @@ import { CarouselStyle } from './style/carouselstyle';
                             [attr.data-p-carousel-item-end]="clonedItemsForStarting && clonedItemsForStarting.length - 1 === index"
                             [pBind]="ptm('itemClone')"
                         >
-                            <ng-container *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: item }"></ng-container>
+                            <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: item }"></ng-container>
                         </div>
                         <div
                             *ngFor="let item of value; let index = index"
@@ -91,7 +90,7 @@ import { CarouselStyle } from './style/carouselstyle';
                             [attr.data-p-carousel-item-end]="lastIndex() === index"
                             [pBind]="getItemPTOptions('item', index)"
                         >
-                            <ng-container *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: item }"></ng-container>
+                            <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: item }"></ng-container>
                         </div>
                         <div
                             *ngFor="let item of clonedItemsForFinishing; let index = index"
@@ -101,7 +100,7 @@ import { CarouselStyle } from './style/carouselstyle';
                             [attr.data-p-carousel-item-end]="false"
                             [pBind]="ptm('itemClone')"
                         >
-                            <ng-container *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: item }"></ng-container>
+                            <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: item }"></ng-container>
                         </div>
                     </div>
                 </div>
@@ -118,12 +117,12 @@ import { CarouselStyle } from './style/carouselstyle';
                     attr.data-pc-group-section="navigator"
                 >
                     <ng-template #icon>
-                        <ng-container *ngIf="!nextIconTemplate && !_nextIconTemplate && !nextButtonProps?.icon">
+                        <ng-container *ngIf="!nextIconTemplate() && !_nextIconTemplate && !nextButtonProps?.icon">
                             <svg data-p-icon="chevron-right" *ngIf="!isVertical()" />
                             <svg data-p-icon="chevron-down" *ngIf="isVertical()" />
                         </ng-container>
-                        <span *ngIf="nextIconTemplate || (_nextIconTemplate && !nextButtonProps?.icon)">
-                            <ng-template *ngTemplateOutlet="nextIconTemplate || _nextIconTemplate"></ng-template>
+                        <span *ngIf="nextIconTemplate() || (_nextIconTemplate && !nextButtonProps?.icon)">
+                            <ng-template *ngTemplateOutlet="nextIconTemplate() || _nextIconTemplate"></ng-template>
                         </span>
                     </ng-template>
                 </p-button>
@@ -143,9 +142,9 @@ import { CarouselStyle } from './style/carouselstyle';
                 </li>
             </ul>
         </div>
-        <div [class]="cx('footer')" *ngIf="footerFacet || footerTemplate || _footerTemplate" [pBind]="ptm('footer')">
+        <div [class]="cx('footer')" *ngIf="footerFacet() || footerTemplate() || _footerTemplate" [pBind]="ptm('footer')">
             <ng-content select="p-footer"></ng-content>
-            <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+            <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
         </div>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -327,13 +326,13 @@ export class Carousel extends BaseComponent {
      */
     @Output() onPage: EventEmitter<CarouselPageEvent> = new EventEmitter<CarouselPageEvent>();
 
-    @ViewChild('itemsContainer') itemsContainer: ElementRef | undefined;
+    readonly itemsContainer = viewChild<ElementRef>('itemsContainer');
 
-    @ViewChild('indicatorContent') indicatorContent: ElementRef | undefined;
+    readonly indicatorContent = viewChild<ElementRef>('indicatorContent');
 
-    @ContentChild(Header) headerFacet: QueryList<Header> | undefined;
+    readonly headerFacet = contentChild(Header);
 
-    @ContentChild(Footer) footerFacet: QueryList<Footer> | undefined;
+    readonly footerFacet = contentChild(Footer);
 
     _numVisible: number = 1;
 
@@ -391,31 +390,31 @@ export class Carousel extends BaseComponent {
      * Custom item template.
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<CarouselItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<CarouselItemTemplateContext>>('item', { descendants: false });
 
     /**
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: TemplateRef<void> | undefined;
+    readonly footerTemplate = contentChild<TemplateRef<void>>('footer', { descendants: false });
 
     /**
      * Custom previous icon template.
      * @group Templates
      */
-    @ContentChild('previousicon', { descendants: false }) previousIconTemplate: TemplateRef<void> | undefined;
+    readonly previousIconTemplate = contentChild<TemplateRef<void>>('previousicon', { descendants: false });
 
     /**
      * Custom next icon template.
      * @group Templates
      */
-    @ContentChild('nexticon', { descendants: false }) nextIconTemplate: TemplateRef<void> | undefined;
+    readonly nextIconTemplate = contentChild<TemplateRef<void>>('nexticon', { descendants: false });
 
     _itemTemplate: TemplateRef<CarouselItemTemplateContext> | undefined;
 
@@ -469,7 +468,7 @@ export class Carousel extends BaseComponent {
         this.cd.markForCheck();
     }
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
         this.id = uuid('pn_id_');
@@ -493,7 +492,7 @@ export class Carousel extends BaseComponent {
             }
         }
 
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -529,7 +528,8 @@ export class Carousel extends BaseComponent {
             const isCircular = this.isCircular();
             let totalShiftedItems = this.totalShiftedItems;
 
-            if (this.value && this.itemsContainer && (this.prevState.numScroll !== this._numScroll || this.prevState.numVisible !== this._numVisible || this.prevState.value.length !== this.value.length)) {
+            const itemsContainer = this.itemsContainer();
+            if (this.value && itemsContainer && (this.prevState.numScroll !== this._numScroll || this.prevState.numVisible !== this._numVisible || this.prevState.value.length !== this.value.length)) {
                 if (this.autoplayInterval) {
                     this.stopAutoplay(false);
                 }
@@ -566,8 +566,8 @@ export class Carousel extends BaseComponent {
                 this.prevState.numVisible = this._numVisible;
                 this.prevState.value = [...(this._value as any[])];
 
-                if (this.totalDots() > 0 && this.itemsContainer.nativeElement) {
-                    this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
+                if (this.totalDots() > 0 && itemsContainer.nativeElement) {
+                    itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
                 }
 
                 this.isCreated = true;
@@ -791,7 +791,7 @@ export class Carousel extends BaseComponent {
     }
 
     onRightKey() {
-        const indicators = [...find(this.indicatorContent?.nativeElement, '[data-pc-section="indicator"]')];
+        const indicators = [...find(this.indicatorContent()?.nativeElement, '[data-pc-section="indicator"]')];
         const activeIndex = this.findFocusedIndicatorIndex();
 
         this.changedFocusedIndicator(activeIndex, activeIndex + 1 === indicators.length ? indicators.length - 1 : activeIndex + 1);
@@ -810,17 +810,18 @@ export class Carousel extends BaseComponent {
     }
 
     onEndKey() {
-        const indicators = [...find(this.indicatorContent?.nativeElement, '[data-pc-section="indicator"]')];
+        const indicators = [...find(this.indicatorContent()?.nativeElement, '[data-pc-section="indicator"]')];
         const activeIndex = this.findFocusedIndicatorIndex();
 
         this.changedFocusedIndicator(activeIndex, indicators.length - 1);
     }
 
     onTabKey() {
-        const indicators = <any>[...find(this.indicatorContent?.nativeElement, '[data-pc-section="indicator"]')];
+        const indicatorContent = this.indicatorContent();
+        const indicators = <any>[...find(indicatorContent?.nativeElement, '[data-pc-section="indicator"]')];
         const highlightedIndex = indicators.findIndex((ind) => getAttribute(ind, 'data-p-highlight') === true);
 
-        const activeIndicator = <any>findSingle(this.indicatorContent?.nativeElement, '[data-pc-section="indicator"] > button[tabindex="0"]');
+        const activeIndicator = <any>findSingle(indicatorContent?.nativeElement, '[data-pc-section="indicator"] > button[tabindex="0"]');
         const activeIndex = indicators.findIndex((ind) => ind === activeIndicator.parentElement);
 
         indicators[activeIndex].children[0].tabIndex = '-1';
@@ -828,14 +829,15 @@ export class Carousel extends BaseComponent {
     }
 
     findFocusedIndicatorIndex() {
-        const indicators = [...find(this.indicatorContent?.nativeElement, '[data-pc-section="indicator"]')];
-        const activeIndicator = findSingle(this.indicatorContent?.nativeElement, '[data-pc-section="indicator"] > button[tabindex="0"]');
+        const indicatorContent = this.indicatorContent();
+        const indicators = [...find(indicatorContent?.nativeElement, '[data-pc-section="indicator"]')];
+        const activeIndicator = findSingle(indicatorContent?.nativeElement, '[data-pc-section="indicator"] > button[tabindex="0"]');
 
         return indicators.findIndex((ind) => ind === activeIndicator?.parentElement);
     }
 
     changedFocusedIndicator(prevInd, nextInd) {
-        const indicators = <any>[...find(this.indicatorContent?.nativeElement, '[data-pc-section="indicator"]')];
+        const indicators = <any>[...find(this.indicatorContent()?.nativeElement, '[data-pc-section="indicator"]')];
 
         indicators[prevInd].children[0].tabIndex = '-1';
         indicators[nextInd].children[0].tabIndex = '0';
@@ -876,10 +878,11 @@ export class Carousel extends BaseComponent {
             this.isRemainingItemsAdded = true;
         }
 
-        if (this.itemsContainer) {
-            !this.$unstyled() && removeClass(this.itemsContainer.nativeElement, 'p-items-hidden');
-            this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
-            this.itemsContainer.nativeElement.style.transition = 'transform 500ms ease 0s';
+        const itemsContainer = this.itemsContainer();
+        if (itemsContainer) {
+            !this.$unstyled() && removeClass(itemsContainer.nativeElement, 'p-items-hidden');
+            itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
+            itemsContainer.nativeElement.style.transition = 'transform 500ms ease 0s';
         }
 
         this.totalShiftedItems = totalShiftedItems;
@@ -920,12 +923,13 @@ export class Carousel extends BaseComponent {
     }
 
     onTransitionEnd() {
-        if (this.itemsContainer) {
-            !this.$unstyled() && addClass(this.itemsContainer.nativeElement, 'p-items-hidden');
-            this.itemsContainer.nativeElement.style.transition = '';
+        const itemsContainer = this.itemsContainer();
+        if (itemsContainer) {
+            !this.$unstyled() && addClass(itemsContainer.nativeElement, 'p-items-hidden');
+            itemsContainer.nativeElement.style.transition = '';
 
             if ((this.page === 0 || this.page === this.totalDots() - 1) && this.isCircular()) {
-                this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${this.totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${this.totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
+                itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${this.totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${this.totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
             }
         }
     }

--- a/packages/optimus-ui/src/cascadeselect/cascadeselect.test.ts
+++ b/packages/optimus-ui/src/cascadeselect/cascadeselect.test.ts
@@ -2157,3 +2157,37 @@ describe('CascadeSelect', () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [CascadeSelect, SharedModule],
+    template: `
+        <p-cascadeselect [options]="opts">
+            <ng-template pTemplate="value">v</ng-template>
+        </p-cascadeselect>
+    `
+})
+class CascadeSelectQueryApiHostComponent {
+    opts = [];
+}
+
+describe('CascadeSelect Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [CascadeSelectQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(CascadeSelectQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(CascadeSelect)).componentInstance;
+
+        expect(instance.templates().length).toBeGreaterThan(0);
+        expect(instance.panelViewChild()).toBeUndefined();
+    });
+});

--- a/packages/optimus-ui/src/cascadeselect/cascadeselect.ts
+++ b/packages/optimus-ui/src/cascadeselect/cascadeselect.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     effect,
     ElementRef,
     EventEmitter,
@@ -18,12 +16,13 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionOptions } from '@openng/optimus-ui-motion';
@@ -293,30 +292,30 @@ export class CascadeSelectSub extends BaseComponent {
             />
         </div>
         <span [class]="cx('label')" [pBind]="ptm('label')">
-            @if (valueTemplate || _valueTemplate) {
-                <ng-container *ngTemplateOutlet="valueTemplate || _valueTemplate; context: { $implicit: value, placeholder: placeholder }"></ng-container>
+            @if (valueTemplate() || _valueTemplate) {
+                <ng-container *ngTemplateOutlet="valueTemplate() || _valueTemplate; context: { $implicit: value, placeholder: placeholder }"></ng-container>
             } @else {
                 {{ label() }}
             }
         </span>
 
         @if ($filled() && !$disabled() && showClear) {
-            @if (!clearIconTemplate && !_clearIconTemplate) {
+            @if (!clearIconTemplate() && !_clearIconTemplate) {
                 <svg data-p-icon="times" [class]="cx('clearIcon')" (click)="clear($event)" [pBind]="ptm('clearIcon')" [attr.aria-hidden]="true" />
             }
-            @if (clearIconTemplate || _clearIconTemplate) {
+            @if (clearIconTemplate() || _clearIconTemplate) {
                 <span [class]="cx('clearIcon')" (click)="clear($event)" [pBind]="ptm('clearIcon')" [attr.aria-hidden]="true">
-                    <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="clearIconTemplate() || _clearIconTemplate"></ng-template>
                 </span>
             }
         }
 
         <div [class]="cx('dropdown')" role="button" aria-haspopup="listbox" [attr.aria-expanded]="overlayVisible ?? false" [pBind]="ptm('dropdown')" [attr.aria-hidden]="true">
             @if (loading) {
-                @if (loadingIconTemplate || _loadingIconTemplate) {
-                    <ng-container *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate"></ng-container>
+                @if (loadingIconTemplate() || _loadingIconTemplate) {
+                    <ng-container *ngTemplateOutlet="loadingIconTemplate() || _loadingIconTemplate"></ng-container>
                 }
-                @if (!loadingIconTemplate && !_loadingIconTemplate) {
+                @if (!loadingIconTemplate() && !_loadingIconTemplate) {
                     @if (loadingIcon) {
                         <span [class]="cn(cx('loadingIcon'), loadingIcon + 'pi-spin')" aria-hidden="true" [pBind]="ptm('loadingIcon')"></span>
                     }
@@ -325,12 +324,12 @@ export class CascadeSelectSub extends BaseComponent {
                     }
                 }
             } @else {
-                @if (!triggerIconTemplate && !_triggerIconTemplate) {
+                @if (!triggerIconTemplate() && !_triggerIconTemplate) {
                     <svg data-p-icon="chevron-down" [class]="cx('dropdownIcon')" [pBind]="ptm('dropdownIcon')" />
                 }
-                @if (triggerIconTemplate || _triggerIconTemplate) {
+                @if (triggerIconTemplate() || _triggerIconTemplate) {
                     <span [class]="cx('dropdownIcon')" [pBind]="ptm('dropdownIcon')">
-                        <ng-template *ngTemplateOutlet="triggerIconTemplate || _triggerIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="triggerIconTemplate() || _triggerIconTemplate"></ng-template>
                     </span>
                 }
             }
@@ -356,7 +355,7 @@ export class CascadeSelectSub extends BaseComponent {
         >
             <ng-template #content>
                 <div #panel [class]="cn(cx('overlay'), panelStyleClass)" [ngStyle]="panelStyle" [pBind]="ptm('overlay')">
-                    <ng-template *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-template>
                     <div [class]="cx('listContainer')" [pBind]="ptm('listContainer')">
                         <ul
                             pCascadeSelectSub
@@ -368,8 +367,8 @@ export class CascadeSelectSub extends BaseComponent {
                             [optionLabel]="optionLabel"
                             [optionValue]="optionValue"
                             [level]="0"
-                            [optionTemplate]="optionTemplate || _optionTemplate"
-                            [groupicon]="groupIconTemplate || groupIconTemplate"
+                            [optionTemplate]="optionTemplate() || _optionTemplate"
+                            [groupicon]="groupIconTemplate() || groupIconTemplate()"
                             [optionGroupLabel]="optionGroupLabel"
                             [optionGroupChildren]="optionGroupChildren"
                             [optionDisabled]="optionDisabled"
@@ -389,7 +388,7 @@ export class CascadeSelectSub extends BaseComponent {
                     <span role="status" aria-live="polite" class="p-hidden-accessible" [pBind]="ptm('selectedMessageText')">
                         {{ selectedMessageText }}
                     </span>
-                    <ng-template *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-template>
                 </div>
             </ng-template>
         </p-overlay>
@@ -669,58 +668,58 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
      */
     @Output() onBlur: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
 
-    @ViewChild('focusInput') focusInputViewChild: Nullable<ElementRef>;
+    readonly focusInputViewChild = viewChild<Nullable<ElementRef>>('focusInput');
 
-    @ViewChild('panel') panelViewChild: Nullable<ElementRef>;
+    readonly panelViewChild = viewChild<Nullable<ElementRef>>('panel');
 
-    @ViewChild('overlay') overlayViewChild: Nullable<Overlay>;
+    readonly overlayViewChild = viewChild<Nullable<Overlay>>('overlay');
     /**
      * Custom value template.
      * @group Templates
      */
-    @ContentChild('value', { descendants: false }) valueTemplate: Nullable<TemplateRef<CascadeSelectValueTemplateContext>>;
+    readonly valueTemplate = contentChild<Nullable<TemplateRef<CascadeSelectValueTemplateContext>>>('value', { descendants: false });
 
     /**
      * Custom option template.
      * @group Templates
      */
-    @ContentChild('option', { descendants: false }) optionTemplate: Nullable<TemplateRef<CascadeSelectOptionTemplateContext>>;
+    readonly optionTemplate = contentChild<Nullable<TemplateRef<CascadeSelectOptionTemplateContext>>>('option', { descendants: false });
 
     /**
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: Nullable<TemplateRef<void>>;
+    readonly headerTemplate = contentChild<Nullable<TemplateRef<void>>>('header', { descendants: false });
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: Nullable<TemplateRef<void>>;
+    readonly footerTemplate = contentChild<Nullable<TemplateRef<void>>>('footer', { descendants: false });
 
     /**
      * Custom trigger icon template.
      * @group Templates
      */
-    @ContentChild('triggericon', { descendants: false }) triggerIconTemplate: Nullable<TemplateRef<void>>;
+    readonly triggerIconTemplate = contentChild<Nullable<TemplateRef<void>>>('triggericon', { descendants: false });
 
     /**
      * Custom loading icon template.
      * @group Templates
      */
-    @ContentChild('loadingicon', { descendants: false }) loadingIconTemplate: Nullable<TemplateRef<void>>;
+    readonly loadingIconTemplate = contentChild<Nullable<TemplateRef<void>>>('loadingicon', { descendants: false });
 
     /**
      * Custom option group icon template.
      * @group Templates
      */
-    @ContentChild('optiongroupicon', { descendants: false }) groupIconTemplate: Nullable<TemplateRef<void>>;
+    readonly groupIconTemplate = contentChild<Nullable<TemplateRef<void>>>('optiongroupicon', { descendants: false });
 
     /**
      * Custom clear icon template.
      * @group Templates
      */
-    @ContentChild('clearicon', { descendants: false }) clearIconTemplate: Nullable<TemplateRef<void>>;
+    readonly clearIconTemplate = contentChild<Nullable<TemplateRef<void>>>('clearicon', { descendants: false });
 
     _valueTemplate: TemplateRef<CascadeSelectValueTemplateContext> | undefined;
 
@@ -843,10 +842,10 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
         return label;
     }
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'value':
                     this._valueTemplate = item.template;
@@ -1175,7 +1174,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
 
     scrollInView(index = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
-        const element = findSingle(this.panelViewChild?.nativeElement, `li[id="${id}"]`);
+        const element = findSingle(this.panelViewChild()?.nativeElement, `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
@@ -1222,14 +1221,14 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
             return;
         }
 
-        if (!this.overlayViewChild?.el?.nativeElement?.contains(event.target)) {
+        if (!this.overlayViewChild()?.el?.nativeElement?.contains(event.target)) {
             if (this.overlayVisible) {
                 this.hide();
             } else {
                 this.show();
             }
 
-            this.focusInputViewChild?.nativeElement.focus();
+            this.focusInputViewChild()?.nativeElement.focus();
         }
 
         this.clicked = true;
@@ -1371,7 +1370,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
             this.activeOptionPath.set([]);
             this.focusedOptionInfo.set({ index: -1, level: 0, parentKey: '' });
 
-            isFocus && focus(this.focusInputViewChild?.nativeElement);
+            isFocus && focus(this.focusInputViewChild()?.nativeElement);
             this.onHide.emit(event);
             this.cd.markForCheck();
         };
@@ -1402,7 +1401,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
 
         this.focusedOptionInfo.set(focusedOptionInfo);
 
-        isFocus && focus(this.focusInputViewChild?.nativeElement);
+        isFocus && focus(this.focusInputViewChild()?.nativeElement);
     }
 
     clear(event?: MouseEvent) {
@@ -1451,7 +1450,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
         effect(() => {
             const activeOptionPath = this.activeOptionPath();
             if (isNotEmpty(activeOptionPath)) {
-                this.overlayViewChild?.alignOverlay();
+                this.overlayViewChild()?.alignOverlay();
             }
         });
     }
@@ -1509,7 +1508,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
             }
         }
 
-        isFocus && focus(this.focusInputViewChild?.nativeElement);
+        isFocus && focus(this.focusInputViewChild()?.nativeElement);
     }
 
     onOptionMouseEnter(event) {

--- a/packages/optimus-ui/src/cascadeselect/cascadeselect.ts
+++ b/packages/optimus-ui/src/cascadeselect/cascadeselect.ts
@@ -668,7 +668,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
      */
     @Output() onBlur: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
 
-    readonly focusInputViewChild = viewChild<Nullable<ElementRef>>('focusInput');
+    readonly focusInputViewChild = viewChild.required<ElementRef>('focusInput');
 
     readonly panelViewChild = viewChild<Nullable<ElementRef>>('panel');
 
@@ -1228,7 +1228,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
                 this.show();
             }
 
-            this.focusInputViewChild()?.nativeElement.focus();
+            this.focusInputViewChild().nativeElement.focus();
         }
 
         this.clicked = true;
@@ -1370,7 +1370,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
             this.activeOptionPath.set([]);
             this.focusedOptionInfo.set({ index: -1, level: 0, parentKey: '' });
 
-            isFocus && focus(this.focusInputViewChild()?.nativeElement);
+            isFocus && focus(this.focusInputViewChild().nativeElement);
             this.onHide.emit(event);
             this.cd.markForCheck();
         };
@@ -1401,7 +1401,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
 
         this.focusedOptionInfo.set(focusedOptionInfo);
 
-        isFocus && focus(this.focusInputViewChild()?.nativeElement);
+        isFocus && focus(this.focusInputViewChild().nativeElement);
     }
 
     clear(event?: MouseEvent) {
@@ -1508,7 +1508,7 @@ export class CascadeSelect extends BaseEditableHolder<CascadeSelectPassThrough> 
             }
         }
 
-        isFocus && focus(this.focusInputViewChild()?.nativeElement);
+        isFocus && focus(this.focusInputViewChild().nativeElement);
     }
 
     onOptionMouseEnter(event) {

--- a/packages/optimus-ui/src/checkbox/checkbox.test.ts
+++ b/packages/optimus-ui/src/checkbox/checkbox.test.ts
@@ -497,11 +497,11 @@ describe('Checkbox', () => {
         });
 
         it('should focus programmatically', async () => {
-            vi.spyOn(checkboxInstance.inputViewChild.nativeElement, 'focus').mockImplementation(() => {});
+            vi.spyOn(checkboxInstance.inputViewChild().nativeElement, 'focus').mockImplementation(() => {});
 
             checkboxInstance.focus();
 
-            expect(checkboxInstance.inputViewChild.nativeElement.focus).toHaveBeenCalled();
+            expect(checkboxInstance.inputViewChild().nativeElement.focus).toHaveBeenCalled();
         });
 
         it('should update model programmatically', async () => {

--- a/packages/optimus-ui/src/checkbox/checkbox.test.ts
+++ b/packages/optimus-ui/src/checkbox/checkbox.test.ts
@@ -6,6 +6,8 @@ import { SharedModule } from '@openng/optimus-ui/api';
 import { CheckboxChangeEvent } from '@openng/optimus-ui/types/checkbox';
 import { Checkbox } from './checkbox';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 // Mock data for testing
 const mockIngredients = [
     { name: 'Cheese', value: 'cheese' },
@@ -1509,5 +1511,41 @@ describe('Checkbox', () => {
                 expect(checkboxElement.getAttribute('data-binary')).toBe('true');
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Checkbox, PrimeTemplate],
+    template: `
+        <p-checkbox>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-checkbox>
+    `
+})
+class CheckboxQueryApiHostComponent {}
+
+describe('Checkbox Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [CheckboxQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(CheckboxQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Checkbox)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/checkbox/checkbox.ts
+++ b/packages/optimus-ui/src/checkbox/checkbox.ts
@@ -30,7 +30,6 @@ import { BaseEditableHolder } from '@openng/optimus-ui/baseeditableholder';
 import { Bind, BindModule } from '@openng/optimus-ui/bind';
 import { CheckIcon } from '@openng/optimus-ui/icons/check';
 import { MinusIcon } from '@openng/optimus-ui/icons/minus';
-import { Nullable } from '@openng/optimus-ui/ts-helpers';
 import { CheckboxChangeEvent, CheckboxIconTemplateContext, CheckboxPassThrough } from '@openng/optimus-ui/types/checkbox';
 import { CheckboxStyle } from './style/checkboxstyle';
 
@@ -215,7 +214,7 @@ export class Checkbox extends BaseEditableHolder<CheckboxPassThrough> {
      */
     @Output() onBlur: EventEmitter<Event> = new EventEmitter<Event>();
 
-    readonly inputViewChild = viewChild<Nullable<ElementRef>>('input');
+    readonly inputViewChild = viewChild.required<ElementRef>('input');
 
     get checked() {
         return this._indeterminate() ? false : this.binary ? this.modelValue() === this.trueValue : contains(this.value, this.modelValue());
@@ -318,7 +317,7 @@ export class Checkbox extends BaseEditableHolder<CheckboxPassThrough> {
     }
 
     focus() {
-        this.inputViewChild()?.nativeElement.focus();
+        this.inputViewChild().nativeElement.focus();
     }
 
     /**

--- a/packages/optimus-ui/src/checkbox/checkbox.ts
+++ b/packages/optimus-ui/src/checkbox/checkbox.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -16,12 +14,13 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { FormControl, NG_VALUE_ACCESSOR, NgControl } from '@angular/forms';
 import { contains, equals } from '@openng/optimus-ui-utils';
@@ -72,7 +71,7 @@ export const CHECKBOX_VALUE_ACCESSOR: any = {
             (change)="handleChange($event)"
         />
         <div [class]="cx('box')" [pBind]="ptm('box')" [attr.data-p]="dataP">
-            @if (!checkboxIconTemplate && !_checkboxIconTemplate) {
+            @if (!checkboxIconTemplate() && !_checkboxIconTemplate) {
                 @if (checked) {
                     @if (checkboxIcon) {
                         <span [class]="cx('icon')" [ngClass]="checkboxIcon" [pBind]="ptm('icon')" [attr.data-p]="dataP"></span>
@@ -85,7 +84,7 @@ export const CHECKBOX_VALUE_ACCESSOR: any = {
                     <svg data-p-icon="minus" [class]="cx('icon')" [pBind]="ptm('icon')" [attr.data-p]="dataP" />
                 }
             }
-            <ng-template *ngTemplateOutlet="checkboxIconTemplate || _checkboxIconTemplate; context: { checked: checked, class: cx('icon'), dataP: dataP }"></ng-template>
+            <ng-template *ngTemplateOutlet="checkboxIconTemplate() || _checkboxIconTemplate; context: { checked: checked, class: cx('icon'), dataP: dataP }"></ng-template>
         </div>
     `,
     providers: [CHECKBOX_VALUE_ACCESSOR, CheckboxStyle, { provide: CHECKBOX_INSTANCE, useExisting: Checkbox }, { provide: PARENT_INSTANCE, useExisting: Checkbox }],
@@ -216,7 +215,7 @@ export class Checkbox extends BaseEditableHolder<CheckboxPassThrough> {
      */
     @Output() onBlur: EventEmitter<Event> = new EventEmitter<Event>();
 
-    @ViewChild('input') inputViewChild: Nullable<ElementRef>;
+    readonly inputViewChild = viewChild<Nullable<ElementRef>>('input');
 
     get checked() {
         return this._indeterminate() ? false : this.binary ? this.modelValue() === this.trueValue : contains(this.value, this.modelValue());
@@ -227,9 +226,9 @@ export class Checkbox extends BaseEditableHolder<CheckboxPassThrough> {
      * Custom checkbox icon template.
      * @group Templates
      */
-    @ContentChild('icon', { descendants: false }) checkboxIconTemplate: TemplateRef<CheckboxIconTemplateContext> | undefined;
+    readonly checkboxIconTemplate = contentChild<TemplateRef<CheckboxIconTemplateContext>>('icon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _checkboxIconTemplate: TemplateRef<CheckboxIconTemplateContext> | undefined;
 
@@ -244,7 +243,7 @@ export class Checkbox extends BaseEditableHolder<CheckboxPassThrough> {
     $variant = computed(() => this.variant() || this.config.inputStyle() || this.config.inputVariant());
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'icon':
                     this._checkboxIconTemplate = item.template;
@@ -319,7 +318,7 @@ export class Checkbox extends BaseEditableHolder<CheckboxPassThrough> {
     }
 
     focus() {
-        this.inputViewChild?.nativeElement.focus();
+        this.inputViewChild()?.nativeElement.focus();
     }
 
     /**

--- a/packages/optimus-ui/src/chip/chip.test.ts
+++ b/packages/optimus-ui/src/chip/chip.test.ts
@@ -7,6 +7,8 @@ import { SharedModule } from '@openng/optimus-ui/api';
 import { ChipProps } from '@openng/optimus-ui/types/chip';
 import { Chip, ChipModule } from './chip';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 const TEST_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 const TEST_IMAGE_2 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
 
@@ -1438,5 +1440,41 @@ describe('Chip', () => {
                 expect(hookCalled).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Chip, PrimeTemplate],
+    template: `
+        <p-chip>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-chip>
+    `
+})
+class ChipQueryApiHostComponent {}
+
+describe('Chip Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ChipQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ChipQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Chip)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/chip/chip.ts
+++ b/packages/optimus-ui/src/chip/chip.ts
@@ -4,8 +4,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     EventEmitter,
     inject,
     InjectionToken,
@@ -15,7 +13,9 @@ import {
     QueryList,
     SimpleChanges,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { PrimeTemplate, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -47,7 +47,7 @@ const CHIP_INSTANCE = new InjectionToken<Chip>('CHIP_INSTANCE');
             <div [pBind]="ptm('label')" [class]="cx('label')">{{ label }}</div>
         }
         @if (removable) {
-            @if (!removeIconTemplate && !_removeIconTemplate) {
+            @if (!removeIconTemplate() && !_removeIconTemplate) {
                 @if (removeIcon) {
                     <span
                         [pBind]="ptm('removeIcon')"
@@ -64,9 +64,9 @@ const CHIP_INSTANCE = new InjectionToken<Chip>('CHIP_INSTANCE');
                     <svg [pBind]="ptm('removeIcon')" data-p-icon="times-circle" [class]="cx('removeIcon')" (click)="close($event)" (keydown)="onKeydown($event)" [attr.tabindex]="disabled ? -1 : 0" [attr.aria-label]="removeAriaLabel" role="button" />
                 }
             }
-            @if (removeIconTemplate || _removeIconTemplate) {
+            @if (removeIconTemplate() || _removeIconTemplate) {
                 <span [pBind]="ptm('removeIcon')" [attr.tabindex]="disabled ? -1 : 0" [class]="cx('removeIcon')" (click)="close($event)" (keydown)="onKeydown($event)" [attr.aria-label]="removeAriaLabel" role="button">
-                    <ng-template *ngTemplateOutlet="removeIconTemplate || _removeIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="removeIconTemplate() || _removeIconTemplate"></ng-template>
                 </span>
             }
         }
@@ -175,14 +175,14 @@ export class Chip extends BaseComponent<ChipPassThrough> {
      * Custom remove icon template.
      * @group Templates
      */
-    @ContentChild('removeicon', { descendants: false }) removeIconTemplate: TemplateRef<void> | undefined;
+    readonly removeIconTemplate = contentChild<TemplateRef<void>>('removeicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _removeIconTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'removeicon':
                     this._removeIconTemplate = item.template;

--- a/packages/optimus-ui/src/chip/chip.ts
+++ b/packages/optimus-ui/src/chip/chip.ts
@@ -10,7 +10,6 @@ import {
     Input,
     NgModule,
     Output,
-    QueryList,
     SimpleChanges,
     TemplateRef,
     ViewEncapsulation,
@@ -182,7 +181,7 @@ export class Chip extends BaseComponent<ChipPassThrough> {
     _removeIconTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'removeicon':
                     this._removeIconTemplate = item.template;

--- a/packages/optimus-ui/src/chip/chip.ts
+++ b/packages/optimus-ui/src/chip/chip.ts
@@ -1,21 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-    AfterContentInit,
-    booleanAttribute,
-    ChangeDetectionStrategy,
-    Component,
-    EventEmitter,
-    inject,
-    InjectionToken,
-    Input,
-    NgModule,
-    Output,
-    SimpleChanges,
-    TemplateRef,
-    ViewEncapsulation,
-    contentChild,
-    contentChildren
-} from '@angular/core';
+import { AfterContentInit, booleanAttribute, ChangeDetectionStrategy, Component, EventEmitter, inject, InjectionToken, Input, NgModule, Output, SimpleChanges, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { PrimeTemplate, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';

--- a/packages/optimus-ui/src/colorpicker/colorpicker.test.ts
+++ b/packages/optimus-ui/src/colorpicker/colorpicker.test.ts
@@ -6,6 +6,8 @@ import { provideOptimus } from '@openng/optimus-ui/config';
 import { ColorPickerChangeEvent } from '@openng/optimus-ui/types/colorpicker';
 import { ColorPicker } from './colorpicker';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1752,5 +1754,32 @@ describe('ColorPicker', () => {
             const hue = fixture.nativeElement.querySelector('.p-colorpicker-hue');
             expect(hue?.style.opacity).toBe('1');
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [ColorPicker, SharedModule],
+    template: ` <p-colorpicker> </p-colorpicker> `
+})
+class ColorPickerQueryApiHostComponent {}
+
+describe('ColorPicker Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ColorPickerQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ColorPickerQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(ColorPicker)).componentInstance;
+
+        expect(instance.overlayViewChild()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/colorpicker/colorpicker.ts
+++ b/packages/optimus-ui/src/colorpicker/colorpicker.ts
@@ -695,9 +695,8 @@ export class ColorPicker extends BaseEditableHolder<ColorPickerPassThrough> impl
             this.scrollHandler = null;
         }
 
-        const overlayViewChild = this.overlayViewChild();
-        if (overlayViewChild?.nativeElement && this.autoZIndex) {
-            ZIndexUtils.clear(overlayViewChild?.nativeElement);
+        if (this.autoZIndex) {
+            ZIndexUtils.clear(this.overlayViewChild().nativeElement);
         }
     }
 }

--- a/packages/optimus-ui/src/colorpicker/colorpicker.ts
+++ b/packages/optimus-ui/src/colorpicker/colorpicker.ts
@@ -1,4 +1,23 @@
-import { AfterViewChecked, booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, EventEmitter, forwardRef, inject, InjectionToken, input, Input, NgModule, Output, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+    AfterViewChecked,
+    booleanAttribute,
+    ChangeDetectionStrategy,
+    Component,
+    computed,
+    ElementRef,
+    EventEmitter,
+    forwardRef,
+    inject,
+    InjectionToken,
+    input,
+    Input,
+    NgModule,
+    Output,
+    TemplateRef,
+    ViewChild,
+    ViewEncapsulation,
+    viewChild
+} from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionOptions } from '@openng/optimus-ui-motion';
 import { OverlayOptions, OverlayService, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
@@ -189,9 +208,9 @@ export class ColorPicker extends BaseEditableHolder<ColorPickerPassThrough> impl
      */
     @Output() onHide: EventEmitter<any> = new EventEmitter<any>();
 
-    @ViewChild('input') inputViewChild: Nullable<ElementRef>;
+    readonly inputViewChild = viewChild<Nullable<ElementRef>>('input');
 
-    @ViewChild('overlay') overlayViewChild!: ElementRef<HTMLDivElement>;
+    readonly overlayViewChild = viewChild.required<ElementRef<HTMLDivElement>>('overlay');
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
 
@@ -678,8 +697,9 @@ export class ColorPicker extends BaseEditableHolder<ColorPickerPassThrough> impl
             this.scrollHandler = null;
         }
 
-        if (this.overlayViewChild?.nativeElement && this.autoZIndex) {
-            ZIndexUtils.clear(this.overlayViewChild?.nativeElement);
+        const overlayViewChild = this.overlayViewChild();
+        if (overlayViewChild?.nativeElement && this.autoZIndex) {
+            ZIndexUtils.clear(overlayViewChild?.nativeElement);
         }
     }
 }

--- a/packages/optimus-ui/src/colorpicker/colorpicker.ts
+++ b/packages/optimus-ui/src/colorpicker/colorpicker.ts
@@ -208,8 +208,6 @@ export class ColorPicker extends BaseEditableHolder<ColorPickerPassThrough> impl
      */
     @Output() onHide: EventEmitter<any> = new EventEmitter<any>();
 
-    readonly inputViewChild = viewChild<Nullable<ElementRef>>('input');
-
     readonly overlayViewChild = viewChild.required<ElementRef<HTMLDivElement>>('overlay');
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());

--- a/packages/optimus-ui/src/confirmdialog/confirmdialog.test.ts
+++ b/packages/optimus-ui/src/confirmdialog/confirmdialog.test.ts
@@ -652,7 +652,7 @@ describe('ConfirmDialog', () => {
                 expect(() => confirmDialogInstance.ngAfterContentInit()).not.toThrow();
 
                 // Test that headerTemplate property exists (ContentChild)
-                expect(confirmDialogInstance.headerTemplate).toBeDefined();
+                expect(confirmDialogInstance.headerTemplate()).toBeDefined();
             });
 
             it("should process headerTemplate from @ContentChild('header')", async () => {
@@ -664,8 +664,8 @@ describe('ConfirmDialog', () => {
                 const confirmDialogInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
 
                 // @ContentChild('header') should set headerTemplate
-                expect(confirmDialogInstance.headerTemplate).toBeDefined();
-                expect(confirmDialogInstance.headerTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmDialogInstance.headerTemplate()).toBeDefined();
+                expect(confirmDialogInstance.headerTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process messageTemplate from @ContentChild('message')", async () => {
@@ -677,8 +677,8 @@ describe('ConfirmDialog', () => {
                 const confirmDialogInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
 
                 // @ContentChild('message') should set messageTemplate
-                expect(confirmDialogInstance.messageTemplate).toBeDefined();
-                expect(confirmDialogInstance.messageTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmDialogInstance.messageTemplate()).toBeDefined();
+                expect(confirmDialogInstance.messageTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process iconTemplate from @ContentChild('icon')", async () => {
@@ -690,8 +690,8 @@ describe('ConfirmDialog', () => {
                 const confirmDialogInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
 
                 // @ContentChild('icon') should set iconTemplate
-                expect(confirmDialogInstance.iconTemplate).toBeDefined();
-                expect(confirmDialogInstance.iconTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmDialogInstance.iconTemplate()).toBeDefined();
+                expect(confirmDialogInstance.iconTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process footerTemplate from @ContentChild('footer')", async () => {
@@ -703,8 +703,8 @@ describe('ConfirmDialog', () => {
                 const confirmDialogInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
 
                 // @ContentChild('footer') should set footerTemplate
-                expect(confirmDialogInstance.footerTemplate).toBeDefined();
-                expect(confirmDialogInstance.footerTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmDialogInstance.footerTemplate()).toBeDefined();
+                expect(confirmDialogInstance.footerTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process rejectIconTemplate from @ContentChild('rejecticon')", async () => {
@@ -716,8 +716,8 @@ describe('ConfirmDialog', () => {
                 const confirmDialogInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
 
                 // @ContentChild('rejecticon') should set rejectIconTemplate
-                expect(confirmDialogInstance.rejectIconTemplate).toBeDefined();
-                expect(confirmDialogInstance.rejectIconTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmDialogInstance.rejectIconTemplate()).toBeDefined();
+                expect(confirmDialogInstance.rejectIconTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process acceptIconTemplate from @ContentChild('accepticon')", async () => {
@@ -729,8 +729,8 @@ describe('ConfirmDialog', () => {
                 const confirmDialogInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
 
                 // @ContentChild('accepticon') should set acceptIconTemplate
-                expect(confirmDialogInstance.acceptIconTemplate).toBeDefined();
-                expect(confirmDialogInstance.acceptIconTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmDialogInstance.acceptIconTemplate()).toBeDefined();
+                expect(confirmDialogInstance.acceptIconTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process headlessTemplate from @ContentChild('headless')", async () => {
@@ -742,8 +742,8 @@ describe('ConfirmDialog', () => {
                 const confirmDialogInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
 
                 // @ContentChild('headless') should set headlessTemplate
-                expect(confirmDialogInstance.headlessTemplate).toBeDefined();
-                expect(confirmDialogInstance.headlessTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmDialogInstance.headlessTemplate()).toBeDefined();
+                expect(confirmDialogInstance.headlessTemplate()?.constructor.name).toBe('TemplateRef');
             });
         });
 
@@ -768,7 +768,7 @@ describe('ConfirmDialog', () => {
                 await new Promise((resolve) => setTimeout(resolve, 100));
 
                 const contentTemplateConfirmDialog = contentTemplateFixture.debugElement.query(By.directive(ConfirmDialog)).componentInstance;
-                expect(contentTemplateConfirmDialog.headerTemplate).toBeDefined();
+                expect(contentTemplateConfirmDialog.headerTemplate()).toBeDefined();
             });
 
             it('should use default templates when custom ones are not provided', () => {

--- a/packages/optimus-ui/src/confirmdialog/confirmdialog.ts
+++ b/packages/optimus-ui/src/confirmdialog/confirmdialog.ts
@@ -23,7 +23,7 @@ import {
     contentChildren
 } from '@angular/core';
 import { findSingle, setAttribute, uuid } from '@openng/optimus-ui-utils';
-import { Confirmation, ConfirmationService, ConfirmEventType, Footer, PrimeTemplate, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
+import { Confirmation, ConfirmationService, ConfirmEventType, PrimeTemplate, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
 import { Button } from '@openng/optimus-ui/button';
@@ -358,8 +358,6 @@ export class ConfirmDialog extends BaseComponent<ConfirmDialogPassThrough> imple
      * @group Emits
      */
     @Output() onHide: EventEmitter<ConfirmEventType> = new EventEmitter<ConfirmEventType>();
-
-    readonly footer = contentChild(Footer);
 
     _componentStyle = inject(ConfirmDialogStyle);
 

--- a/packages/optimus-ui/src/confirmdialog/confirmdialog.ts
+++ b/packages/optimus-ui/src/confirmdialog/confirmdialog.ts
@@ -5,8 +5,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -19,9 +17,10 @@ import {
     OnDestroy,
     OnInit,
     Output,
-    QueryList,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { findSingle, setAttribute, uuid } from '@openng/optimus-ui-utils';
 import { Confirmation, ConfirmationService, ConfirmEventType, Footer, PrimeTemplate, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
@@ -68,11 +67,11 @@ const CONFIRMDIALOG_INSTANCE = new InjectionToken<ConfirmDialog>('CONFIRMDIALOG_
             [unstyled]="unstyled()"
             (onHide)="onDialogHide()"
         >
-            @if (headlessTemplate || _headlessTemplate) {
+            @if (headlessTemplate() || _headlessTemplate) {
                 <ng-template #headless>
                     <ng-container
                         *ngTemplateOutlet="
-                            headlessTemplate || _headlessTemplate;
+                            headlessTemplate() || _headlessTemplate;
                             context: {
                                 $implicit: confirmation,
                                 onAccept: onAccept.bind(this),
@@ -82,31 +81,31 @@ const CONFIRMDIALOG_INSTANCE = new InjectionToken<ConfirmDialog>('CONFIRMDIALOG_
                     ></ng-container>
                 </ng-template>
             } @else {
-                @if (headerTemplate || _headerTemplate) {
+                @if (headerTemplate() || _headerTemplate) {
                     <ng-template #header>
-                        <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
                     </ng-template>
                 }
 
                 <ng-template #content>
-                    @if (iconTemplate || _iconTemplate) {
-                        <ng-template *ngTemplateOutlet="iconTemplate || _iconTemplate"></ng-template>
-                    } @else if (!iconTemplate && !_iconTemplate && !_messageTemplate && !messageTemplate) {
+                    @if (iconTemplate() || _iconTemplate) {
+                        <ng-template *ngTemplateOutlet="iconTemplate() || _iconTemplate"></ng-template>
+                    } @else if (!iconTemplate() && !_iconTemplate && !_messageTemplate && !messageTemplate()) {
                         <i [ngClass]="cx('icon')" [class]="option('icon')" [pBind]="ptm('icon')" *ngIf="option('icon')"></i>
                     }
-                    @if (messageTemplate || _messageTemplate) {
-                        <ng-template *ngTemplateOutlet="messageTemplate || _messageTemplate; context: { $implicit: confirmation }"></ng-template>
+                    @if (messageTemplate() || _messageTemplate) {
+                        <ng-template *ngTemplateOutlet="messageTemplate() || _messageTemplate; context: { $implicit: confirmation }"></ng-template>
                     } @else {
                         <span [class]="cx('message')" [pBind]="ptm('message')" [innerHTML]="option('message')"> </span>
                     }
                 </ng-template>
             }
             <ng-template #footer>
-                @if (footerTemplate || _footerTemplate) {
+                @if (footerTemplate() || _footerTemplate) {
                     <ng-content select="p-footer"></ng-content>
-                    <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
                 }
-                @if (!footerTemplate && !_footerTemplate) {
+                @if (!footerTemplate() && !_footerTemplate) {
                     <p-button
                         [pt]="ptm('pcRejectButton')"
                         *ngIf="option('rejectVisible')"
@@ -118,10 +117,10 @@ const CONFIRMDIALOG_INSTANCE = new InjectionToken<ConfirmDialog>('CONFIRMDIALOG_
                         [unstyled]="unstyled()"
                     >
                         <ng-template #icon>
-                            @if (option('rejectIcon') && !rejectIconTemplate && !_rejectIconTemplate) {
+                            @if (option('rejectIcon') && !rejectIconTemplate() && !_rejectIconTemplate) {
                                 <i *ngIf="option('rejectIcon')" [class]="option('rejectIcon')" [pBind]="ptm('pcRejectButton')['icon']"></i>
                             }
-                            <ng-template *ngTemplateOutlet="rejectIconTemplate || _rejectIconTemplate"></ng-template>
+                            <ng-template *ngTemplateOutlet="rejectIconTemplate() || _rejectIconTemplate"></ng-template>
                         </ng-template>
                     </p-button>
                     <p-button
@@ -135,10 +134,10 @@ const CONFIRMDIALOG_INSTANCE = new InjectionToken<ConfirmDialog>('CONFIRMDIALOG_
                         [unstyled]="unstyled()"
                     >
                         <ng-template #icon>
-                            @if (option('acceptIcon') && !_acceptIconTemplate && !acceptIconTemplate) {
+                            @if (option('acceptIcon') && !_acceptIconTemplate && !acceptIconTemplate()) {
                                 <i *ngIf="option('acceptIcon')" [class]="option('acceptIcon')" [pBind]="ptm('pcAcceptButton')['icon']"></i>
                             }
-                            <ng-template *ngTemplateOutlet="acceptIconTemplate || _acceptIconTemplate"></ng-template>
+                            <ng-template *ngTemplateOutlet="acceptIconTemplate() || _acceptIconTemplate"></ng-template>
                         </ng-template>
                     </p-button>
                 }
@@ -360,7 +359,7 @@ export class ConfirmDialog extends BaseComponent<ConfirmDialogPassThrough> imple
      */
     @Output() onHide: EventEmitter<ConfirmEventType> = new EventEmitter<ConfirmEventType>();
 
-    @ContentChild(Footer) footer: Nullable<TemplateRef<any>>;
+    readonly footer = contentChild(Footer);
 
     _componentStyle = inject(ConfirmDialogStyle);
 
@@ -368,45 +367,45 @@ export class ConfirmDialog extends BaseComponent<ConfirmDialogPassThrough> imple
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: Nullable<TemplateRef<void>>;
+    readonly headerTemplate = contentChild<Nullable<TemplateRef<void>>>('header', { descendants: false });
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: Nullable<TemplateRef<void>>;
+    readonly footerTemplate = contentChild<Nullable<TemplateRef<void>>>('footer', { descendants: false });
 
     /**
      * Custom reject icon template.
      * @group Templates
      */
-    @ContentChild('rejecticon', { descendants: false }) rejectIconTemplate: Nullable<TemplateRef<void>>;
+    readonly rejectIconTemplate = contentChild<Nullable<TemplateRef<void>>>('rejecticon', { descendants: false });
 
     /**
      * Custom accept icon template.
      * @group Templates
      */
-    @ContentChild('accepticon', { descendants: false }) acceptIconTemplate: Nullable<TemplateRef<void>>;
+    readonly acceptIconTemplate = contentChild<Nullable<TemplateRef<void>>>('accepticon', { descendants: false });
 
     /**
      * Custom message template.
      * @group Templates
      */
-    @ContentChild('message', { descendants: false }) messageTemplate: Nullable<TemplateRef<ConfirmDialogMessageTemplateContext>>;
+    readonly messageTemplate = contentChild<Nullable<TemplateRef<ConfirmDialogMessageTemplateContext>>>('message', { descendants: false });
 
     /**
      * Custom icon template.
      * @group Templates
      */
-    @ContentChild('icon', { descendants: false }) iconTemplate: Nullable<TemplateRef<void>>;
+    readonly iconTemplate = contentChild<Nullable<TemplateRef<void>>>('icon', { descendants: false });
 
     /**
      * Custom headless template.
      * @group Templates
      */
-    @ContentChild('headless', { descendants: false }) headlessTemplate: Nullable<TemplateRef<ConfirmDialogHeadlessTemplateContext>>;
+    readonly headlessTemplate = contentChild<Nullable<TemplateRef<ConfirmDialogHeadlessTemplateContext>>>('headless', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
 
@@ -488,7 +487,7 @@ export class ConfirmDialog extends BaseComponent<ConfirmDialogPassThrough> imple
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;

--- a/packages/optimus-ui/src/confirmpopup/confirmpopup.test.ts
+++ b/packages/optimus-ui/src/confirmpopup/confirmpopup.test.ts
@@ -7,6 +7,8 @@ import { ButtonModule } from '@openng/optimus-ui/button';
 import { FocusTrap } from '@openng/optimus-ui/focustrap';
 import { ConfirmPopup } from './confirmpopup';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 // Basic ConfirmPopup Component Test
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1962,5 +1964,33 @@ describe('ConfirmPopup', () => {
                 expect(component.onDestroyCalled).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [ConfirmPopup, SharedModule],
+    template: ` <p-confirmpopup> </p-confirmpopup> `
+})
+class ConfirmPopupQueryApiHostComponent {}
+
+describe('ConfirmPopup Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ConfirmPopupQueryApiHostComponent],
+            providers: [ConfirmationService, provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ConfirmPopupQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(ConfirmPopup)).componentInstance;
+
+        expect(instance.acceptButtonViewChild()).toBeUndefined();
+        expect(instance.rejectButtonViewChild()).toBeUndefined();
     });
 });

--- a/packages/optimus-ui/src/confirmpopup/confirmpopup.test.ts
+++ b/packages/optimus-ui/src/confirmpopup/confirmpopup.test.ts
@@ -714,10 +714,10 @@ describe('ConfirmPopup', () => {
 
             it('should use default templates when custom ones are not provided', () => {
                 // Test default behavior without custom templates
-                expect(confirmPopupInstance.contentTemplate).toBeUndefined();
-                expect(confirmPopupInstance.acceptIconTemplate).toBeUndefined();
-                expect(confirmPopupInstance.rejectIconTemplate).toBeUndefined();
-                expect(confirmPopupInstance.headlessTemplate).toBeUndefined();
+                expect(confirmPopupInstance.contentTemplate()).toBeUndefined();
+                expect(confirmPopupInstance.acceptIconTemplate()).toBeUndefined();
+                expect(confirmPopupInstance.rejectIconTemplate()).toBeUndefined();
+                expect(confirmPopupInstance.headlessTemplate()).toBeUndefined();
             });
 
             it('should handle ngAfterContentInit template processing correctly', async () => {

--- a/packages/optimus-ui/src/confirmpopup/confirmpopup.test.ts
+++ b/packages/optimus-ui/src/confirmpopup/confirmpopup.test.ts
@@ -638,7 +638,7 @@ describe('ConfirmPopup', () => {
                 expect(() => confirmPopupInstance.ngAfterContentInit()).not.toThrow();
 
                 // Test that contentTemplate property exists (ContentChild)
-                expect(confirmPopupInstance.contentTemplate).toBeDefined();
+                expect(confirmPopupInstance.contentTemplate()).toBeDefined();
             });
 
             it("should process contentTemplate from @ContentChild('content')", async () => {
@@ -649,8 +649,8 @@ describe('ConfirmPopup', () => {
                 const confirmPopupInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmPopup)).componentInstance;
 
                 // @ContentChild('content') should set contentTemplate
-                expect(confirmPopupInstance.contentTemplate).toBeDefined();
-                expect(confirmPopupInstance.contentTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmPopupInstance.contentTemplate()).toBeDefined();
+                expect(confirmPopupInstance.contentTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process acceptIconTemplate from @ContentChild('accepticon')", async () => {
@@ -661,8 +661,8 @@ describe('ConfirmPopup', () => {
                 const confirmPopupInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmPopup)).componentInstance;
 
                 // @ContentChild('accepticon') should set acceptIconTemplate
-                expect(confirmPopupInstance.acceptIconTemplate).toBeDefined();
-                expect(confirmPopupInstance.acceptIconTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmPopupInstance.acceptIconTemplate()).toBeDefined();
+                expect(confirmPopupInstance.acceptIconTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process rejectIconTemplate from @ContentChild('rejecticon')", async () => {
@@ -673,8 +673,8 @@ describe('ConfirmPopup', () => {
                 const confirmPopupInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmPopup)).componentInstance;
 
                 // @ContentChild('rejecticon') should set rejectIconTemplate
-                expect(confirmPopupInstance.rejectIconTemplate).toBeDefined();
-                expect(confirmPopupInstance.rejectIconTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmPopupInstance.rejectIconTemplate()).toBeDefined();
+                expect(confirmPopupInstance.rejectIconTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process headlessTemplate from @ContentChild('headless')", async () => {
@@ -685,8 +685,8 @@ describe('ConfirmPopup', () => {
                 const confirmPopupInstance = contentTemplateFixture.debugElement.query(By.directive(ConfirmPopup)).componentInstance;
 
                 // @ContentChild('headless') should set headlessTemplate
-                expect(confirmPopupInstance.headlessTemplate).toBeDefined();
-                expect(confirmPopupInstance.headlessTemplate?.constructor.name).toBe('TemplateRef');
+                expect(confirmPopupInstance.headlessTemplate()).toBeDefined();
+                expect(confirmPopupInstance.headlessTemplate()?.constructor.name).toBe('TemplateRef');
             });
         });
 
@@ -709,7 +709,7 @@ describe('ConfirmPopup', () => {
                 await new Promise((resolve) => setTimeout(resolve, 100));
 
                 const contentTemplateConfirmPopup = contentTemplateFixture.debugElement.query(By.directive(ConfirmPopup)).componentInstance;
-                expect(contentTemplateConfirmPopup.contentTemplate).toBeDefined();
+                expect(contentTemplateConfirmPopup.contentTemplate()).toBeDefined();
             });
 
             it('should use default templates when custom ones are not provided', () => {

--- a/packages/optimus-ui/src/confirmpopup/confirmpopup.ts
+++ b/packages/optimus-ui/src/confirmpopup/confirmpopup.ts
@@ -5,8 +5,6 @@ import {
     ChangeDetectorRef,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     effect,
     ElementRef,
     EventEmitter,
@@ -17,13 +15,14 @@ import {
     Input,
     NgModule,
     numberAttribute,
-    QueryList,
     Renderer2,
     signal,
     TemplateRef,
     untracked,
     viewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { absolutePosition, addClass, appendChild, findSingle, focus, getOffset, isIOS, isTouchDevice } from '@openng/optimus-ui-utils';
@@ -68,13 +67,13 @@ const CONFIRMPOPUP_INSTANCE = new InjectionToken<ConfirmPopup>('CONFIRMPOPUP_INS
                 role="alertdialog"
                 (click)="onOverlayClick($event)"
             >
-                <ng-container *ngIf="headlessTemplate || _headlessTemplate; else notHeadless">
-                    <ng-container *ngTemplateOutlet="headlessTemplate || _headlessTemplate; context: { $implicit: confirmation }"></ng-container>
+                <ng-container *ngIf="headlessTemplate() || _headlessTemplate; else notHeadless">
+                    <ng-container *ngTemplateOutlet="headlessTemplate() || _headlessTemplate; context: { $implicit: confirmation }"></ng-container>
                 </ng-container>
                 <ng-template #notHeadless>
                     <div #content [pBind]="ptm('content')" [class]="cx('content')">
-                        <ng-container *ngIf="contentTemplate || _contentTemplate; else withoutContentTemplate">
-                            <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: confirmation }"></ng-container>
+                        <ng-container *ngIf="contentTemplate() || _contentTemplate; else withoutContentTemplate">
+                            <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { $implicit: confirmation }"></ng-container>
                         </ng-container>
                         <ng-template #withoutContentTemplate>
                             <i [pBind]="ptm('icon')" [class]="cx('icon')" *ngIf="confirmation?.icon"></i>
@@ -99,7 +98,7 @@ const CONFIRMPOPUP_INSTANCE = new InjectionToken<ConfirmPopup>('CONFIRMPOPUP_INS
                         >
                             <ng-template #icon>
                                 <i [class]="confirmation?.rejectIcon" *ngIf="confirmation?.rejectIcon; else rejecticon"></i>
-                                <ng-template #rejecticon *ngTemplateOutlet="rejectIconTemplate || _rejectIconTemplate"></ng-template>
+                                <ng-template #rejecticon *ngTemplateOutlet="rejectIconTemplate() || _rejectIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                         <p-button
@@ -118,7 +117,7 @@ const CONFIRMPOPUP_INSTANCE = new InjectionToken<ConfirmPopup>('CONFIRMPOPUP_INS
                         >
                             <ng-template #icon>
                                 <i [class]="confirmation?.acceptIcon" *ngIf="confirmation?.acceptIcon; else accepticontemplate"></i>
-                                <ng-template #accepticontemplate *ngTemplateOutlet="acceptIconTemplate || _acceptIconTemplate"></ng-template>
+                                <ng-template #accepticontemplate *ngTemplateOutlet="acceptIconTemplate() || _acceptIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                     </div>
@@ -237,25 +236,25 @@ export class ConfirmPopup extends BaseComponent<ConfirmPopupPassThrough> {
      * Custom content template.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: Nullable<TemplateRef<ConfirmPopupContentTemplateContext>>;
+    readonly contentTemplate = contentChild<Nullable<TemplateRef<ConfirmPopupContentTemplateContext>>>('content', { descendants: false });
 
     /**
      * Custom accept icon template.
      * @group Templates
      */
-    @ContentChild('accepticon', { descendants: false }) acceptIconTemplate: Nullable<TemplateRef<void>>;
+    readonly acceptIconTemplate = contentChild<Nullable<TemplateRef<void>>>('accepticon', { descendants: false });
 
     /**
      * Custom reject icon template.
      * @group Templates
      */
-    @ContentChild('rejecticon', { descendants: false }) rejectIconTemplate: Nullable<TemplateRef<void>>;
+    readonly rejectIconTemplate = contentChild<Nullable<TemplateRef<void>>>('rejecticon', { descendants: false });
 
     /**
      * Custom headless template.
      * @group Templates
      */
-    @ContentChild('headless', { descendants: false }) headlessTemplate: Nullable<TemplateRef<ConfirmPopupHeadlessTemplateContext>>;
+    readonly headlessTemplate = contentChild<Nullable<TemplateRef<ConfirmPopupHeadlessTemplateContext>>>('headless', { descendants: false });
 
     acceptButtonViewChild = viewChild('acceptButton', { read: ElementRef });
 
@@ -323,10 +322,10 @@ export class ConfirmPopup extends BaseComponent<ConfirmPopupPassThrough> {
         });
     }
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/contextmenu/contextmenu.test.ts
+++ b/packages/optimus-ui/src/contextmenu/contextmenu.test.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MenuItem, SharedModule } from '@openng/optimus-ui/api';
 import { ContextMenu } from './contextmenu';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1617,5 +1618,34 @@ describe('ContextMenu', () => {
                 }
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [ContextMenu, SharedModule],
+    template: ` <p-contextmenu [model]="model"> </p-contextmenu> `
+})
+class ContextMenuQueryApiHostComponent {
+    model = [{ label: 'a' }];
+}
+
+describe('ContextMenu Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ContextMenuQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ContextMenuQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(ContextMenu)).componentInstance;
+
+        expect(() => instance.rootmenu()?.sublistViewChild()).not.toThrow();
     });
 });

--- a/packages/optimus-ui/src/contextmenu/contextmenu.test.ts
+++ b/packages/optimus-ui/src/contextmenu/contextmenu.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DebugElement, ViewChild, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -65,7 +65,7 @@ class TestBasicContextMenuComponent {
     `
 })
 class TestTargetContextMenuComponent {
-    @ViewChild('targetDiv', { static: true }) targetDiv: any;
+    readonly targetDiv = viewChild<any>('targetDiv');
 
     model: MenuItem[] = [
         { label: 'Copy', icon: 'pi pi-copy' },
@@ -695,7 +695,7 @@ describe('ContextMenu', () => {
             // Create mock menu items structure
             const mockMenuDiv = document.createElement('div');
             mockMenuDiv.innerHTML = '<ul><li data-pc-section="menuitem" id="item_0"></li></ul>';
-            contextMenuInstance.rootmenu!.el!.nativeElement.appendChild(mockMenuDiv);
+            contextMenuInstance.rootmenu()!.el!.nativeElement.appendChild(mockMenuDiv);
         });
 
         it('should handle arrow down key', () => {
@@ -1251,7 +1251,7 @@ describe('ContextMenu', () => {
                 template: `<p-contextmenu #cm [model]="model" [pt]="pt" [global]="true"></p-contextmenu>`
             })
             class PTStringTestComponent {
-                @ViewChild('cm') contextMenu!: ContextMenu;
+                readonly contextMenu = viewChild.required<ContextMenu>('cm');
                 model: MenuItem[] = [
                     {
                         label: 'File',
@@ -1305,7 +1305,7 @@ describe('ContextMenu', () => {
                 template: `<p-contextmenu #cm [model]="model" [pt]="pt" [global]="true"></p-contextmenu>`
             })
             class PTObjectTestComponent {
-                @ViewChild('cm') contextMenu!: ContextMenu;
+                readonly contextMenu = viewChild.required<ContextMenu>('cm');
                 model: MenuItem[] = [
                     {
                         label: 'File',
@@ -1380,7 +1380,7 @@ describe('ContextMenu', () => {
                 template: `<p-contextmenu #cm [model]="model" [pt]="pt" [global]="true"></p-contextmenu>`
             })
             class PTMixedTestComponent {
-                @ViewChild('cm') contextMenu!: ContextMenu;
+                readonly contextMenu = viewChild.required<ContextMenu>('cm');
                 model: MenuItem[] = [
                     {
                         label: 'File',
@@ -1431,7 +1431,7 @@ describe('ContextMenu', () => {
                 template: `<p-contextmenu #cm [model]="model" [pt]="pt" [global]="true"></p-contextmenu>`
             })
             class PTBasicStringTestComponent {
-                @ViewChild('cm') contextMenu!: ContextMenu;
+                readonly contextMenu = viewChild.required<ContextMenu>('cm');
                 model: MenuItem[] = [
                     { label: 'Item 1', icon: 'pi pi-file' },
                     { label: 'Item 2', icon: 'pi pi-pencil', disabled: true }
@@ -1500,7 +1500,7 @@ describe('ContextMenu', () => {
                 template: `<p-contextmenu #cm [model]="model" [pt]="pt" [global]="true"></p-contextmenu>`
             })
             class PTObjectContextTestComponent {
-                @ViewChild('cm') contextMenu!: ContextMenu;
+                readonly contextMenu = viewChild.required<ContextMenu>('cm');
                 model: MenuItem[] = [
                     { label: 'Item 0', icon: 'pi pi-file' },
                     { label: 'Disabled Item', icon: 'pi pi-ban', disabled: true },

--- a/packages/optimus-ui/src/contextmenu/contextmenu.test.ts
+++ b/packages/optimus-ui/src/contextmenu/contextmenu.test.ts
@@ -686,11 +686,12 @@ describe('ContextMenu', () => {
             contextMenuInstance.focusedItemInfo.set({ index: 0, level: 0, parentKey: '', item: null });
 
             // Mock the rootmenu property to prevent undefined errors
-            contextMenuInstance.rootmenu = {
-                el: {
-                    nativeElement: document.createElement('div')
-                }
-            } as any;
+            (contextMenuInstance as any).rootmenu = () =>
+                ({
+                    el: {
+                        nativeElement: document.createElement('div')
+                    }
+                }) as any;
 
             // Create mock menu items structure
             const mockMenuDiv = document.createElement('div');

--- a/packages/optimus-ui/src/contextmenu/contextmenu.ts
+++ b/packages/optimus-ui/src/contextmenu/contextmenu.ts
@@ -311,7 +311,7 @@ export class ContextMenuSub extends BaseComponent<ContextMenuPassThrough> implem
 
     @Output() menuKeydown: EventEmitter<any> = new EventEmitter();
 
-    readonly sublistViewChild = viewChild.required<ElementRef>('sublist');
+    readonly sublistViewChild = viewChild<ElementRef>('sublist');
 
     render = signal<boolean>(false);
 

--- a/packages/optimus-ui/src/contextmenu/contextmenu.ts
+++ b/packages/optimus-ui/src/contextmenu/contextmenu.ts
@@ -5,8 +5,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     effect,
     ElementRef,
     EventEmitter,
@@ -17,13 +15,14 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     Renderer2,
     signal,
     TemplateRef,
-    ViewChild,
     ViewEncapsulation,
-    ViewRef
+    ViewRef,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
@@ -164,12 +163,12 @@ const CONTEXTMENUSUB_INSTANCE = new InjectionToken<ContextMenuSub>('CONTEXTMENUS
                                     <ng-container *ngIf="isItemGroup(processedItem)">
                                         <svg
                                             data-p-icon="angle-right"
-                                            *ngIf="!contextMenu.submenuIconTemplate && !contextMenu._submenuIconTemplate"
+                                            *ngIf="!contextMenu.submenuIconTemplate() && !contextMenu._submenuIconTemplate"
                                             [class]="cx('submenuIcon')"
                                             [pBind]="getPTOptions(processedItem, index, 'submenuIcon')"
                                             [attr.aria-hidden]="true"
                                         />
-                                        <ng-template *ngTemplateOutlet="contextMenu.submenuIconTemplate || contextMenu._submenuIconTemplate; context: { class: 'p-contextmenu-submenu-icon' }" [attr.aria-hidden]="true"></ng-template>
+                                        <ng-template *ngTemplateOutlet="contextMenu.submenuIconTemplate() || contextMenu._submenuIconTemplate; context: { class: 'p-contextmenu-submenu-icon' }" [attr.aria-hidden]="true"></ng-template>
                                     </ng-container>
                                 </a>
                                 <a
@@ -221,12 +220,12 @@ const CONTEXTMENUSUB_INSTANCE = new InjectionToken<ContextMenuSub>('CONTEXTMENUS
                                     <ng-container *ngIf="isItemGroup(processedItem)">
                                         <svg
                                             data-p-icon="angle-right"
-                                            *ngIf="!contextMenu.submenuIconTemplate && !contextMenu._submenuIconTemplate"
+                                            *ngIf="!contextMenu.submenuIconTemplate() && !contextMenu._submenuIconTemplate"
                                             [class]="cx('submenuIcon')"
                                             [pBind]="getPTOptions(processedItem, index, 'submenuIcon')"
                                             [attr.aria-hidden]="true"
                                         />
-                                        <ng-template *ngTemplateOutlet="contextMenu.submenuIconTemplate || contextMenu._submenuIconTemplate; context: { class: 'p-contextmenu-submenu-icon' }" [attr.aria-hidden]="true"></ng-template>
+                                        <ng-template *ngTemplateOutlet="contextMenu.submenuIconTemplate() || contextMenu._submenuIconTemplate; context: { class: 'p-contextmenu-submenu-icon' }" [attr.aria-hidden]="true"></ng-template>
                                     </ng-container>
                                 </a>
                             </ng-container>
@@ -312,7 +311,7 @@ export class ContextMenuSub extends BaseComponent<ContextMenuPassThrough> implem
 
     @Output() menuKeydown: EventEmitter<any> = new EventEmitter();
 
-    @ViewChild('sublist') sublistViewChild: ElementRef;
+    readonly sublistViewChild = viewChild.required<ElementRef>('sublist');
 
     render = signal<boolean>(false);
 
@@ -462,7 +461,7 @@ export class ContextMenuSub extends BaseComponent<ContextMenuPassThrough> implem
                     #rootmenu
                     [root]="true"
                     [items]="processedItems"
-                    [itemTemplate]="itemTemplate || _itemTemplate"
+                    [itemTemplate]="itemTemplate() || _itemTemplate"
                     [menuId]="id"
                     [ariaLabel]="ariaLabel"
                     [ariaLabelledBy]="ariaLabelledBy"
@@ -592,7 +591,7 @@ export class ContextMenu extends BaseComponent<ContextMenuPassThrough> {
      */
     @Output() onHide: EventEmitter<null> = new EventEmitter<null>();
 
-    @ViewChild('rootmenu') rootmenu: ContextMenuSub | undefined;
+    readonly rootmenu = viewChild<ContextMenuSub>('rootmenu');
 
     container: HTMLElement | null | undefined;
 
@@ -737,22 +736,22 @@ export class ContextMenu extends BaseComponent<ContextMenuPassThrough> {
      * Custom item template.
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<ContextMenuItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<ContextMenuItemTemplateContext>>('item', { descendants: false });
 
     /**
      * Custom submenu icon template.
      * @group Templates
      */
-    @ContentChild('submenuicon', { descendants: false }) submenuIconTemplate: TemplateRef<ContextMenuSubmenuIconTemplateContext> | undefined;
+    readonly submenuIconTemplate = contentChild<TemplateRef<ContextMenuSubmenuIconTemplateContext>>('submenuicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _submenuIconTemplate: TemplateRef<ContextMenuSubmenuIconTemplateContext> | undefined;
 
     _itemTemplate: TemplateRef<ContextMenuItemTemplateContext> | undefined;
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'submenuicon':
                     this._submenuIconTemplate = item.template;
@@ -884,7 +883,7 @@ export class ContextMenu extends BaseComponent<ContextMenuPassThrough> {
             this.activeItemPath.set(this.activeItemPath().filter((p) => key !== p.key && key.startsWith(p.key)));
             this.focusedItemInfo.set({ index, level, parentKey, item });
 
-            focus(this.rootmenu?.sublistViewChild?.nativeElement);
+            focus(this.rootmenu()?.sublistViewChild()?.nativeElement);
         } else {
             grouped ? this.onItemChange(event) : this.hide();
         }
@@ -1048,7 +1047,7 @@ export class ContextMenu extends BaseComponent<ContextMenuPassThrough> {
 
     onEnterKey(event: KeyboardEvent) {
         if (this.focusedItemInfo().index !== -1) {
-            const element = <any>findSingle(this.rootmenu?.el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+            const element = <any>findSingle(this.rootmenu()?.el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
             const anchorElement = element && (<any>findSingle(element, '[data-pc-section="itemlink"]') || findSingle(element, 'a,button'));
 
             anchorElement ? anchorElement.click() : element && element.click();
@@ -1078,7 +1077,7 @@ export class ContextMenu extends BaseComponent<ContextMenuPassThrough> {
             this.submenuVisible.set(true);
         }
         this.focusedItemInfo.set({ index, level, parentKey, item: processedItem.item });
-        isFocus && focus(this.rootmenu?.sublistViewChild?.nativeElement);
+        isFocus && focus(this.rootmenu()?.sublistViewChild()?.nativeElement);
 
         if (type === 'hover' && this.queryMatches()) {
             return;
@@ -1110,7 +1109,7 @@ export class ContextMenu extends BaseComponent<ContextMenuPassThrough> {
 
     onAfterEnter() {
         this.bindGlobalListeners();
-        focus(this.rootmenu?.sublistViewChild?.nativeElement);
+        focus(this.rootmenu()?.sublistViewChild()?.nativeElement);
     }
 
     onAfterLeave() {
@@ -1182,7 +1181,7 @@ export class ContextMenu extends BaseComponent<ContextMenuPassThrough> {
     show(event: any) {
         this.activeItemPath.set([]);
         this.focusedItemInfo.set({ index: -1, level: 0, parentKey: '', item: null });
-        focus(this.rootmenu?.sublistViewChild?.nativeElement);
+        focus(this.rootmenu()?.sublistViewChild()?.nativeElement);
 
         this.pageX = event.pageX;
         this.pageY = event.pageY;
@@ -1316,7 +1315,7 @@ export class ContextMenu extends BaseComponent<ContextMenuPassThrough> {
 
     scrollInView(index: number = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedItemId;
-        const element = findSingle(this.rootmenu?.el?.nativeElement, `li[id="${id}"]`);
+        const element = findSingle(this.rootmenu()?.el?.nativeElement, `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });

--- a/packages/optimus-ui/src/dataview/dataview.test.ts
+++ b/packages/optimus-ui/src/dataview/dataview.test.ts
@@ -5,6 +5,8 @@ import { CommonModule } from '@angular/common';
 import { DataView } from './dataview';
 import { PaginatorModule } from '@openng/optimus-ui/paginator';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1758,3 +1760,42 @@ class TestDynamicDataViewComponent {
         }, 500);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [DataView, SharedModule],
+    template: `
+        <p-dataview [value]="items">
+            <p-header>H</p-header>
+            <p-footer>F</p-footer>
+            <ng-template #paginatordropdownitem let-item>{{ item?.label }}</ng-template>
+            <ng-template #loadingicon>li</ng-template>
+        </p-dataview>
+    `
+})
+class DataViewQueryApiHostComponent {
+    items = [];
+}
+
+describe('DataView Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [DataViewQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(DataViewQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(DataView)).componentInstance;
+
+        expect(instance.paginatordropdownitem()).toBeDefined();
+        expect(instance.loadingicon()).toBeDefined();
+        expect(instance.header()).toBeDefined();
+        expect(instance.footer()).toBeDefined();
+    });
+});

--- a/packages/optimus-ui/src/dataview/dataview.test.ts
+++ b/packages/optimus-ui/src/dataview/dataview.test.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ChangeDetectionStrategy, Component, ViewChild, signal, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import { DataView } from './dataview';
@@ -1437,7 +1437,7 @@ describe('DataView', () => {
             dynamicFixture = TestBed.createComponent(TestDynamicDataViewComponent);
             dynamicComponent = dynamicFixture.componentInstance;
             await dynamicFixture.whenStable();
-            dynamicDataView = dynamicComponent.dataView;
+            dynamicDataView = dynamicComponent.dataView();
         });
 
         it('should handle dynamic value changes', async () => {
@@ -1677,7 +1677,7 @@ describe('DataView', () => {
     `
 })
 class TestDynamicDataViewComponent {
-    @ViewChild('dataView') dataView!: DataView;
+    readonly dataView = viewChild.required<DataView>('dataView');
 
     value = [
         { id: 1, name: 'Product 1', price: 100 },

--- a/packages/optimus-ui/src/dataview/dataview.ts
+++ b/packages/optimus-ui/src/dataview/dataview.ts
@@ -346,55 +346,55 @@ export class DataView extends BaseComponent<DataViewPassThrough> implements Bloc
      * @param {DataViewGridTemplateContext} context - grid template context.
      * @group Templates
      */
-    readonly gridTemplate = contentChild.required<TemplateRef<DataViewGridTemplateContext>>('grid');
+    readonly gridTemplate = contentChild<TemplateRef<DataViewGridTemplateContext>>('grid');
     /**
      * Template for the header section.
      * @group Templates
      */
-    readonly headerTemplate = contentChild.required<TemplateRef<void>>('header');
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header');
     /**
      * Template for the empty message section.
      * @group Templates
      */
-    readonly emptymessageTemplate = contentChild.required<TemplateRef<void>>('emptymessage');
+    readonly emptymessageTemplate = contentChild<TemplateRef<void>>('emptymessage');
     /**
      * Template for the footer section.
      * @group Templates
      */
-    readonly footerTemplate = contentChild.required<TemplateRef<void>>('footer');
+    readonly footerTemplate = contentChild<TemplateRef<void>>('footer');
     /**
      * Template for the left side of paginator.
      * @param {DataViewPaginatorLeftTemplateContext} context - paginator left template context.
      * @group Templates
      */
-    readonly paginatorleft = contentChild.required<TemplateRef<DataViewPaginatorLeftTemplateContext>>('paginatorleft');
+    readonly paginatorleft = contentChild<TemplateRef<DataViewPaginatorLeftTemplateContext>>('paginatorleft');
     /**
      * Template for the right side of paginator.
      * @param {DataViewPaginatorRightTemplateContext} context - paginator right template context.
      * @group Templates
      */
-    readonly paginatorright = contentChild.required<TemplateRef<DataViewPaginatorRightTemplateContext>>('paginatorright');
+    readonly paginatorright = contentChild<TemplateRef<DataViewPaginatorRightTemplateContext>>('paginatorright');
     /**
      * Template for items in paginator dropdown.
      * @param {DataViewPaginatorDropdownItemTemplateContext} context - paginator dropdown item template context.
      * @group Templates
      */
-    readonly paginatordropdownitem = contentChild.required<TemplateRef<DataViewPaginatorDropdownItemTemplateContext>>('paginatordropdownitem');
+    readonly paginatordropdownitem = contentChild<TemplateRef<DataViewPaginatorDropdownItemTemplateContext>>('paginatordropdownitem');
     /**
      * Template for loading icon.
      * @group Templates
      */
-    readonly loadingicon = contentChild.required<TemplateRef<void>>('loadingicon');
+    readonly loadingicon = contentChild<TemplateRef<void>>('loadingicon');
     /**
      * Template for list icon.
      * @group Templates
      */
-    readonly listicon = contentChild.required<TemplateRef<void>>('listicon');
+    readonly listicon = contentChild<TemplateRef<void>>('listicon');
     /**
      * Template for grid icon.
      * @group Templates
      */
-    readonly gridicon = contentChild.required<TemplateRef<void>>('gridicon');
+    readonly gridicon = contentChild<TemplateRef<void>>('gridicon');
 
     readonly header = contentChild(Header);
 

--- a/packages/optimus-ui/src/dataview/dataview.ts
+++ b/packages/optimus-ui/src/dataview/dataview.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ContentChild, ElementRef, EventEmitter, inject, InjectionToken, Input, NgModule, numberAttribute, Output, SimpleChanges, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, inject, InjectionToken, Input, NgModule, numberAttribute, Output, SimpleChanges, TemplateRef, ViewEncapsulation, contentChild } from '@angular/core';
 import { resolveFieldData } from '@openng/optimus-ui-utils';
 import { BlockableUI, FilterService, Footer, Header, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -42,16 +42,16 @@ const DATAVIEW_INSTANCE = new InjectionToken<DataView>('DATAVIEW_INSTANCE');
                     } @else {
                         <ng-container>
                             <svg [pBind]="ptm('loadingIcon')" data-p-icon="spinner" [spin]="true" [class]="cx('loadingIcon')" />
-                            <ng-template *ngTemplateOutlet="loadingicon"></ng-template>
+                            <ng-template *ngTemplateOutlet="loadingicon()"></ng-template>
                         </ng-container>
                     }
                 </div>
             </div>
         }
-        @if (header || headerTemplate) {
+        @if (header() || headerTemplate()) {
             <div [pBind]="ptm('header')" [class]="cx('header')">
                 <ng-content select="p-header"></ng-content>
-                <ng-container *ngTemplateOutlet="headerTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="headerTemplate()"></ng-container>
             </div>
         }
         @if (paginator && (paginatorPosition === 'top' || paginatorPosition == 'both')) {
@@ -65,11 +65,11 @@ const DATAVIEW_INSTANCE = new InjectionToken<DataView>('DATAVIEW_INSTANCE');
                 [rowsPerPageOptions]="rowsPerPageOptions"
                 [appendTo]="paginatorDropdownAppendTo"
                 [dropdownScrollHeight]="paginatorDropdownScrollHeight"
-                [templateLeft]="paginatorleft"
-                [templateRight]="paginatorright"
+                [templateLeft]="paginatorleft()"
+                [templateRight]="paginatorright()"
                 [currentPageReportTemplate]="currentPageReportTemplate"
                 [showFirstLastIcon]="showFirstLastIcon"
-                [dropdownItemTemplate]="paginatordropdownitem"
+                [dropdownItemTemplate]="paginatordropdownitem()"
                 [showCurrentPageReport]="showCurrentPageReport"
                 [showJumpToPageDropdown]="showJumpToPageDropdown"
                 [showPageLinks]="showPageLinks"
@@ -82,7 +82,7 @@ const DATAVIEW_INSTANCE = new InjectionToken<DataView>('DATAVIEW_INSTANCE');
             @if (layout === 'list') {
                 <ng-container
                     *ngTemplateOutlet="
-                        listTemplate;
+                        listTemplate();
                         context: {
                             $implicit: paginator ? (filteredValue || value | slice: (lazy ? 0 : first) : (lazy ? 0 : first) + rows) : filteredValue || value
                         }
@@ -92,7 +92,7 @@ const DATAVIEW_INSTANCE = new InjectionToken<DataView>('DATAVIEW_INSTANCE');
             @if (layout === 'grid') {
                 <ng-container
                     *ngTemplateOutlet="
-                        gridTemplate;
+                        gridTemplate();
                         context: {
                             $implicit: paginator ? (filteredValue || value | slice: (lazy ? 0 : first) : (lazy ? 0 : first) + rows) : filteredValue || value
                         }
@@ -101,12 +101,12 @@ const DATAVIEW_INSTANCE = new InjectionToken<DataView>('DATAVIEW_INSTANCE');
             }
             @if (isEmpty() && !loading) {
                 <div [pBind]="ptm('emptyMessage')" [class]="cx('emptyMessage')">
-                    @if (!emptymessageTemplate) {
+                    @if (!emptymessageTemplate()) {
                         {{ emptyMessageLabel }}
                     } @else {
                         <ng-template [ngTemplateOutlet]="empty"></ng-template>
                     }
-                    <ng-container #empty *ngTemplateOutlet="emptymessageTemplate"></ng-container>
+                    <ng-container #empty *ngTemplateOutlet="emptymessageTemplate()"></ng-container>
                 </div>
             }
         </div>
@@ -121,11 +121,11 @@ const DATAVIEW_INSTANCE = new InjectionToken<DataView>('DATAVIEW_INSTANCE');
                 [rowsPerPageOptions]="rowsPerPageOptions"
                 [appendTo]="paginatorDropdownAppendTo"
                 [dropdownScrollHeight]="paginatorDropdownScrollHeight"
-                [templateLeft]="paginatorleft"
-                [templateRight]="paginatorright"
+                [templateLeft]="paginatorleft()"
+                [templateRight]="paginatorright()"
                 [currentPageReportTemplate]="currentPageReportTemplate"
                 [showFirstLastIcon]="showFirstLastIcon"
-                [dropdownItemTemplate]="paginatordropdownitem"
+                [dropdownItemTemplate]="paginatordropdownitem()"
                 [showCurrentPageReport]="showCurrentPageReport"
                 [showJumpToPageDropdown]="showJumpToPageDropdown"
                 [showPageLinks]="showPageLinks"
@@ -134,10 +134,10 @@ const DATAVIEW_INSTANCE = new InjectionToken<DataView>('DATAVIEW_INSTANCE');
                 [unstyled]="unstyled()"
             ></p-paginator>
         }
-        @if (footer || footerTemplate) {
+        @if (footer() || footerTemplate()) {
             <div [pBind]="ptm('footer')" [class]="cx('footer')">
                 <ng-content select="p-footer"></ng-content>
-                <ng-container *ngTemplateOutlet="footerTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="footerTemplate()"></ng-container>
             </div>
         }
     `,
@@ -340,65 +340,65 @@ export class DataView extends BaseComponent<DataViewPassThrough> implements Bloc
      * @param {DataViewListTemplateContext} context - list template context.
      * @group Templates
      */
-    @ContentChild('list') listTemplate: Nullable<TemplateRef<DataViewListTemplateContext>>;
+    readonly listTemplate = contentChild<Nullable<TemplateRef<DataViewListTemplateContext>>>('list');
     /**
      * Template for grid layout.
      * @param {DataViewGridTemplateContext} context - grid template context.
      * @group Templates
      */
-    @ContentChild('grid') gridTemplate: TemplateRef<DataViewGridTemplateContext>;
+    readonly gridTemplate = contentChild.required<TemplateRef<DataViewGridTemplateContext>>('grid');
     /**
      * Template for the header section.
      * @group Templates
      */
-    @ContentChild('header') headerTemplate: TemplateRef<void>;
+    readonly headerTemplate = contentChild.required<TemplateRef<void>>('header');
     /**
      * Template for the empty message section.
      * @group Templates
      */
-    @ContentChild('emptymessage') emptymessageTemplate: TemplateRef<void>;
+    readonly emptymessageTemplate = contentChild.required<TemplateRef<void>>('emptymessage');
     /**
      * Template for the footer section.
      * @group Templates
      */
-    @ContentChild('footer') footerTemplate: TemplateRef<void>;
+    readonly footerTemplate = contentChild.required<TemplateRef<void>>('footer');
     /**
      * Template for the left side of paginator.
      * @param {DataViewPaginatorLeftTemplateContext} context - paginator left template context.
      * @group Templates
      */
-    @ContentChild('paginatorleft') paginatorleft: TemplateRef<DataViewPaginatorLeftTemplateContext>;
+    readonly paginatorleft = contentChild.required<TemplateRef<DataViewPaginatorLeftTemplateContext>>('paginatorleft');
     /**
      * Template for the right side of paginator.
      * @param {DataViewPaginatorRightTemplateContext} context - paginator right template context.
      * @group Templates
      */
-    @ContentChild('paginatorright') paginatorright: TemplateRef<DataViewPaginatorRightTemplateContext>;
+    readonly paginatorright = contentChild.required<TemplateRef<DataViewPaginatorRightTemplateContext>>('paginatorright');
     /**
      * Template for items in paginator dropdown.
      * @param {DataViewPaginatorDropdownItemTemplateContext} context - paginator dropdown item template context.
      * @group Templates
      */
-    @ContentChild('paginatordropdownitem') paginatordropdownitem: TemplateRef<DataViewPaginatorDropdownItemTemplateContext>;
+    readonly paginatordropdownitem = contentChild.required<TemplateRef<DataViewPaginatorDropdownItemTemplateContext>>('paginatordropdownitem');
     /**
      * Template for loading icon.
      * @group Templates
      */
-    @ContentChild('loadingicon') loadingicon: TemplateRef<void>;
+    readonly loadingicon = contentChild.required<TemplateRef<void>>('loadingicon');
     /**
      * Template for list icon.
      * @group Templates
      */
-    @ContentChild('listicon') listicon: TemplateRef<void>;
+    readonly listicon = contentChild.required<TemplateRef<void>>('listicon');
     /**
      * Template for grid icon.
      * @group Templates
      */
-    @ContentChild('gridicon') gridicon: TemplateRef<void>;
+    readonly gridicon = contentChild.required<TemplateRef<void>>('gridicon');
 
-    @ContentChild(Header) header: any;
+    readonly header = contentChild(Header);
 
-    @ContentChild(Footer) footer: any;
+    readonly footer = contentChild(Footer);
 
     _value: Nullable<any[]>;
 

--- a/packages/optimus-ui/src/dataview/dataview.ts
+++ b/packages/optimus-ui/src/dataview/dataview.ts
@@ -385,17 +385,6 @@ export class DataView extends BaseComponent<DataViewPassThrough> implements Bloc
      * @group Templates
      */
     readonly loadingicon = contentChild<TemplateRef<void>>('loadingicon');
-    /**
-     * Template for list icon.
-     * @group Templates
-     */
-    readonly listicon = contentChild<TemplateRef<void>>('listicon');
-    /**
-     * Template for grid icon.
-     * @group Templates
-     */
-    readonly gridicon = contentChild<TemplateRef<void>>('gridicon');
-
     readonly header = contentChild(Header);
 
     readonly footer = contentChild(Footer);

--- a/packages/optimus-ui/src/datepicker/datepicker.test.ts
+++ b/packages/optimus-ui/src/datepicker/datepicker.test.ts
@@ -6,6 +6,8 @@ import { By } from '@angular/platform-browser';
 import { CommonModule } from '@angular/common';
 import type { DatePickerMonthChangeEvent, DatePickerYearChangeEvent } from '@openng/optimus-ui/types/datepicker';
 import { DatePicker } from './datepicker';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1873,5 +1875,37 @@ describe('DatePicker', () => {
 
             expect(ptFixture.componentInstance).toBeTruthy();
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [DatePicker, SharedModule],
+    template: `
+        <p-datepicker>
+            <ng-template #buttonbar>bb</ng-template>
+        </p-datepicker>
+    `
+})
+class DatePickerQueryApiHostComponent {}
+
+describe('DatePicker Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [DatePickerQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(DatePickerQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(DatePicker)).componentInstance;
+
+        expect(instance.buttonBarTemplate()).toBeDefined();
+        expect(instance.inputfieldViewChild()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/datepicker/datepicker.test.ts
+++ b/packages/optimus-ui/src/datepicker/datepicker.test.ts
@@ -1498,7 +1498,7 @@ describe('DatePicker', () => {
 
                 // Templates should be available for context binding
                 if (datePickerComponent.templates) {
-                    datePickerComponent.templates.forEach((template: any) => {
+                    datePickerComponent.templates().forEach((template: any) => {
                         expect(template).toBeTruthy();
                     });
                 }

--- a/packages/optimus-ui/src/datepicker/datepicker.ts
+++ b/packages/optimus-ui/src/datepicker/datepicker.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -17,10 +15,12 @@ import {
     NgZone,
     numberAttribute,
     Output,
-    QueryList,
     TemplateRef,
     ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
@@ -114,10 +114,10 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                 [pt]="ptm('pcInputText')"
                 [unstyled]="unstyled()"
             />
-            <ng-container *ngIf="showClear && !$disabled() && inputfieldViewChild?.nativeElement?.value">
-                <svg data-p-icon="times" *ngIf="!clearIconTemplate && !_clearIconTemplate" [class]="cx('clearIcon')" [pBind]="ptm('inputIcon')" (click)="clear()" />
-                <span *ngIf="clearIconTemplate || _clearIconTemplate" [class]="cx('clearIcon')" [pBind]="ptm('inputIcon')" (click)="clear()">
-                    <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
+            <ng-container *ngIf="showClear && !$disabled() && inputfieldViewChild()?.nativeElement?.value">
+                <svg data-p-icon="times" *ngIf="!clearIconTemplate() && !_clearIconTemplate" [class]="cx('clearIcon')" [pBind]="ptm('inputIcon')" (click)="clear()" />
+                <span *ngIf="clearIconTemplate() || _clearIconTemplate" [class]="cx('clearIcon')" [pBind]="ptm('inputIcon')" (click)="clear()">
+                    <ng-template *ngTemplateOutlet="clearIconTemplate() || _clearIconTemplate"></ng-template>
                 </span>
             </ng-container>
             <button
@@ -135,15 +135,15 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
             >
                 <span *ngIf="icon" [ngClass]="icon" [pBind]="ptm('dropdownIcon')"></span>
                 <ng-container *ngIf="!icon">
-                    <svg data-p-icon="calendar" *ngIf="!triggerIconTemplate && !_triggerIconTemplate" [pBind]="ptm('dropdownIcon')" />
-                    <ng-template *ngTemplateOutlet="triggerIconTemplate || _triggerIconTemplate"></ng-template>
+                    <svg data-p-icon="calendar" *ngIf="!triggerIconTemplate() && !_triggerIconTemplate" [pBind]="ptm('dropdownIcon')" />
+                    <ng-template *ngTemplateOutlet="triggerIconTemplate() || _triggerIconTemplate"></ng-template>
                 </ng-container>
             </button>
             <ng-container *ngIf="iconDisplay === 'input' && showIcon">
                 <span [class]="cx('inputIconContainer')" [pBind]="ptm('inputIconContainer')" [attr.data-p]="inputIconDataP">
-                    <svg data-p-icon="calendar" (click)="onButtonClick($event)" *ngIf="!inputIconTemplate && !_inputIconTemplate" [class]="cx('inputIcon')" [pBind]="ptm('inputIcon')" />
+                    <svg data-p-icon="calendar" (click)="onButtonClick($event)" *ngIf="!inputIconTemplate() && !_inputIconTemplate" [class]="cx('inputIcon')" [pBind]="ptm('inputIcon')" />
 
-                    <ng-container *ngTemplateOutlet="inputIconTemplate || _inputIconTemplate; context: { clickCallBack: onButtonClick.bind(this) }"></ng-container>
+                    <ng-container *ngTemplateOutlet="inputIconTemplate() || _inputIconTemplate; context: { clickCallBack: onButtonClick.bind(this) }"></ng-container>
                 </span>
             </ng-container>
         </ng-template>
@@ -168,7 +168,7 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                 [pBind]="ptm('panel')"
             >
                 <ng-content select="p-header"></ng-content>
-                <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
                 <ng-container *ngIf="!timeOnly">
                     <div [class]="cx('calendarContainer')" [pBind]="ptm('calendarContainer')">
                         <div [class]="cx('calendar')" *ngFor="let month of months; let i = index" [pBind]="ptm('calendar')">
@@ -187,9 +187,9 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                     [attr.data-pc-group-section]="'navigator'"
                                 >
                                     <ng-template #icon>
-                                        <svg data-p-icon="chevron-left" *ngIf="!previousIconTemplate && !_previousIconTemplate" />
-                                        <span *ngIf="previousIconTemplate || _previousIconTemplate">
-                                            <ng-template *ngTemplateOutlet="previousIconTemplate || _previousIconTemplate"></ng-template>
+                                        <svg data-p-icon="chevron-left" *ngIf="!previousIconTemplate() && !_previousIconTemplate" />
+                                        <span *ngIf="previousIconTemplate() || _previousIconTemplate">
+                                            <ng-template *ngTemplateOutlet="previousIconTemplate() || _previousIconTemplate"></ng-template>
                                         </span>
                                     </ng-template>
                                 </p-button>
@@ -223,8 +223,8 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                         {{ getYear(month) }}
                                     </button>
                                     <span [class]="cx('decade')" *ngIf="currentView === 'year'" [pBind]="ptm('decade')">
-                                        <ng-container *ngIf="!decadeTemplate && !_decadeTemplate">{{ yearPickerValues()[0] }} - {{ yearPickerValues()[yearPickerValues().length - 1] }}</ng-container>
-                                        <ng-container *ngTemplateOutlet="decadeTemplate || _decadeTemplate; context: { $implicit: yearPickerValues }"></ng-container>
+                                        <ng-container *ngIf="!decadeTemplate() && !_decadeTemplate">{{ yearPickerValues()[0] }} - {{ yearPickerValues()[yearPickerValues().length - 1] }}</ng-container>
+                                        <ng-container *ngTemplateOutlet="decadeTemplate() || _decadeTemplate; context: { $implicit: yearPickerValues }"></ng-container>
                                     </span>
                                 </div>
                                 <p-button
@@ -240,9 +240,9 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                     [attr.data-pc-group-section]="'navigator'"
                                 >
                                     <ng-template #icon>
-                                        <svg data-p-icon="chevron-right" *ngIf="!nextIconTemplate && !_nextIconTemplate" />
-                                        <ng-container *ngIf="nextIconTemplate || _nextIconTemplate">
-                                            <ng-template *ngTemplateOutlet="nextIconTemplate || _nextIconTemplate"></ng-template>
+                                        <svg data-p-icon="chevron-right" *ngIf="!nextIconTemplate() && !_nextIconTemplate" />
+                                        <ng-container *ngIf="nextIconTemplate() || _nextIconTemplate">
+                                            <ng-template *ngTemplateOutlet="nextIconTemplate() || _nextIconTemplate"></ng-template>
                                         </ng-container>
                                     </ng-template>
                                 </p-button>
@@ -276,12 +276,12 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                                     pRipple
                                                     [pBind]="ptm('day')"
                                                 >
-                                                    <ng-container *ngIf="!dateTemplate && !_dateTemplate && (date.selectable || (!disabledDateTemplate && !_disabledDateTemplate))">{{ date.day }}</ng-container>
-                                                    <ng-container *ngIf="date.selectable || (!disabledDateTemplate && !_disabledDateTemplate)">
-                                                        <ng-container *ngTemplateOutlet="dateTemplate || _dateTemplate; context: { $implicit: date }"></ng-container>
+                                                    <ng-container *ngIf="!dateTemplate() && !_dateTemplate && (date.selectable || (!disabledDateTemplate() && !_disabledDateTemplate))">{{ date.day }}</ng-container>
+                                                    <ng-container *ngIf="date.selectable || (!disabledDateTemplate() && !_disabledDateTemplate)">
+                                                        <ng-container *ngTemplateOutlet="dateTemplate() || _dateTemplate; context: { $implicit: date }"></ng-container>
                                                     </ng-container>
                                                     <ng-container *ngIf="!date.selectable">
-                                                        <ng-container *ngTemplateOutlet="disabledDateTemplate || _disabledDateTemplate; context: { $implicit: date }"></ng-container>
+                                                        <ng-container *ngTemplateOutlet="disabledDateTemplate() || _disabledDateTemplate; context: { $implicit: date }"></ng-container>
                                                     </ng-container>
                                                 </span>
                                                 <div *ngIf="isSelected(date)" class="p-hidden-accessible" aria-live="polite">
@@ -331,8 +331,8 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                             [attr.data-pc-group-section]="'timepickerbutton'"
                         >
                             <ng-template #icon>
-                                <svg data-p-icon="chevron-up" *ngIf="!incrementIconTemplate && !_incrementIconTemplate" [pBind]="ptm('pcIncrementButton')['icon']" />
-                                <ng-template *ngTemplateOutlet="incrementIconTemplate || _incrementIconTemplate"></ng-template>
+                                <svg data-p-icon="chevron-up" *ngIf="!incrementIconTemplate() && !_incrementIconTemplate" [pBind]="ptm('pcIncrementButton')['icon']" />
+                                <ng-template *ngTemplateOutlet="incrementIconTemplate() || _incrementIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                         <span [pBind]="ptm('hour')"><ng-container *ngIf="currentHour < 10">0</ng-container>{{ currentHour }}</span>
@@ -354,8 +354,8 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                             [attr.data-pc-group-section]="'timepickerbutton'"
                         >
                             <ng-template #icon>
-                                <svg data-p-icon="chevron-down" *ngIf="!decrementIconTemplate && !_decrementIconTemplate" [pBind]="ptm('pcDecrementButton')['icon']" />
-                                <ng-template *ngTemplateOutlet="decrementIconTemplate || _decrementIconTemplate"></ng-template>
+                                <svg data-p-icon="chevron-down" *ngIf="!decrementIconTemplate() && !_decrementIconTemplate" [pBind]="ptm('pcDecrementButton')['icon']" />
+                                <ng-template *ngTemplateOutlet="decrementIconTemplate() || _decrementIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                     </div>
@@ -381,8 +381,8 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                             [attr.data-pc-group-section]="'timepickerbutton'"
                         >
                             <ng-template #icon>
-                                <svg data-p-icon="chevron-up" *ngIf="!incrementIconTemplate && !_incrementIconTemplate" [pBind]="ptm('pcIncrementButton')['icon']" />
-                                <ng-template *ngTemplateOutlet="incrementIconTemplate || _incrementIconTemplate"></ng-template>
+                                <svg data-p-icon="chevron-up" *ngIf="!incrementIconTemplate() && !_incrementIconTemplate" [pBind]="ptm('pcIncrementButton')['icon']" />
+                                <ng-template *ngTemplateOutlet="incrementIconTemplate() || _incrementIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                         <span [pBind]="ptm('minute')"><ng-container *ngIf="currentMinute < 10">0</ng-container>{{ currentMinute }}</span>
@@ -404,8 +404,8 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                             [attr.data-pc-group-section]="'timepickerbutton'"
                         >
                             <ng-template #icon>
-                                <svg data-p-icon="chevron-down" *ngIf="!decrementIconTemplate && !_decrementIconTemplate" [pBind]="ptm('pcDecrementButton')['icon']" />
-                                <ng-template *ngTemplateOutlet="decrementIconTemplate || _decrementIconTemplate"></ng-template>
+                                <svg data-p-icon="chevron-down" *ngIf="!decrementIconTemplate() && !_decrementIconTemplate" [pBind]="ptm('pcDecrementButton')['icon']" />
+                                <ng-template *ngTemplateOutlet="decrementIconTemplate() || _decrementIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                     </div>
@@ -431,8 +431,8 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                             [attr.data-pc-group-section]="'timepickerbutton'"
                         >
                             <ng-template #icon>
-                                <svg data-p-icon="chevron-up" *ngIf="!incrementIconTemplate && !_incrementIconTemplate" [pBind]="ptm('pcIncrementButton')['icon']" />
-                                <ng-template *ngTemplateOutlet="incrementIconTemplate || _incrementIconTemplate"></ng-template>
+                                <svg data-p-icon="chevron-up" *ngIf="!incrementIconTemplate() && !_incrementIconTemplate" [pBind]="ptm('pcIncrementButton')['icon']" />
+                                <ng-template *ngTemplateOutlet="incrementIconTemplate() || _incrementIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                         <span [pBind]="ptm('second')"><ng-container *ngIf="currentSecond < 10">0</ng-container>{{ currentSecond }}</span>
@@ -454,8 +454,8 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                             [attr.data-pc-group-section]="'timepickerbutton'"
                         >
                             <ng-template #icon>
-                                <svg data-p-icon="chevron-down" *ngIf="!decrementIconTemplate && !_decrementIconTemplate" [pBind]="ptm('pcDecrementButton')['icon']" />
-                                <ng-template *ngTemplateOutlet="decrementIconTemplate || _decrementIconTemplate"></ng-template>
+                                <svg data-p-icon="chevron-down" *ngIf="!decrementIconTemplate() && !_decrementIconTemplate" [pBind]="ptm('pcDecrementButton')['icon']" />
+                                <ng-template *ngTemplateOutlet="decrementIconTemplate() || _decrementIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                     </div>
@@ -476,8 +476,8 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                             [attr.data-pc-group-section]="'timepickerbutton'"
                         >
                             <ng-template #icon>
-                                <svg data-p-icon="chevron-up" *ngIf="!incrementIconTemplate && !_incrementIconTemplate" [pBind]="ptm('pcIncrementButton')['icon']" />
-                                <ng-template *ngTemplateOutlet="incrementIconTemplate || _incrementIconTemplate"></ng-template>
+                                <svg data-p-icon="chevron-up" *ngIf="!incrementIconTemplate() && !_incrementIconTemplate" [pBind]="ptm('pcIncrementButton')['icon']" />
+                                <ng-template *ngTemplateOutlet="incrementIconTemplate() || _incrementIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                         <span [pBind]="ptm('ampm')">{{ pm ? 'PM' : 'AM' }}</span>
@@ -494,15 +494,15 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                             [attr.data-pc-group-section]="'timepickerbutton'"
                         >
                             <ng-template #icon>
-                                <svg data-p-icon="chevron-down" *ngIf="!decrementIconTemplate && !_decrementIconTemplate" [pBind]="ptm('pcDecrementButton')['icon']" />
-                                <ng-template *ngTemplateOutlet="decrementIconTemplate || _decrementIconTemplate"></ng-template>
+                                <svg data-p-icon="chevron-down" *ngIf="!decrementIconTemplate() && !_decrementIconTemplate" [pBind]="ptm('pcDecrementButton')['icon']" />
+                                <ng-template *ngTemplateOutlet="decrementIconTemplate() || _decrementIconTemplate"></ng-template>
                             </ng-template>
                         </p-button>
                     </div>
                 </div>
                 <div [class]="cx('buttonbar')" *ngIf="showButtonBar" [pBind]="ptm('buttonbar')">
-                    @if (buttonBarTemplate || _buttonBarTemplate) {
-                        <ng-container *ngTemplateOutlet="buttonBarTemplate || _buttonBarTemplate; context: { todayCallback: onTodayButtonClick.bind(this), clearCallback: onClearButtonClick.bind(this) }"></ng-container>
+                    @if (buttonBarTemplate() || _buttonBarTemplate) {
+                        <ng-container *ngTemplateOutlet="buttonBarTemplate() || _buttonBarTemplate; context: { todayCallback: onTodayButtonClick.bind(this), clearCallback: onClearButtonClick.bind(this) }"></ng-container>
                     } @else {
                         <p-button
                             size="small"
@@ -533,7 +533,7 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                     }
                 </div>
                 <ng-content select="p-footer"></ng-content>
-                <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
             </div>
         </p-motion>
     `,
@@ -1039,7 +1039,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
      */
     @Output() onShow: EventEmitter<HTMLElement> = new EventEmitter<HTMLElement>();
 
-    @ViewChild('inputfield', { static: false }) inputfieldViewChild: Nullable<ElementRef>;
+    readonly inputfieldViewChild = viewChild<Nullable<ElementRef>>('inputfield');
 
     @ViewChild('contentWrapper', { static: false }) set content(content: ElementRef) {
         this.contentViewChild = content;
@@ -1133,83 +1133,83 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
      * @param {DatePickerDateTemplateContext} context - date template context.
      * @group Templates
      */
-    @ContentChild('date', { descendants: false }) dateTemplate: Nullable<TemplateRef<DatePickerDateTemplateContext>>;
+    readonly dateTemplate = contentChild<Nullable<TemplateRef<DatePickerDateTemplateContext>>>('date', { descendants: false });
 
     /**
      * Custom template for header section.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: Nullable<TemplateRef<void>>;
+    readonly headerTemplate = contentChild<Nullable<TemplateRef<void>>>('header', { descendants: false });
 
     /**
      * Custom template for footer section.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: Nullable<TemplateRef<void>>;
+    readonly footerTemplate = contentChild<Nullable<TemplateRef<void>>>('footer', { descendants: false });
 
     /**
      * Custom template for disabled date cells.
      * @param {DatePickerDisabledDateTemplateContext} context - disabled date template context.
      * @group Templates
      */
-    @ContentChild('disabledDate', { descendants: false }) disabledDateTemplate: Nullable<TemplateRef<DatePickerDisabledDateTemplateContext>>;
+    readonly disabledDateTemplate = contentChild<Nullable<TemplateRef<DatePickerDisabledDateTemplateContext>>>('disabledDate', { descendants: false });
 
     /**
      * Custom template for decade view.
      * @param {DatePickerDecadeTemplateContext} context - decade template context.
      * @group Templates
      */
-    @ContentChild('decade', { descendants: false }) decadeTemplate: Nullable<TemplateRef<DatePickerDecadeTemplateContext>>;
+    readonly decadeTemplate = contentChild<Nullable<TemplateRef<DatePickerDecadeTemplateContext>>>('decade', { descendants: false });
 
     /**
      * Custom template for previous month icon.
      * @group Templates
      */
-    @ContentChild('previousicon', { descendants: false }) previousIconTemplate: Nullable<TemplateRef<void>>;
+    readonly previousIconTemplate = contentChild<Nullable<TemplateRef<void>>>('previousicon', { descendants: false });
 
     /**
      * Custom template for next month icon.
      * @group Templates
      */
-    @ContentChild('nexticon', { descendants: false }) nextIconTemplate: Nullable<TemplateRef<void>>;
+    readonly nextIconTemplate = contentChild<Nullable<TemplateRef<void>>>('nexticon', { descendants: false });
 
     /**
      * Custom template for trigger icon.
      * @group Templates
      */
-    @ContentChild('triggericon', { descendants: false }) triggerIconTemplate: Nullable<TemplateRef<void>>;
+    readonly triggerIconTemplate = contentChild<Nullable<TemplateRef<void>>>('triggericon', { descendants: false });
 
     /**
      * Custom template for clear icon.
      * @group Templates
      */
-    @ContentChild('clearicon', { descendants: false }) clearIconTemplate: Nullable<TemplateRef<void>>;
+    readonly clearIconTemplate = contentChild<Nullable<TemplateRef<void>>>('clearicon', { descendants: false });
 
     /**
      * Custom template for decrement icon.
      * @group Templates
      */
-    @ContentChild('decrementicon', { descendants: false }) decrementIconTemplate: Nullable<TemplateRef<void>>;
+    readonly decrementIconTemplate = contentChild<Nullable<TemplateRef<void>>>('decrementicon', { descendants: false });
 
     /**
      * Custom template for increment icon.
      * @group Templates
      */
-    @ContentChild('incrementicon', { descendants: false }) incrementIconTemplate: Nullable<TemplateRef<void>>;
+    readonly incrementIconTemplate = contentChild<Nullable<TemplateRef<void>>>('incrementicon', { descendants: false });
 
     /**
      * Custom template for input icon.
      * @param {DatePickerInputIconTemplateContext} context - input icon template context.
      * @group Templates
      */
-    @ContentChild('inputicon', { descendants: false }) inputIconTemplate: Nullable<TemplateRef<DatePickerInputIconTemplateContext>>;
+    readonly inputIconTemplate = contentChild<Nullable<TemplateRef<DatePickerInputIconTemplateContext>>>('inputicon', { descendants: false });
 
     /**
      * Custom template for button bar.
      * @param {DatePickerButtonBarTemplateContext} context - button bar template context.
      * @group Templates
      */
-    @ContentChild('buttonbar', { descendants: false }) buttonBarTemplate: Nullable<TemplateRef<DatePickerButtonBarTemplateContext>>;
+    readonly buttonBarTemplate = contentChild<Nullable<TemplateRef<DatePickerButtonBarTemplateContext>>>('buttonbar', { descendants: false });
 
     _dateTemplate: TemplateRef<DatePickerDateTemplateContext> | undefined;
 
@@ -1348,10 +1348,10 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
     }
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'date':
                     this._dateTemplate = item.template;
@@ -1767,8 +1767,9 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
 
         this.inputFieldValue = formattedValue;
 
-        if (this.inputfieldViewChild && this.inputfieldViewChild.nativeElement) {
-            this.inputfieldViewChild.nativeElement.value = this.inputFieldValue;
+        const inputfieldViewChild = this.inputfieldViewChild();
+        if (inputfieldViewChild && inputfieldViewChild.nativeElement) {
+            inputfieldViewChild.nativeElement.value = this.inputFieldValue;
         }
     }
 
@@ -2146,7 +2147,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         this.onModelTouched();
     }
 
-    onButtonClick(event: Event, inputfield: any = this.inputfieldViewChild?.nativeElement) {
+    onButtonClick(event: Event, inputfield: any = this.inputfieldViewChild()?.nativeElement) {
         if (this.$disabled()) {
             return;
         }
@@ -2219,7 +2220,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
 
             //escape
             case 27:
-                this.inputfieldViewChild?.nativeElement.focus();
+                this.inputfieldViewChild()?.nativeElement.focus();
                 this.overlayVisible = false;
                 event.preventDefault();
                 break;
@@ -2236,7 +2237,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
             this.trapFocus(event);
         } else if (event.keyCode === 27) {
             if (this.overlayVisible) {
-                this.inputfieldViewChild?.nativeElement.focus();
+                this.inputfieldViewChild()?.nativeElement.focus();
                 this.overlayVisible = false;
                 event.preventDefault();
             }
@@ -2351,7 +2352,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
 
             //escape
             case 27: {
-                this.inputfieldViewChild?.nativeElement.focus();
+                this.inputfieldViewChild()?.nativeElement.focus();
                 this.overlayVisible = false;
                 event.preventDefault();
                 break;
@@ -2478,7 +2479,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
 
             //escape
             case 27: {
-                this.inputfieldViewChild?.nativeElement.focus();
+                this.inputfieldViewChild()?.nativeElement.focus();
                 this.overlayVisible = false;
                 event.preventDefault();
                 break;
@@ -2560,7 +2561,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
 
             //escape
             case 27: {
-                this.inputfieldViewChild?.nativeElement.focus();
+                this.inputfieldViewChild()?.nativeElement.focus();
                 this.overlayVisible = false;
                 event.preventDefault();
                 break;
@@ -3162,7 +3163,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
     }
 
     hideOverlay() {
-        this.inputfieldViewChild?.nativeElement.focus();
+        this.inputfieldViewChild()?.nativeElement.focus();
         this.overlayVisible = false;
         this.clearTimePickerTimer();
 
@@ -3177,7 +3178,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
         if (!this.inline) {
             if (!this.overlayVisible) {
                 this.showOverlay();
-                this.inputfieldViewChild?.nativeElement.focus();
+                this.inputfieldViewChild()?.nativeElement.focus();
             } else {
                 this.hideOverlay();
             }
@@ -3225,9 +3226,9 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
             this.enableModality(this.overlay);
         } else if (this.overlay) {
             if (this.$appendTo() && this.$appendTo() !== 'self') {
-                absolutePosition(this.overlay, this.inputfieldViewChild?.nativeElement);
+                absolutePosition(this.overlay, this.inputfieldViewChild()?.nativeElement);
             } else {
-                relativePosition(this.overlay, this.inputfieldViewChild?.nativeElement);
+                relativePosition(this.overlay, this.inputfieldViewChild()?.nativeElement);
             }
         }
     }

--- a/packages/optimus-ui/src/dialog/dialog.test.ts
+++ b/packages/optimus-ui/src/dialog/dialog.test.ts
@@ -1037,12 +1037,12 @@ describe('Dialog', () => {
                 await new Promise((resolve) => setTimeout(resolve, 0));
 
                 // Check that ContentChild templates are assigned
-                expect(hashTemplateDialogInstance._headerTemplate).toBeDefined();
-                expect(hashTemplateDialogInstance._contentTemplate).toBeDefined();
-                expect(hashTemplateDialogInstance._footerTemplate).toBeDefined();
-                expect(hashTemplateDialogInstance._closeiconTemplate).toBeDefined();
-                expect(hashTemplateDialogInstance._maximizeiconTemplate).toBeDefined();
-                expect(hashTemplateDialogInstance._minimizeiconTemplate).toBeDefined();
+                expect(hashTemplateDialogInstance._headerTemplate()).toBeDefined();
+                expect(hashTemplateDialogInstance._contentTemplate()).toBeDefined();
+                expect(hashTemplateDialogInstance._footerTemplate()).toBeDefined();
+                expect(hashTemplateDialogInstance._closeiconTemplate()).toBeDefined();
+                expect(hashTemplateDialogInstance._maximizeiconTemplate()).toBeDefined();
+                expect(hashTemplateDialogInstance._minimizeiconTemplate()).toBeDefined();
             });
         });
 

--- a/packages/optimus-ui/src/dialog/dialog.test.ts
+++ b/packages/optimus-ui/src/dialog/dialog.test.ts
@@ -6,6 +6,8 @@ import { ButtonModule } from '@openng/optimus-ui/button';
 import { FocusTrap } from '@openng/optimus-ui/focustrap';
 import { Dialog } from './dialog';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 // Basic Dialog Test Component
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1761,5 +1763,37 @@ describe('Dialog', () => {
                 expect(component.onDestroyCalled).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Dialog, SharedModule],
+    template: `
+        <p-dialog [visible]="true" header="H">
+            <ng-template pTemplate="content">c</ng-template>
+        </p-dialog>
+    `
+})
+class DialogQueryApiHostComponent {}
+
+describe('Dialog Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [DialogQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(DialogQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Dialog)).componentInstance;
+
+        expect(instance.headerViewChild()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'content')).toBe(true);
     });
 });

--- a/packages/optimus-ui/src/dialog/dialog.ts
+++ b/packages/optimus-ui/src/dialog/dialog.ts
@@ -5,8 +5,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -19,12 +17,13 @@ import {
     OnDestroy,
     OnInit,
     Output,
-    QueryList,
     signal,
     TemplateRef,
-    ViewChild,
     ViewEncapsulation,
-    ViewRef
+    ViewRef,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { addStyle, appendChild, getOuterHeight, getOuterWidth, getViewport, hasClass, removeClass, setAttribute, uuid } from '@openng/optimus-ui-utils';
@@ -89,15 +88,15 @@ const DIALOG_INSTANCE = new InjectionToken<Dialog>('DIALOG_INSTANCE');
                         [attr.aria-modal]="true"
                         [attr.data-p]="dataP"
                     >
-                        <ng-container *ngIf="_headlessTemplate || headlessTemplate || headlessT; else notHeadless">
-                            <ng-container *ngTemplateOutlet="_headlessTemplate || headlessTemplate || headlessT"></ng-container>
+                        <ng-container *ngIf="_headlessTemplate() || headlessTemplate || headlessT; else notHeadless">
+                            <ng-container *ngTemplateOutlet="_headlessTemplate() || headlessTemplate || headlessT"></ng-container>
                         </ng-container>
 
                         <ng-template #notHeadless>
                             <div *ngIf="resizable" [class]="cx('resizeHandle')" [pBind]="ptm('resizeHandle')" [style.z-index]="90" (mousedown)="initResize($event)"></div>
                             <div #titlebar [class]="cx('header')" [pBind]="ptm('header')" (mousedown)="initDrag($event)" *ngIf="showHeader">
-                                <span [id]="headerId()" [class]="cx('title')" [pBind]="ptm('title')" *ngIf="!_headerTemplate && !headerTemplate && !headerT">{{ header() }}</span>
-                                <ng-container *ngTemplateOutlet="_headerTemplate || headerTemplate || headerT; context: { ariaLabelledBy: computedAriaLabelledBy() }"></ng-container>
+                                <span [id]="headerId()" [class]="cx('title')" [pBind]="ptm('title')" *ngIf="!_headerTemplate() && !headerTemplate && !headerT">{{ header() }}</span>
+                                <ng-container *ngTemplateOutlet="_headerTemplate() || headerTemplate || headerT; context: { ariaLabelledBy: computedAriaLabelledBy() }"></ng-container>
                                 <div [class]="cx('headerActions')" [pBind]="ptm('headerActions')">
                                     <p-button
                                         [pt]="ptm('pcMaximizeButton')"
@@ -112,16 +111,16 @@ const DIALOG_INSTANCE = new InjectionToken<Dialog>('DIALOG_INSTANCE');
                                         [attr.data-pc-group-section]="'headericon'"
                                     >
                                         <ng-template #icon>
-                                            <span *ngIf="maximizeIcon && !_maximizeiconTemplate && !_minimizeiconTemplate" [ngClass]="maximized ? minimizeIcon : maximizeIcon"></span>
+                                            <span *ngIf="maximizeIcon && !_maximizeiconTemplate() && !_minimizeiconTemplate()" [ngClass]="maximized ? minimizeIcon : maximizeIcon"></span>
                                             <ng-container *ngIf="!maximizeIcon && !maximizeButtonProps?.icon">
-                                                <svg data-p-icon="window-maximize" *ngIf="!maximized && !_maximizeiconTemplate && !maximizeIconTemplate && !maximizeIconT" />
-                                                <svg data-p-icon="window-minimize" *ngIf="maximized && !_minimizeiconTemplate && !minimizeIconTemplate && !minimizeIconT" />
+                                                <svg data-p-icon="window-maximize" *ngIf="!maximized && !_maximizeiconTemplate() && !maximizeIconTemplate && !maximizeIconT" />
+                                                <svg data-p-icon="window-minimize" *ngIf="maximized && !_minimizeiconTemplate() && !minimizeIconTemplate && !minimizeIconT" />
                                             </ng-container>
                                             <ng-container *ngIf="!maximized">
-                                                <ng-template *ngTemplateOutlet="_maximizeiconTemplate || maximizeIconTemplate || maximizeIconT"></ng-template>
+                                                <ng-template *ngTemplateOutlet="_maximizeiconTemplate() || maximizeIconTemplate || maximizeIconT"></ng-template>
                                             </ng-container>
                                             <ng-container *ngIf="maximized">
-                                                <ng-template *ngTemplateOutlet="_minimizeiconTemplate || minimizeIconTemplate || minimizeIconT"></ng-template>
+                                                <ng-template *ngTemplateOutlet="_minimizeiconTemplate() || minimizeIconTemplate || minimizeIconT"></ng-template>
                                             </ng-container>
                                         </ng-template>
                                     </p-button>
@@ -138,12 +137,12 @@ const DIALOG_INSTANCE = new InjectionToken<Dialog>('DIALOG_INSTANCE');
                                         [attr.data-pc-group-section]="'headericon'"
                                     >
                                         <ng-template #icon>
-                                            <ng-container *ngIf="!_closeiconTemplate && !closeIconTemplate && !closeIconT && !closeButtonProps?.icon">
+                                            <ng-container *ngIf="!_closeiconTemplate() && !closeIconTemplate && !closeIconT && !closeButtonProps?.icon">
                                                 <span *ngIf="closeIcon" [class]="closeIcon"></span>
                                                 <svg data-p-icon="times" *ngIf="!closeIcon" />
                                             </ng-container>
-                                            <span *ngIf="_closeiconTemplate || closeIconTemplate || closeIconT">
-                                                <ng-template *ngTemplateOutlet="_closeiconTemplate || closeIconTemplate || closeIconT"></ng-template>
+                                            <span *ngIf="_closeiconTemplate() || closeIconTemplate || closeIconT">
+                                                <ng-template *ngTemplateOutlet="_closeiconTemplate() || closeIconTemplate || closeIconT"></ng-template>
                                             </span>
                                         </ng-template>
                                     </p-button>
@@ -151,11 +150,11 @@ const DIALOG_INSTANCE = new InjectionToken<Dialog>('DIALOG_INSTANCE');
                             </div>
                             <div #content [class]="cn(cx('content'), contentStyleClass)" [ngStyle]="contentStyle" [pBind]="ptm('content')">
                                 <ng-content></ng-content>
-                                <ng-container *ngTemplateOutlet="_contentTemplate || contentTemplate || contentT"></ng-container>
+                                <ng-container *ngTemplateOutlet="_contentTemplate() || contentTemplate || contentT"></ng-container>
                             </div>
-                            <div #footer [class]="cx('footer')" [pBind]="ptm('footer')" *ngIf="_footerTemplate || footerTemplate || footerT">
+                            <div #footer [class]="cx('footer')" [pBind]="ptm('footer')" *ngIf="_footerTemplate() || footerTemplate || footerT">
                                 <ng-content select="p-footer"></ng-content>
-                                <ng-container *ngTemplateOutlet="_footerTemplate || footerTemplate || footerT"></ng-container>
+                                <ng-container *ngTemplateOutlet="_footerTemplate() || footerTemplate || footerT"></ng-container>
                             </div>
                         </ng-template>
                     </div>
@@ -464,11 +463,11 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
      */
     @Output() onMaximize: EventEmitter<any> = new EventEmitter<any>();
 
-    @ViewChild('titlebar') headerViewChild: Nullable<ElementRef>;
+    readonly headerViewChild = viewChild<Nullable<ElementRef>>('titlebar');
 
-    @ViewChild('content') contentViewChild: Nullable<ElementRef>;
+    readonly contentViewChild = viewChild<Nullable<ElementRef>>('content');
 
-    @ViewChild('footer') footerViewChild: Nullable<ElementRef>;
+    readonly footerViewChild = viewChild<Nullable<ElementRef>>('footer');
     /**
      * Header template.
      * @group Templates
@@ -509,43 +508,43 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) _headerTemplate: TemplateRef<void> | undefined;
+    readonly _headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
 
     /**
      * Custom content template.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) _contentTemplate: TemplateRef<void> | undefined;
+    readonly _contentTemplate = contentChild<TemplateRef<void>>('content', { descendants: false });
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) _footerTemplate: TemplateRef<void> | undefined;
+    readonly _footerTemplate = contentChild<TemplateRef<void>>('footer', { descendants: false });
 
     /**
      * Custom close icon template.
      * @group Templates
      */
-    @ContentChild('closeicon', { descendants: false }) _closeiconTemplate: TemplateRef<void> | undefined;
+    readonly _closeiconTemplate = contentChild<TemplateRef<void>>('closeicon', { descendants: false });
 
     /**
      * Custom maximize icon template.
      * @group Templates
      */
-    @ContentChild('maximizeicon', { descendants: false }) _maximizeiconTemplate: TemplateRef<void> | undefined;
+    readonly _maximizeiconTemplate = contentChild<TemplateRef<void>>('maximizeicon', { descendants: false });
 
     /**
      * Custom minimize icon template.
      * @group Templates
      */
-    @ContentChild('minimizeicon', { descendants: false }) _minimizeiconTemplate: TemplateRef<void> | undefined;
+    readonly _minimizeiconTemplate = contentChild<TemplateRef<void>>('minimizeicon', { descendants: false });
 
     /**
      * Custom headless template.
      * @group Templates
      */
-    @ContentChild('headless', { descendants: false }) _headlessTemplate: TemplateRef<void> | undefined;
+    readonly _headlessTemplate = contentChild<TemplateRef<void>>('headless', { descendants: false });
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
 
@@ -657,10 +656,10 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
         }
     }
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this.headerT = item.template;
@@ -731,15 +730,15 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
         return false;
     }
 
-    focus(focusParentElement: HTMLElement = this.contentViewChild?.nativeElement) {
+    focus(focusParentElement: HTMLElement = this.contentViewChild()?.nativeElement) {
         let focused = this._focus(focusParentElement);
 
         if (!focused) {
-            focused = this._focus(this.footerViewChild?.nativeElement);
+            focused = this._focus(this.footerViewChild()?.nativeElement);
             if (!focused) {
-                focused = this._focus(this.headerViewChild?.nativeElement);
+                focused = this._focus(this.headerViewChild()?.nativeElement);
                 if (!focused) {
-                    this._focus(this.contentViewChild?.nativeElement);
+                    this._focus(this.contentViewChild()?.nativeElement);
                 }
             }
         }
@@ -939,7 +938,8 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
             let deltaY = event.pageY - (this.lastPageY as number);
             let containerWidth = getOuterWidth(this.container() as HTMLDivElement);
             let containerHeight = getOuterHeight(this.container() as HTMLDivElement);
-            let contentHeight = getOuterHeight(this.contentViewChild?.nativeElement);
+            const contentViewChild = this.contentViewChild();
+            let contentHeight = getOuterHeight(contentViewChild?.nativeElement);
             let newWidth = containerWidth + deltaX;
             let newHeight = containerHeight + deltaY;
             let minWidth = (this.container() as HTMLDivElement).style.minWidth;
@@ -959,7 +959,7 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
             }
 
             if ((!minHeight || newHeight > parseInt(minHeight)) && offset.top + newHeight < viewport.height) {
-                (<ElementRef>this.contentViewChild).nativeElement.style.height = contentHeight + newHeight - containerHeight + 'px';
+                (<ElementRef>contentViewChild).nativeElement.style.height = contentHeight + newHeight - containerHeight + 'px';
 
                 if (this._style.height) {
                     this._style.height = newHeight + 'px';

--- a/packages/optimus-ui/src/dock/dock.test.ts
+++ b/packages/optimus-ui/src/dock/dock.test.ts
@@ -7,6 +7,7 @@ import { MenuItem, SharedModule } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { Dock } from './dock';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1406,5 +1407,34 @@ describe('Dock', () => {
                 expect(true).toBe(true); // Pass for now as global CSS handling varies
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Dock, SharedModule],
+    template: ` <p-dock [model]="model"> </p-dock> `
+})
+class DockQueryApiHostComponent {
+    model = [{ label: 'a' }];
+}
+
+describe('Dock Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [DockQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(DockQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Dock)).componentInstance;
+
+        expect(instance.listViewChild()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/dock/dock.ts
+++ b/packages/optimus-ui/src/dock/dock.ts
@@ -1,23 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-    ChangeDetectionStrategy,
-    ChangeDetectorRef,
-    Component,
-    ContentChild,
-    ContentChildren,
-    ElementRef,
-    EventEmitter,
-    inject,
-    InjectionToken,
-    Input,
-    NgModule,
-    Output,
-    QueryList,
-    signal,
-    TemplateRef,
-    ViewChild,
-    ViewEncapsulation
-} from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, inject, InjectionToken, Input, NgModule, Output, signal, TemplateRef, ViewEncapsulation, viewChild, contentChild, contentChildren } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterModule } from '@angular/router';
 import { find, findSingle, resolve, uuid } from '@openng/optimus-ui-utils';
 import { MenuItem, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
@@ -99,10 +81,10 @@ const DOCK_INSTANCE = new InjectionToken<Dock>('DOCK_INSTANCE');
                                         [attr.aria-hidden]="true"
                                         [pBind]="getPTOptions(item, i, 'itemLink')"
                                     >
-                                        @if (item.icon && !itemTemplate && !_itemTemplate) {
+                                        @if (item.icon && !itemTemplate() && !_itemTemplate) {
                                             <span [class]="cn(cx('itemIcon'), item.icon, item.iconClass)" [ngStyle]="item.iconStyle" [pBind]="getPTOptions(item, i, 'itemIcon')"></span>
                                         }
-                                        <ng-container *ngTemplateOutlet="itemTemplate || itemTemplate; context: { $implicit: item }"></ng-container>
+                                        <ng-container *ngTemplateOutlet="itemTemplate() || itemTemplate(); context: { $implicit: item }"></ng-container>
                                         @if (item.badge) {
                                             <p-badge [styleClass]="item.badgeStyleClass" [value]="item.badge" [pt]="getPTOptions(item, i, 'pcBadge')" [unstyled]="unstyled()" />
                                         }
@@ -124,10 +106,10 @@ const DOCK_INSTANCE = new InjectionToken<Dock>('DOCK_INSTANCE');
                                         [attr.aria-hidden]="true"
                                         [pBind]="getPTOptions(item, i, 'itemLink')"
                                     >
-                                        @if (item.icon && !itemTemplate && !_itemTemplate) {
+                                        @if (item.icon && !itemTemplate() && !_itemTemplate) {
                                             <span [class]="cn(cx('itemIcon'), item.icon, item.iconClass)" [ngStyle]="item.iconStyle" [pBind]="getPTOptions(item, i, 'itemIcon')"></span>
                                         }
-                                        <ng-container *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: item }"></ng-container>
+                                        <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: item }"></ng-container>
                                         @if (item.badge) {
                                             <p-badge [styleClass]="item.badgeStyleClass" [value]="item.badge" [pt]="getPTOptions(item, i, 'pcBadge')" [unstyled]="unstyled()" />
                                         }
@@ -203,7 +185,7 @@ export class Dock extends BaseComponent<DockPassThrough> {
      */
     @Output() onBlur: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
 
-    @ViewChild('list', { static: false }) listViewChild: Nullable<ElementRef>;
+    readonly listViewChild = viewChild<Nullable<ElementRef>>('list');
 
     currentIndex: number;
 
@@ -250,7 +232,7 @@ export class Dock extends BaseComponent<DockPassThrough> {
      * @param {DockItemTemplateContext} context - item template context.
      * @group Templates
      */
-    @ContentChild('item') itemTemplate: TemplateRef<DockItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<DockItemTemplateContext>>('item');
 
     _itemTemplate: TemplateRef<DockItemTemplateContext> | undefined;
 
@@ -370,25 +352,25 @@ export class Dock extends BaseComponent<DockPassThrough> {
     }
 
     onEndKey() {
-        this.changeFocusedOptionIndex(find(this.listViewChild?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]').length - 1);
+        this.changeFocusedOptionIndex(find(this.listViewChild()?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]').length - 1);
     }
 
     onSpaceKey() {
-        const element = <HTMLElement>findSingle(this.listViewChild?.nativeElement, `li[id="${`${this.focusedOptionIndex}`}"]`);
+        const element = <HTMLElement>findSingle(this.listViewChild()?.nativeElement, `li[id="${`${this.focusedOptionIndex}`}"]`);
         const anchorElement = element && <HTMLElement>findSingle(element, 'a,button');
 
         anchorElement ? anchorElement.click() : element && element.click();
     }
 
     findNextOptionIndex(index) {
-        const menuitems = find(this.listViewChild?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
+        const menuitems = find(this.listViewChild()?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
         const matchedOptionIndex = [...menuitems].findIndex((link) => link.id === index);
 
         return matchedOptionIndex > -1 ? matchedOptionIndex + 1 : 0;
     }
 
     changeFocusedOptionIndex(index) {
-        const menuitems = <any>find(this.listViewChild?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
+        const menuitems = <any>find(this.listViewChild()?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
 
         let order = index >= menuitems.length ? menuitems.length - 1 : index < 0 ? 0 : index;
 
@@ -396,7 +378,7 @@ export class Dock extends BaseComponent<DockPassThrough> {
     }
 
     findPrevOptionIndex(index) {
-        const menuitems = find(this.listViewChild?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
+        const menuitems = find(this.listViewChild()?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
         const matchedOptionIndex = [...menuitems].findIndex((link) => link.id === index);
 
         return matchedOptionIndex > -1 ? matchedOptionIndex - 1 : 0;
@@ -406,10 +388,10 @@ export class Dock extends BaseComponent<DockPassThrough> {
         return !!item.routerLink && !this.disabled(item);
     }
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;

--- a/packages/optimus-ui/src/dock/dock.ts
+++ b/packages/optimus-ui/src/dock/dock.ts
@@ -8,7 +8,6 @@ import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent
 import { Bind } from '@openng/optimus-ui/bind';
 import { Ripple } from '@openng/optimus-ui/ripple';
 import { TooltipModule } from '@openng/optimus-ui/tooltip';
-import { Nullable } from '@openng/optimus-ui/ts-helpers';
 import { DockItemTemplateContext, DockPassThrough } from '@openng/optimus-ui/types/dock';
 import { DockStyle } from './style/dockstyle';
 
@@ -185,7 +184,7 @@ export class Dock extends BaseComponent<DockPassThrough> {
      */
     @Output() onBlur: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
 
-    readonly listViewChild = viewChild<Nullable<ElementRef>>('list');
+    readonly listViewChild = viewChild.required<ElementRef>('list');
 
     currentIndex: number;
 
@@ -352,25 +351,25 @@ export class Dock extends BaseComponent<DockPassThrough> {
     }
 
     onEndKey() {
-        this.changeFocusedOptionIndex(find(this.listViewChild()?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]').length - 1);
+        this.changeFocusedOptionIndex(find(this.listViewChild().nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]').length - 1);
     }
 
     onSpaceKey() {
-        const element = <HTMLElement>findSingle(this.listViewChild()?.nativeElement, `li[id="${`${this.focusedOptionIndex}`}"]`);
+        const element = <HTMLElement>findSingle(this.listViewChild().nativeElement, `li[id="${`${this.focusedOptionIndex}`}"]`);
         const anchorElement = element && <HTMLElement>findSingle(element, 'a,button');
 
         anchorElement ? anchorElement.click() : element && element.click();
     }
 
     findNextOptionIndex(index) {
-        const menuitems = find(this.listViewChild()?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
+        const menuitems = find(this.listViewChild().nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
         const matchedOptionIndex = [...menuitems].findIndex((link) => link.id === index);
 
         return matchedOptionIndex > -1 ? matchedOptionIndex + 1 : 0;
     }
 
     changeFocusedOptionIndex(index) {
-        const menuitems = <any>find(this.listViewChild()?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
+        const menuitems = <any>find(this.listViewChild().nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
 
         let order = index >= menuitems.length ? menuitems.length - 1 : index < 0 ? 0 : index;
 
@@ -378,7 +377,7 @@ export class Dock extends BaseComponent<DockPassThrough> {
     }
 
     findPrevOptionIndex(index) {
-        const menuitems = find(this.listViewChild()?.nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
+        const menuitems = find(this.listViewChild().nativeElement, 'li[data-pc-section="item"][data-p-disabled="false"]');
         const matchedOptionIndex = [...menuitems].findIndex((link) => link.id === index);
 
         return matchedOptionIndex > -1 ? matchedOptionIndex - 1 : 0;

--- a/packages/optimus-ui/src/drawer/drawer.test.ts
+++ b/packages/optimus-ui/src/drawer/drawer.test.ts
@@ -5,6 +5,7 @@ import { By } from '@angular/platform-browser';
 import { PrimeTemplate } from '@openng/optimus-ui/api';
 import { Drawer } from './drawer';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1488,5 +1489,41 @@ describe('Drawer', () => {
                 expect(component.onDestroyCalled).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Drawer, PrimeTemplate],
+    template: `
+        <p-drawer>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-drawer>
+    `
+})
+class DrawerQueryApiHostComponent {}
+
+describe('Drawer Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [DrawerQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(DrawerQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Drawer)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/drawer/drawer.ts
+++ b/packages/optimus-ui/src/drawer/drawer.ts
@@ -15,7 +15,6 @@ import {
     Output,
     TemplateRef,
     ViewEncapsulation,
-    viewChild,
     contentChild,
     contentChildren
 } from '@angular/core';
@@ -267,10 +266,6 @@ export class Drawer extends BaseComponent<DrawerPassThrough> {
      * @group Emits
      */
     @Output() visibleChange: EventEmitter<boolean> = new EventEmitter<boolean>();
-
-    readonly containerViewChild = viewChild<ElementRef>('container');
-
-    readonly closeButtonViewChild = viewChild<ElementRef>('closeButton');
 
     initialized: boolean | undefined;
 

--- a/packages/optimus-ui/src/drawer/drawer.ts
+++ b/packages/optimus-ui/src/drawer/drawer.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -15,10 +13,11 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { addClass, appendChild, removeClass, setAttribute } from '@openng/optimus-ui-utils';
@@ -67,11 +66,11 @@ const DRAWER_INSTANCE = new InjectionToken<Drawer>('DRAWER_INSTANCE');
                 [attr.data-p]="dataP"
                 [attr.data-p-open]="visible"
             >
-                @if (headlessTemplate || _headlessTemplate) {
-                    <ng-container *ngTemplateOutlet="headlessTemplate || _headlessTemplate"></ng-container>
+                @if (headlessTemplate() || _headlessTemplate) {
+                    <ng-container *ngTemplateOutlet="headlessTemplate() || _headlessTemplate"></ng-container>
                 } @else {
                     <div [pBind]="ptm('header')" [ngClass]="cx('header')" [attr.data-pc-section]="'header'">
-                        <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
                         @if (header) {
                             <div [pBind]="ptm('title')" [class]="cx('title')">{{ header }}</div>
                         }
@@ -87,10 +86,10 @@ const DRAWER_INSTANCE = new InjectionToken<Drawer>('DRAWER_INSTANCE');
                                 [unstyled]="unstyled()"
                             >
                                 <ng-template #icon>
-                                    @if (!closeIconTemplate && !_closeIconTemplate) {
+                                    @if (!closeIconTemplate() && !_closeIconTemplate) {
                                         <svg data-p-icon="times" [attr.data-pc-section]="'closeicon'" />
                                     }
-                                    <ng-template *ngTemplateOutlet="closeIconTemplate || _closeIconTemplate"></ng-template>
+                                    <ng-template *ngTemplateOutlet="closeIconTemplate() || _closeIconTemplate"></ng-template>
                                 </ng-template>
                             </p-button>
                         }
@@ -98,12 +97,12 @@ const DRAWER_INSTANCE = new InjectionToken<Drawer>('DRAWER_INSTANCE');
 
                     <div [pBind]="ptm('content')" [ngClass]="cx('content')" [attr.data-pc-section]="'content'">
                         <ng-content></ng-content>
-                        <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate"></ng-container>
                     </div>
 
-                    @if (footerTemplate || _footerTemplate) {
+                    @if (footerTemplate() || _footerTemplate) {
                         <div [pBind]="ptm('footer')" [ngClass]="cx('footer')" [attr.data-pc-section]="'footer'">
-                            <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+                            <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
                         </div>
                     }
                 }
@@ -269,9 +268,9 @@ export class Drawer extends BaseComponent<DrawerPassThrough> {
      */
     @Output() visibleChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-    @ViewChild('container') containerViewChild: ElementRef | undefined;
+    readonly containerViewChild = viewChild<ElementRef>('container');
 
-    @ViewChild('closeButton') closeButtonViewChild: ElementRef | undefined;
+    readonly closeButtonViewChild = viewChild<ElementRef>('closeButton');
 
     initialized: boolean | undefined;
 
@@ -302,27 +301,27 @@ export class Drawer extends BaseComponent<DrawerPassThrough> {
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: TemplateRef<void> | undefined;
+    readonly footerTemplate = contentChild<TemplateRef<void>>('footer', { descendants: false });
     /**
      * Custom content template.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<void> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<void>>('content', { descendants: false });
     /**
      * Custom close icon template.
      * @group Templates
      */
-    @ContentChild('closeicon', { descendants: false }) closeIconTemplate: TemplateRef<void> | undefined;
+    readonly closeIconTemplate = contentChild<TemplateRef<void>>('closeicon', { descendants: false });
     /**
      * Custom headless template to replace the entire drawer content.
      * @group Templates
      */
-    @ContentChild('headless', { descendants: false }) headlessTemplate: TemplateRef<void> | undefined;
+    readonly headlessTemplate = contentChild<TemplateRef<void>>('headless', { descendants: false });
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
 
@@ -336,10 +335,10 @@ export class Drawer extends BaseComponent<DrawerPassThrough> {
 
     _headlessTemplate: TemplateRef<void> | undefined;
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
@@ -789,9 +789,10 @@ describe('DynamicDialog', () => {
                 }))
             };
 
-            component.insertionPoint = {
-                viewContainerRef: mockViewContainer as any
-            } as any;
+            (component as any).insertionPoint = () =>
+                ({
+                    viewContainerRef: mockViewContainer as any
+                }) as any;
 
             component.loadChildComponent(TestDialogContentComponent);
 

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ComponentRef, inject, InjectionToken, NgModule, Type, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ComponentRef, inject, InjectionToken, NgModule, Type, ViewEncapsulation, viewChild } from '@angular/core';
 import { uuid } from '@openng/optimus-ui-utils';
 import { SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -127,9 +127,9 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
 
     id: string = uuid('pn_id_');
 
-    @ViewChild(DynamicDialogContent) insertionPoint: Nullable<DynamicDialogContent>;
+    readonly insertionPoint = viewChild(DynamicDialogContent);
 
-    @ViewChild(Dialog) dialog: Nullable<Dialog>;
+    readonly dialog = viewChild(Dialog);
 
     childComponentType: Nullable<Type<any>>;
 
@@ -285,7 +285,7 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
     }
 
     loadChildComponent(componentType: Type<any>) {
-        let viewContainerRef = this.insertionPoint?.viewContainerRef;
+        let viewContainerRef = this.insertionPoint()?.viewContainerRef;
         viewContainerRef?.clear();
 
         this.componentRef = viewContainerRef?.createComponent(componentType);

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
@@ -129,8 +129,6 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
 
     readonly insertionPoint = viewChild(DynamicDialogContent);
 
-    readonly dialog = viewChild(Dialog);
-
     childComponentType: Nullable<Type<any>>;
 
     inputValues: Record<string, any>;

--- a/packages/optimus-ui/src/editor/editor.test.ts
+++ b/packages/optimus-ui/src/editor/editor.test.ts
@@ -8,6 +8,7 @@ import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import type { EditorBlurEvent, EditorChangeEvent, EditorFocusEvent, EditorInitEvent, EditorSelectionChangeEvent, EditorTextChangeEvent } from '@openng/optimus-ui/types/editor';
 import { Editor } from './editor';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 // Test Components for different scenarios
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1319,5 +1320,38 @@ describe('Editor', () => {
                 expect(hookEvents.some((e) => e.hook === 'onAfterViewInit')).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Editor, SharedModule],
+    template: `
+        <p-editor>
+            <p-header>T</p-header>
+            <ng-template pTemplate="header">h</ng-template>
+        </p-editor>
+    `
+})
+class EditorQueryApiHostComponent {}
+
+describe('Editor Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [EditorQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(EditorQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Editor)).componentInstance;
+
+        expect(instance.toolbar()).toBeDefined();
+        expect(instance.templates().length).toBeGreaterThan(0);
     });
 });

--- a/packages/optimus-ui/src/editor/editor.ts
+++ b/packages/optimus-ui/src/editor/editor.ts
@@ -238,7 +238,7 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
         this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'header':
-                    this.headerTemplate = item.template;
+                    this._headerTemplate = item.template;
                     break;
             }
         });

--- a/packages/optimus-ui/src/editor/editor.ts
+++ b/packages/optimus-ui/src/editor/editor.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformServer } from '@angular/common';
-import { afterNextRender, ChangeDetectionStrategy, Component, ContentChild, ContentChildren, EventEmitter, forwardRef, inject, InjectionToken, Input, NgModule, Output, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, EventEmitter, forwardRef, inject, InjectionToken, Input, NgModule, Output, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { findSingle } from '@openng/optimus-ui-utils';
 import { Header, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
@@ -26,13 +26,13 @@ export const EDITOR_VALUE_ACCESSOR: any = {
     standalone: true,
     imports: [CommonModule, SharedModule, BindModule],
     template: `
-        @if (toolbar || headerTemplate || _headerTemplate) {
+        @if (toolbar() || headerTemplate() || _headerTemplate) {
             <div [class]="cx('toolbar')" [pBind]="ptm('toolbar')">
                 <ng-content select="p-header"></ng-content>
-                <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
             </div>
         }
-        @if (!toolbar && !headerTemplate && !_headerTemplate) {
+        @if (!toolbar() && !headerTemplate() && !_headerTemplate) {
             <div [class]="cx('toolbar')" [pBind]="ptm('toolbar')">
                 <span class="ql-formats" [pBind]="ptm('formats')">
                     <select class="ql-header" [pBind]="ptm('header')">
@@ -189,7 +189,7 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
      */
     @Output() onBlur: EventEmitter<EditorBlurEvent> = new EventEmitter<EditorBlurEvent>();
 
-    @ContentChild(Header) toolbar: any;
+    readonly toolbar = contentChild(Header);
 
     value: Nullable<string>;
 
@@ -205,9 +205,9 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
      * Custom item template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: Nullable<TemplateRef<any>>;
+    readonly headerTemplate = contentChild<Nullable<TemplateRef<any>>>('header', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _headerTemplate: TemplateRef<any> | undefined;
 
@@ -235,7 +235,7 @@ export class Editor extends BaseEditableHolder<EditorPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this.headerTemplate = item.template;

--- a/packages/optimus-ui/src/fieldset/fieldset.test.ts
+++ b/packages/optimus-ui/src/fieldset/fieldset.test.ts
@@ -6,6 +6,8 @@ import { provideOptimus } from '@openng/optimus-ui/config';
 import { FieldsetAfterToggleEvent, FieldsetBeforeToggleEvent } from '@openng/optimus-ui/types/fieldset';
 import { Fieldset } from './fieldset';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: true,
@@ -1251,5 +1253,37 @@ describe('Fieldset', () => {
                 expect(toggleButton.nativeElement.className).toContain('TOGGLE_BUTTON_CLASS');
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Fieldset, SharedModule],
+    template: `
+        <p-fieldset legend="L">
+            <ng-template pTemplate="header">h</ng-template>
+        </p-fieldset>
+    `
+})
+class FieldsetQueryApiHostComponent {}
+
+describe('Fieldset Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [FieldsetQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(FieldsetQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Fieldset)).componentInstance;
+
+        expect(instance.contentWrapperViewChild()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'header')).toBe(true);
     });
 });

--- a/packages/optimus-ui/src/fieldset/fieldset.ts
+++ b/packages/optimus-ui/src/fieldset/fieldset.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -14,10 +12,11 @@ import {
     Input,
     NgModule,
     Output,
-    QueryList,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { uuid } from '@openng/optimus-ui-utils';
@@ -56,22 +55,22 @@ const FIELDSET_INSTANCE = new InjectionToken<Fieldset>('FIELDSET_INSTANCE');
                         [pBind]="ptm('toggleButton')"
                     >
                         @if (collapsed) {
-                            @if (!expandIconTemplate && !_expandIconTemplate) {
+                            @if (!expandIconTemplate() && !_expandIconTemplate) {
                                 <svg data-p-icon="plus" [class]="cx('toggleIcon')" [pBind]="ptm('toggleIcon')" />
                             }
-                            @if (expandIconTemplate || _expandIconTemplate) {
+                            @if (expandIconTemplate() || _expandIconTemplate) {
                                 <span [class]="cx('toggleIcon')" [pBind]="ptm('toggleIcon')">
-                                    <ng-container *ngTemplateOutlet="expandIconTemplate || _expandIconTemplate"></ng-container>
+                                    <ng-container *ngTemplateOutlet="expandIconTemplate() || _expandIconTemplate"></ng-container>
                                 </span>
                             }
                         }
                         @if (!collapsed) {
-                            @if (!collapseIconTemplate && !_collapseIconTemplate) {
+                            @if (!collapseIconTemplate() && !_collapseIconTemplate) {
                                 <svg data-p-icon="minus" [class]="cx('toggleIcon')" [attr.aria-hidden]="true" [pBind]="ptm('toggleIcon')" />
                             }
-                            @if (collapseIconTemplate || _collapseIconTemplate) {
+                            @if (collapseIconTemplate() || _collapseIconTemplate) {
                                 <span [class]="cx('toggleIcon')" [pBind]="ptm('toggleIcon')">
-                                    <ng-container *ngTemplateOutlet="collapseIconTemplate || _collapseIconTemplate"></ng-container>
+                                    <ng-container *ngTemplateOutlet="collapseIconTemplate() || _collapseIconTemplate"></ng-container>
                                 </span>
                             }
                         }
@@ -80,12 +79,12 @@ const FIELDSET_INSTANCE = new InjectionToken<Fieldset>('FIELDSET_INSTANCE');
                 } @else {
                     <span [class]="cx('legendLabel')" [pBind]="ptm('legendLabel')">{{ legend }}</span>
                     <ng-content select="p-header"></ng-content>
-                    <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
                 }
                 <ng-template #legendContent>
                     <span [class]="cx('legendLabel')" [pBind]="ptm('legendLabel')">{{ legend }}</span>
                     <ng-content select="p-header"></ng-content>
-                    <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
                 </ng-template>
             </legend>
             <div
@@ -105,7 +104,7 @@ const FIELDSET_INSTANCE = new InjectionToken<Fieldset>('FIELDSET_INSTANCE');
                 <div [pBind]="ptm('contentWrapper')" [class]="cx('contentWrapper')">
                     <div [class]="cx('content')" [pBind]="ptm('content')" #contentWrapper>
                         <ng-content></ng-content>
-                        <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate"></ng-container>
                     </div>
                 </div>
             </div>
@@ -193,7 +192,7 @@ export class Fieldset extends BaseComponent<FieldsetPassThrough> implements Bloc
      */
     @Output() onAfterToggle: EventEmitter<FieldsetAfterToggleEvent> = new EventEmitter<FieldsetAfterToggleEvent>();
 
-    @ViewChild('contentWrapper') contentWrapperViewChild: ElementRef;
+    readonly contentWrapperViewChild = viewChild.required<ElementRef>('contentWrapper');
 
     private _id: string = uuid('pn_id_');
 
@@ -226,25 +225,25 @@ export class Fieldset extends BaseComponent<FieldsetPassThrough> implements Bloc
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
 
     /**
      * Custom expand icon template.
      * @group Templates
      */
-    @ContentChild('expandicon', { descendants: false }) expandIconTemplate: TemplateRef<void> | undefined;
+    readonly expandIconTemplate = contentChild<TemplateRef<void>>('expandicon', { descendants: false });
 
     /**
      * Custom collapse icon template.
      * @group Templates
      */
-    @ContentChild('collapseicon', { descendants: false }) collapseIconTemplate: TemplateRef<void> | undefined;
+    readonly collapseIconTemplate = contentChild<TemplateRef<void>>('collapseicon', { descendants: false });
 
     /**
      * Custom content template.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<void> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<void>>('content', { descendants: false });
 
     toggle(event: MouseEvent) {
         this.onBeforeToggle.emit({ originalEvent: event, collapsed: this.collapsed });
@@ -279,8 +278,9 @@ export class Fieldset extends BaseComponent<FieldsetPassThrough> implements Bloc
     }
 
     updateTabIndex() {
-        if (this.contentWrapperViewChild) {
-            const focusableElements = this.contentWrapperViewChild.nativeElement.querySelectorAll('input, button, select, a, textarea, [tabindex]');
+        const contentWrapperViewChild = this.contentWrapperViewChild();
+        if (contentWrapperViewChild) {
+            const focusableElements = contentWrapperViewChild.nativeElement.querySelectorAll('input, button, select, a, textarea, [tabindex]');
             focusableElements.forEach((element: HTMLElement) => {
                 if (this.collapsed) {
                     element.setAttribute('tabindex', '-1');
@@ -303,10 +303,10 @@ export class Fieldset extends BaseComponent<FieldsetPassThrough> implements Bloc
 
     _contentTemplate: TemplateRef<void> | undefined;
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;

--- a/packages/optimus-ui/src/fieldset/fieldset.ts
+++ b/packages/optimus-ui/src/fieldset/fieldset.ts
@@ -278,17 +278,14 @@ export class Fieldset extends BaseComponent<FieldsetPassThrough> implements Bloc
     }
 
     updateTabIndex() {
-        const contentWrapperViewChild = this.contentWrapperViewChild();
-        if (contentWrapperViewChild) {
-            const focusableElements = contentWrapperViewChild.nativeElement.querySelectorAll('input, button, select, a, textarea, [tabindex]');
-            focusableElements.forEach((element: HTMLElement) => {
-                if (this.collapsed) {
-                    element.setAttribute('tabindex', '-1');
-                } else {
-                    element.removeAttribute('tabindex');
-                }
-            });
-        }
+        const focusableElements = this.contentWrapperViewChild().nativeElement.querySelectorAll('input, button, select, a, textarea, [tabindex]');
+        focusableElements.forEach((element: HTMLElement) => {
+            if (this.collapsed) {
+                element.setAttribute('tabindex', '-1');
+            } else {
+                element.removeAttribute('tabindex');
+            }
+        });
     }
 
     onToggleDone(event: MotionEvent) {

--- a/packages/optimus-ui/src/fileupload/fileupload.test.ts
+++ b/packages/optimus-ui/src/fileupload/fileupload.test.ts
@@ -77,10 +77,11 @@ describe('FileUpload', () => {
             component.mode = 'advanced';
             fixture.detectChanges();
 
-            if (component.advancedFileInput?.nativeElement) {
-                vi.spyOn(component.advancedFileInput.nativeElement, 'click').mockImplementation(() => {});
+            const advancedFileInput = component.advancedFileInput();
+            if (advancedFileInput?.nativeElement) {
+                vi.spyOn(advancedFileInput.nativeElement, 'click').mockImplementation(() => {});
                 component.choose();
-                expect(component.advancedFileInput.nativeElement.click).toHaveBeenCalled();
+                expect(advancedFileInput.nativeElement.click).toHaveBeenCalled();
             } else {
                 // If element doesn't exist, just verify the method doesn't throw
                 expect(() => component.choose()).not.toThrow();
@@ -127,10 +128,11 @@ describe('FileUpload', () => {
             component.mode = 'basic';
             fixture.detectChanges();
 
-            if (component.basicFileInput?.nativeElement) {
-                vi.spyOn(component.basicFileInput.nativeElement, 'click').mockImplementation(() => {});
+            const basicFileInput = component.basicFileInput();
+            if (basicFileInput?.nativeElement) {
+                vi.spyOn(basicFileInput.nativeElement, 'click').mockImplementation(() => {});
                 component.onBasicUploaderClick();
-                expect(component.basicFileInput.nativeElement.click).toHaveBeenCalled();
+                expect(basicFileInput.nativeElement.click).toHaveBeenCalled();
             } else {
                 // If element doesn't exist, just verify the method doesn't throw
                 expect(() => component.onBasicUploaderClick()).not.toThrow();

--- a/packages/optimus-ui/src/fileupload/fileupload.test.ts
+++ b/packages/optimus-ui/src/fileupload/fileupload.test.ts
@@ -8,6 +8,8 @@ import { MessageService } from '@openng/optimus-ui/api';
 import { BehaviorSubject, delay, of, Subscription, timer } from 'rxjs';
 import { FileUpload } from './fileupload';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 describe('FileUpload', () => {
     let component: FileUpload;
     let fixture: ComponentFixture<FileUpload>;
@@ -3131,5 +3133,41 @@ describe('FileUpload Input Properties - Observable/Async Values', () => {
                 expect(component.onDestroyCalled).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [FileUpload, PrimeTemplate],
+    template: `
+        <p-fileupload name="demo" url="/upload">
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-fileupload>
+    `
+})
+class FileUploadQueryApiHostComponent {}
+
+describe('FileUpload Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [FileUploadQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(FileUploadQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(FileUpload)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/fileupload/fileupload.ts
+++ b/packages/optimus-ui/src/fileupload/fileupload.ts
@@ -4,8 +4,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -17,10 +15,11 @@ import {
     numberAttribute,
     output,
     Output,
-    QueryList,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    viewChild,
+    contentChildren
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { addClass, removeClass } from '@openng/optimus-ui-utils';
@@ -130,7 +129,7 @@ export class FileContent extends BaseComponent {
         <div [class]="cn(cx('root'), styleClass)" [ngStyle]="style" *ngIf="mode === 'advanced'" [pBind]="ptm('root')">
             <input [attr.aria-label]="browseFilesLabel" #advancedfileinput type="file" (change)="onFileSelect($event)" [multiple]="multiple" [accept]="accept" [disabled]="disabled || isChooseDisabled()" [attr.title]="''" [pBind]="ptm('input')" />
             <div [class]="cx('header')" [pBind]="ptm('header')">
-                <ng-container *ngIf="!headerTemplate && !_headerTemplate">
+                <ng-container *ngIf="!headerTemplate() && !_headerTemplate">
                     <p-button
                         [styleClass]="cn(cx('pcChooseButton'), chooseStyleClass)"
                         [disabled]="disabled || isChooseDisabled()"
@@ -157,9 +156,9 @@ export class FileContent extends BaseComponent {
                         <ng-template #icon>
                             <span *ngIf="chooseIcon" [class]="chooseIcon" [attr.aria-label]="true" [pBind]="ptm('pcChooseButton')?.icon"></span>
                             <ng-container *ngIf="!chooseIcon">
-                                <svg data-p-icon="plus" *ngIf="!chooseIconTemplate && !_chooseIconTemplate" [attr.aria-label]="true" [pBind]="ptm('pcChooseButton')?.icon" />
-                                <span *ngIf="chooseIconTemplate || _chooseIconTemplate" [attr.aria-label]="true" [pBind]="ptm('pcChooseButton')?.icon">
-                                    <ng-template *ngTemplateOutlet="chooseIconTemplate || _chooseIconTemplate"></ng-template>
+                                <svg data-p-icon="plus" *ngIf="!chooseIconTemplate() && !_chooseIconTemplate" [attr.aria-label]="true" [pBind]="ptm('pcChooseButton')?.icon" />
+                                <span *ngIf="chooseIconTemplate() || _chooseIconTemplate" [attr.aria-label]="true" [pBind]="ptm('pcChooseButton')?.icon">
+                                    <ng-template *ngTemplateOutlet="chooseIconTemplate() || _chooseIconTemplate"></ng-template>
                                 </span>
                             </ng-container>
                         </ng-template>
@@ -178,9 +177,9 @@ export class FileContent extends BaseComponent {
                         <ng-template #icon>
                             <span *ngIf="uploadIcon" [ngClass]="uploadIcon" [attr.aria-hidden]="true" [pBind]="ptm('pcUploadButton')?.icon"></span>
                             <ng-container *ngIf="!uploadIcon">
-                                <svg data-p-icon="upload" *ngIf="!uploadIconTemplate && !_uploadIconTemplate" [pBind]="ptm('pcUploadButton')?.icon" />
-                                <span *ngIf="uploadIconTemplate || _uploadIconTemplate" [attr.aria-hidden]="true" [pBind]="ptm('pcUploadButton')?.icon">
-                                    <ng-template *ngTemplateOutlet="uploadIconTemplate || _uploadIconTemplate"></ng-template>
+                                <svg data-p-icon="upload" *ngIf="!uploadIconTemplate() && !_uploadIconTemplate" [pBind]="ptm('pcUploadButton')?.icon" />
+                                <span *ngIf="uploadIconTemplate() || _uploadIconTemplate" [attr.aria-hidden]="true" [pBind]="ptm('pcUploadButton')?.icon">
+                                    <ng-template *ngTemplateOutlet="uploadIconTemplate() || _uploadIconTemplate"></ng-template>
                                 </span>
                             </ng-container>
                         </ng-template>
@@ -198,9 +197,9 @@ export class FileContent extends BaseComponent {
                         <ng-template #icon>
                             <span *ngIf="cancelIcon" [ngClass]="cancelIcon"></span>
                             <ng-container *ngIf="!cancelIcon">
-                                <svg data-p-icon="times" *ngIf="!cancelIconTemplate && !_cancelIconTemplate" [attr.aria-hidden]="true" />
-                                <span *ngIf="cancelIconTemplate || _cancelIconTemplate" [attr.aria-hidden]="true">
-                                    <ng-template *ngTemplateOutlet="cancelIconTemplate || _cancelIconTemplate"></ng-template>
+                                <svg data-p-icon="times" *ngIf="!cancelIconTemplate() && !_cancelIconTemplate" [attr.aria-hidden]="true" />
+                                <span *ngIf="cancelIconTemplate() || _cancelIconTemplate" [attr.aria-hidden]="true">
+                                    <ng-template *ngTemplateOutlet="cancelIconTemplate() || _cancelIconTemplate"></ng-template>
                                 </span>
                             </ng-container>
                         </ng-template>
@@ -208,7 +207,7 @@ export class FileContent extends BaseComponent {
                 </ng-container>
                 <ng-container
                     *ngTemplateOutlet="
-                        headerTemplate || _headerTemplate;
+                        headerTemplate() || _headerTemplate;
                         context: {
                             $implicit: files,
                             uploadedFiles: uploadedFiles,
@@ -218,13 +217,13 @@ export class FileContent extends BaseComponent {
                         }
                     "
                 ></ng-container>
-                <ng-container *ngTemplateOutlet="toolbarTemplate || _toolbarTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="toolbarTemplate() || _toolbarTemplate"></ng-container>
             </div>
             <div #content [class]="cx('content')" (dragenter)="onDragEnter($event)" (dragleave)="onDragLeave($event)" (drop)="onDrop($event)" [pBind]="ptm('content')">
-                @if (contentTemplate || _contentTemplate) {
+                @if (contentTemplate() || _contentTemplate) {
                     <ng-container
                         *ngTemplateOutlet="
-                            contentTemplate || _contentTemplate;
+                            contentTemplate() || _contentTemplate;
                             context: {
                                 $implicit: files,
                                 uploadedFiles: uploadedFiles,
@@ -245,8 +244,8 @@ export class FileContent extends BaseComponent {
 
                     @if (hasFiles()) {
                         <div [class]="cx('fileList')" [pBind]="ptm('fileList')">
-                            <ng-template ngFor [ngForOf]="files" [ngForTemplate]="fileTemplate || _fileTemplate"></ng-template>
-                            @if (!fileTemplate && !_fileTemplate) {
+                            <ng-template ngFor [ngForOf]="files" [ngForTemplate]="fileTemplate() || _fileTemplate"></ng-template>
+                            @if (!fileTemplate() && !_fileTemplate) {
                                 <div
                                     pFileContent
                                     [unstyled]="unstyled()"
@@ -254,15 +253,15 @@ export class FileContent extends BaseComponent {
                                     (onRemove)="onRemoveClick($event)"
                                     [badgeValue]="pendingLabel"
                                     [previewWidth]="previewWidth"
-                                    [fileRemoveIconTemplate]="cancelIconTemplate || _cancelIconTemplate"
+                                    [fileRemoveIconTemplate]="cancelIconTemplate() || _cancelIconTemplate"
                                 ></div>
                             }
                         </div>
                     }
                     @if (hasUploadedFiles()) {
                         <div [class]="cx('fileList')" [pBind]="ptm('fileList')">
-                            <ng-template ngFor [ngForOf]="uploadedFiles" [ngForTemplate]="fileTemplate || _fileTemplate"></ng-template>
-                            @if (!fileTemplate && !_fileTemplate) {
+                            <ng-template ngFor [ngForOf]="uploadedFiles" [ngForTemplate]="fileTemplate() || _fileTemplate"></ng-template>
+                            @if (!fileTemplate() && !_fileTemplate) {
                                 <div
                                     pFileContent
                                     [unstyled]="unstyled()"
@@ -271,14 +270,14 @@ export class FileContent extends BaseComponent {
                                     [badgeValue]="completedLabel()"
                                     badgeSeverity="success"
                                     [previewWidth]="previewWidth"
-                                    [fileRemoveIconTemplate]="cancelIconTemplate || _cancelIconTemplate"
+                                    [fileRemoveIconTemplate]="cancelIconTemplate() || _cancelIconTemplate"
                                 ></div>
                             }
                         </div>
                     }
                 }
-                @if ((emptyTemplate || _emptyTemplate) && !hasFiles() && !hasUploadedFiles()) {
-                    <ng-container *ngTemplateOutlet="emptyTemplate || _emptyTemplate" [pBind]="ptm('empty')"></ng-container>
+                @if ((emptyTemplate() || _emptyTemplate) && !hasFiles() && !hasUploadedFiles()) {
+                    <ng-container *ngTemplateOutlet="emptyTemplate() || _emptyTemplate" [pBind]="ptm('empty')"></ng-container>
                 }
             </div>
         </div>
@@ -303,28 +302,28 @@ export class FileContent extends BaseComponent {
                         @if (hasFiles() && !auto) {
                             <span *ngIf="uploadIcon" class="p-button-icon p-button-icon-left" [ngClass]="uploadIcon" [pBind]="ptm('pcChooseButton')?.icon"></span>
                             <ng-container *ngIf="!uploadIcon">
-                                <svg data-p-icon="upload" *ngIf="!uploadIconTemplate && !_uploadIconTemplate" [class]="'p-button-icon p-button-icon-left'" [pBind]="ptm('pcChooseButton')?.icon" />
-                                <span *ngIf="_uploadIconTemplate || uploadIconTemplate" class="p-button-icon p-button-icon-left" [pBind]="ptm('pcChooseButton')?.icon">
-                                    <ng-template *ngTemplateOutlet="_uploadIconTemplate || uploadIconTemplate"></ng-template>
+                                <svg data-p-icon="upload" *ngIf="!uploadIconTemplate() && !_uploadIconTemplate" [class]="'p-button-icon p-button-icon-left'" [pBind]="ptm('pcChooseButton')?.icon" />
+                                <span *ngIf="_uploadIconTemplate || uploadIconTemplate()" class="p-button-icon p-button-icon-left" [pBind]="ptm('pcChooseButton')?.icon">
+                                    <ng-template *ngTemplateOutlet="_uploadIconTemplate || uploadIconTemplate()"></ng-template>
                                 </span>
                             </ng-container>
                         } @else {
                             <span *ngIf="chooseIcon" class="p-button-icon p-button-icon-left pi" [ngClass]="chooseIcon" [pBind]="ptm('pcChooseButton')?.icon"></span>
                             <ng-container *ngIf="!chooseIcon">
-                                <svg data-p-icon="plus" *ngIf="!chooseIconTemplate && !_chooseIconTemplate" [pBind]="ptm('pcChooseButton')?.icon" />
-                                <ng-template *ngTemplateOutlet="chooseIconTemplate || _chooseIconTemplate"></ng-template>
+                                <svg data-p-icon="plus" *ngIf="!chooseIconTemplate() && !_chooseIconTemplate" [pBind]="ptm('pcChooseButton')?.icon" />
+                                <ng-template *ngTemplateOutlet="chooseIconTemplate() || _chooseIconTemplate"></ng-template>
                             </ng-container>
                         }
                     </ng-template>
                     <input [attr.aria-label]="browseFilesLabel" #basicfileinput type="file" [accept]="accept" [multiple]="multiple" [disabled]="disabled" (change)="onFileSelect($event)" (focus)="onFocus()" (blur)="onBlur()" [pBind]="ptm('input')" />
                 </p-button>
                 @if (!auto) {
-                    @if (!fileLabelTemplate && !_fileLabelTemplate) {
+                    @if (!fileLabelTemplate() && !_fileLabelTemplate) {
                         <span>
                             {{ basicFileChosenLabel() }}
                         </span>
                     } @else {
-                        <ng-container *ngTemplateOutlet="fileLabelTemplate || _fileLabelTemplate; context: { $implicit: files }"></ng-container>
+                        <ng-container *ngTemplateOutlet="fileLabelTemplate() || _fileLabelTemplate; context: { $implicit: files }"></ng-container>
                     }
                 }
             </div>
@@ -600,64 +599,64 @@ export class FileUpload extends BaseComponent<FileUploadPassThrough> implements 
      * Custom file template.
      * @group Templates
      */
-    @ContentChild('file', { descendants: false }) fileTemplate: TemplateRef<void> | undefined;
+    readonly fileTemplate = contentChild<TemplateRef<void>>('file', { descendants: false });
 
     /**
      * Custom header template.
      * @param {FileUploadHeaderTemplateContext} context - header template context.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<FileUploadHeaderTemplateContext> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<FileUploadHeaderTemplateContext>>('header', { descendants: false });
 
     /**
      * Custom content template.
      * @param {FileUploadContentTemplateContext} context - content template context.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<FileUploadContentTemplateContext> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<FileUploadContentTemplateContext>>('content', { descendants: false });
 
     /**
      * Custom toolbar template.
      * @group Templates
      */
-    @ContentChild('toolbar', { descendants: false }) toolbarTemplate: TemplateRef<void> | undefined;
+    readonly toolbarTemplate = contentChild<TemplateRef<void>>('toolbar', { descendants: false });
 
     /**
      * Custom choose icon template.
      * @group Templates
      */
-    @ContentChild('chooseicon', { descendants: false }) chooseIconTemplate: TemplateRef<void> | undefined;
+    readonly chooseIconTemplate = contentChild<TemplateRef<void>>('chooseicon', { descendants: false });
 
     /**
      * Custom file label template.
      * @param {FileUploadFileLabelTemplateContext} context - file label template context.
      * @group Templates
      */
-    @ContentChild('filelabel', { descendants: false }) fileLabelTemplate: TemplateRef<FileUploadFileLabelTemplateContext> | undefined;
+    readonly fileLabelTemplate = contentChild<TemplateRef<FileUploadFileLabelTemplateContext>>('filelabel', { descendants: false });
 
     /**
      * Custom upload icon template.
      * @group Templates
      */
-    @ContentChild('uploadicon', { descendants: false }) uploadIconTemplate: TemplateRef<void> | undefined;
+    readonly uploadIconTemplate = contentChild<TemplateRef<void>>('uploadicon', { descendants: false });
 
     /**
      * Custom cancel icon template.
      * @group Templates
      */
-    @ContentChild('cancelicon', { descendants: false }) cancelIconTemplate: TemplateRef<void> | undefined;
+    readonly cancelIconTemplate = contentChild<TemplateRef<void>>('cancelicon', { descendants: false });
 
     /**
      * Custom empty state template.
      * @group Templates
      */
-    @ContentChild('empty', { descendants: false }) emptyTemplate: TemplateRef<void> | undefined;
+    readonly emptyTemplate = contentChild<TemplateRef<void>>('empty', { descendants: false });
 
-    @ViewChild('advancedfileinput') advancedFileInput: ElementRef | undefined | any;
+    readonly advancedFileInput = viewChild<ElementRef | any>('advancedfileinput');
 
-    @ViewChild('basicfileinput') basicFileInput: ElementRef | undefined;
+    readonly basicFileInput = viewChild<ElementRef>('basicfileinput');
 
-    @ViewChild('content') content: ElementRef | undefined;
+    readonly content = viewChild<ElementRef>('content');
 
     @Input() set files(files) {
         this._files = [];
@@ -727,8 +726,9 @@ export class FileUpload extends BaseComponent<FileUploadPassThrough> implements 
         if (isPlatformBrowser(this.platformId)) {
             if (this.mode === 'advanced') {
                 this.zone.runOutsideAngular(() => {
-                    if (this.content) {
-                        this.dragOverListener = this.renderer.listen(this.content.nativeElement, 'dragover', this.onDragOver.bind(this));
+                    const content = this.content();
+                    if (content) {
+                        this.dragOverListener = this.renderer.listen(content.nativeElement, 'dragover', this.onDragOver.bind(this));
                     }
                 });
             }
@@ -753,10 +753,10 @@ export class FileUpload extends BaseComponent<FileUploadPassThrough> implements 
 
     _fileLabelTemplate: TemplateRef<FileUploadFileLabelTemplateContext> | undefined;
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;
@@ -821,7 +821,7 @@ export class FileUpload extends BaseComponent<FileUploadPassThrough> implements 
     }
 
     choose() {
-        this.advancedFileInput?.nativeElement.click();
+        this.advancedFileInput()?.nativeElement.click();
     }
 
     onFileSelect(event: any) {
@@ -1100,19 +1100,22 @@ export class FileUpload extends BaseComponent<FileUploadPassThrough> implements 
     }
 
     clearInputElement() {
-        if (this.advancedFileInput && this.advancedFileInput.nativeElement) {
-            this.advancedFileInput.nativeElement.value = '';
+        const advancedFileInput = this.advancedFileInput();
+        if (advancedFileInput && advancedFileInput.nativeElement) {
+            advancedFileInput.nativeElement.value = '';
         }
 
-        if (this.basicFileInput && this.basicFileInput.nativeElement) {
-            this.basicFileInput.nativeElement.value = '';
+        const basicFileInput = this.basicFileInput();
+        if (basicFileInput && basicFileInput.nativeElement) {
+            basicFileInput.nativeElement.value = '';
         }
     }
 
     clearIEInput() {
-        if (this.advancedFileInput && this.advancedFileInput.nativeElement) {
+        const advancedFileInput = this.advancedFileInput();
+        if (advancedFileInput && advancedFileInput.nativeElement) {
             this.duplicateIEEvent = true; //IE11 fix to prevent onFileChange trigger again
-            this.advancedFileInput.nativeElement.value = '';
+            advancedFileInput.nativeElement.value = '';
         }
     }
 
@@ -1133,8 +1136,8 @@ export class FileUpload extends BaseComponent<FileUploadPassThrough> implements 
 
     onDragOver(e: DragEvent) {
         if (!this.disabled) {
-            !this.$unstyled() && addClass(this.content?.nativeElement, 'p-fileupload-highlight');
-            this.content?.nativeElement.setAttribute('data-p-highlight', true);
+            !this.$unstyled() && addClass(this.content()?.nativeElement, 'p-fileupload-highlight');
+            this.content()?.nativeElement.setAttribute('data-p-highlight', true);
             this.dragHighlight = true;
             e.stopPropagation();
             e.preventDefault();
@@ -1143,15 +1146,15 @@ export class FileUpload extends BaseComponent<FileUploadPassThrough> implements 
 
     onDragLeave(event: DragEvent) {
         if (!this.disabled) {
-            !this.$unstyled() && removeClass(this.content?.nativeElement, 'p-fileupload-highlight');
-            this.content?.nativeElement.setAttribute('data-p-highlight', false);
+            !this.$unstyled() && removeClass(this.content()?.nativeElement, 'p-fileupload-highlight');
+            this.content()?.nativeElement.setAttribute('data-p-highlight', false);
         }
     }
 
     onDrop(event: any) {
         if (!this.disabled) {
-            !this.$unstyled() && removeClass(this.content?.nativeElement, 'p-fileupload-highlight');
-            this.content?.nativeElement.setAttribute('data-p-highlight', false);
+            !this.$unstyled() && removeClass(this.content()?.nativeElement, 'p-fileupload-highlight');
+            this.content()?.nativeElement.setAttribute('data-p-highlight', false);
             event.stopPropagation();
             event.preventDefault();
 
@@ -1192,7 +1195,7 @@ export class FileUpload extends BaseComponent<FileUploadPassThrough> implements 
     }
 
     onBasicUploaderClick() {
-        this.basicFileInput?.nativeElement.click();
+        this.basicFileInput()?.nativeElement.click();
     }
 
     onBasicKeydown(event: KeyboardEvent) {
@@ -1235,7 +1238,8 @@ export class FileUpload extends BaseComponent<FileUploadPassThrough> implements 
     }
 
     onDestroy() {
-        if (this.content && this.content.nativeElement) {
+        const content = this.content();
+        if (content && content.nativeElement) {
             if (this.dragOverListener) {
                 this.dragOverListener();
                 this.dragOverListener = null;

--- a/packages/optimus-ui/src/galleria/galleria.test.ts
+++ b/packages/optimus-ui/src/galleria/galleria.test.ts
@@ -5,8 +5,9 @@ import { By } from '@angular/platform-browser';
 
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { GalleriaResponsiveOptions } from '@openng/optimus-ui/types/galleria';
-import { Galleria, GalleriaModule } from './galleria';
+import { Galleria, GalleriaModule, GalleriaThumbnails } from './galleria';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 // Mock data for testing
 const mockImages = [
     { itemImageSrc: 'https://primefaces.org/cdn/primeng/images/galleria/galleria1.jpg', thumbnailImageSrc: 'https://primefaces.org/cdn/primeng/images/galleria/galleria1s.jpg', alt: 'Image 1', title: 'Title 1' },
@@ -1290,5 +1291,53 @@ describe('Galleria', () => {
                 expect(footer.classList.contains('custom-footer')).toBe(true);
             }
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [GalleriaModule, SharedModule],
+    template: `
+        <p-galleria [value]="items">
+            <ng-template #indicator>ind</ng-template>
+            <ng-template #closeicon>cl</ng-template>
+            <ng-template #previousthumbnailicon>pt</ng-template>
+            <ng-template #nextthumbnailicon>nt</ng-template>
+            <ng-template #itempreviousicon>ip</ng-template>
+            <ng-template #itemnexticon>in</ng-template>
+            <ng-template pTemplate="item">i</ng-template>
+        </p-galleria>
+    `
+})
+class GalleriaQueryApiHostComponent {
+    items = [{ itemImageSrc: 'a.png' }];
+}
+
+describe('Galleria Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [GalleriaQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(GalleriaQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Galleria)).componentInstance;
+
+        expect(instance.indicatorTemplate()).toBeDefined();
+        expect(instance._closeIconTemplate()).toBeDefined();
+        expect(instance._previousThumbnailIconTemplate()).toBeDefined();
+        expect(instance._nextThumbnailIconTemplate()).toBeDefined();
+        expect(instance._itemPreviousIconTemplate()).toBeDefined();
+        expect(instance._itemNextIconTemplate()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'item')).toBe(true);
+
+        const thumbnails = fixture.debugElement.query(By.directive(GalleriaThumbnails)).componentInstance;
+        expect(thumbnails.itemsContainer()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/galleria/galleria.test.ts
+++ b/packages/optimus-ui/src/galleria/galleria.test.ts
@@ -747,9 +747,10 @@ describe('Galleria', () => {
             const galleriaInstance = galleriaEl.componentInstance as Galleria;
 
             // Mock container element
-            galleriaInstance.container = {
-                nativeElement: document.createElement('div')
-            } as any;
+            (galleriaInstance as any).container = () =>
+                ({
+                    nativeElement: document.createElement('div')
+                }) as any;
 
             // Add a mock close button element
             const closeButton = document.createElement('button');

--- a/packages/optimus-ui/src/galleria/galleria.test.ts
+++ b/packages/optimus-ui/src/galleria/galleria.test.ts
@@ -754,7 +754,7 @@ describe('Galleria', () => {
             // Add a mock close button element
             const closeButton = document.createElement('button');
             closeButton.setAttribute('data-pc-section', 'closebutton');
-            galleriaInstance.container!.nativeElement.appendChild(closeButton);
+            galleriaInstance.container()!.nativeElement.appendChild(closeButton);
 
             // const mockAnimationEvent = {
             //     toState: 'visible'

--- a/packages/optimus-ui/src/galleria/galleria.ts
+++ b/packages/optimus-ui/src/galleria/galleria.ts
@@ -753,7 +753,7 @@ export class GalleriaContent extends BaseComponent<GalleriaPassThrough> {
 export class GalleriaItemSlot extends BaseComponent<GalleriaPassThrough> {
     hostName: string = 'Galleria';
 
-    @Input() templates: QueryList<PrimeTemplate> | undefined;
+    @Input() templates: readonly PrimeTemplate[] | undefined;
 
     @Input({ transform: numberAttribute }) index: number | undefined;
 
@@ -782,7 +782,7 @@ export class GalleriaItemSlot extends BaseComponent<GalleriaPassThrough> {
 
     set item(item: any) {
         this._item = item;
-        if (this.templates && this.templates?.toArray().length > 0) {
+        if (this.templates && this.templates.length > 0) {
             this.templates.forEach((item) => {
                 if (item.getType() === this.type) {
                     switch (this.type) {
@@ -845,7 +845,7 @@ export class GalleriaItemSlot extends BaseComponent<GalleriaPassThrough> {
     _item: any;
 
     onAfterContentInit() {
-        if (this.templates && this.templates.toArray().length > 0) {
+        if (this.templates && this.templates.length > 0) {
             this.templates?.forEach((item) => {
                 if (item.getType() === this.type) {
                     switch (this.type) {
@@ -975,7 +975,7 @@ export class GalleriaItem extends BaseComponent<GalleriaPassThrough> {
 
     @Input({ transform: booleanAttribute }) autoPlay: boolean = false;
 
-    @Input() templates: QueryList<PrimeTemplate> | undefined;
+    @Input() templates: readonly PrimeTemplate[] | undefined;
 
     @Input() indicatorFacet: any;
 

--- a/packages/optimus-ui/src/galleria/galleria.ts
+++ b/packages/optimus-ui/src/galleria/galleria.ts
@@ -632,8 +632,6 @@ export class GalleriaContent extends BaseComponent<GalleriaPassThrough> {
 
     @Output() activeItemChange: EventEmitter<number> = new EventEmitter();
 
-    readonly closeButton = viewChild<ElementRef>('closeButton');
-
     _componentStyle = inject(GalleriaStyle);
 
     $pcGalleria: Galleria | undefined = inject(GALLERIA_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;

--- a/packages/optimus-ui/src/galleria/galleria.ts
+++ b/packages/optimus-ui/src/galleria/galleria.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     HostListener,
@@ -21,8 +19,10 @@ import {
     signal,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { addClass, find, findSingle, focus, getAttribute, removeClass, setAttribute, uuid } from '@openng/optimus-ui-utils';
@@ -309,7 +309,7 @@ export class Galleria extends BaseComponent<GalleriaPassThrough> {
      */
     @Output() visibleChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-    @ViewChild('container') container: ElementRef | undefined;
+    readonly container = viewChild<ElementRef>('container');
 
     _visible: boolean = false;
 
@@ -319,77 +319,77 @@ export class Galleria extends BaseComponent<GalleriaPassThrough> {
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
     headerFacet: TemplateRef<void> | undefined;
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false, static: false }) footerTemplate: TemplateRef<void> | undefined;
+    readonly footerTemplate = contentChild<TemplateRef<void>>('footer', { descendants: false });
     footerFacet: TemplateRef<void> | undefined;
 
     /**
      * Custom indicator template.
      * @group Templates
      */
-    @ContentChild('indicator', { descendants: false }) indicatorTemplate: TemplateRef<GalleriaIndicatorTemplateContext> | undefined;
+    readonly indicatorTemplate = contentChild<TemplateRef<GalleriaIndicatorTemplateContext>>('indicator', { descendants: false });
     indicatorFacet: TemplateRef<GalleriaIndicatorTemplateContext> | undefined;
 
     /**
      * Custom caption template.
      * @group Templates
      */
-    @ContentChild('caption', { descendants: false }) captionTemplate: TemplateRef<GalleriaCaptionTemplateContext> | undefined;
+    readonly captionTemplate = contentChild<TemplateRef<GalleriaCaptionTemplateContext>>('caption', { descendants: false });
     captionFacet: TemplateRef<GalleriaCaptionTemplateContext> | undefined;
 
     /**
      * Custom close icon template.
      * @group Templates
      */
-    @ContentChild('closeicon', { descendants: false }) _closeIconTemplate: TemplateRef<void> | undefined;
+    readonly _closeIconTemplate = contentChild<TemplateRef<void>>('closeicon', { descendants: false });
     closeIconTemplate: TemplateRef<void> | undefined;
 
     /**
      * Custom previous thumbnail icon template.
      * @group Templates
      */
-    @ContentChild('previousthumbnailicon', { descendants: false }) _previousThumbnailIconTemplate: TemplateRef<void> | undefined;
+    readonly _previousThumbnailIconTemplate = contentChild<TemplateRef<void>>('previousthumbnailicon', { descendants: false });
     previousThumbnailIconTemplate: TemplateRef<void> | undefined;
 
     /**
      * Custom next thumbnail icon template.
      * @group Templates
      */
-    @ContentChild('nextthumbnailicon', { descendants: false }) _nextThumbnailIconTemplate: TemplateRef<void> | undefined;
+    readonly _nextThumbnailIconTemplate = contentChild<TemplateRef<void>>('nextthumbnailicon', { descendants: false });
     nextThumbnailIconTemplate: TemplateRef<void> | undefined;
 
     /**
      * Custom item previous icon template.
      * @group Templates
      */
-    @ContentChild('itempreviousicon', { descendants: false }) _itemPreviousIconTemplate: TemplateRef<void> | undefined;
+    readonly _itemPreviousIconTemplate = contentChild<TemplateRef<void>>('itempreviousicon', { descendants: false });
     itemPreviousIconTemplate: TemplateRef<void> | undefined;
 
     /**
      * Custom item next icon template.
      * @group Templates
      */
-    @ContentChild('itemnexticon', { descendants: false }) _itemNextIconTemplate: TemplateRef<void> | undefined;
+    readonly _itemNextIconTemplate = contentChild<TemplateRef<void>>('itemnexticon', { descendants: false });
     itemNextIconTemplate: TemplateRef<void> | undefined;
 
     /**
      * Custom item template.
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) _itemTemplate: TemplateRef<GalleriaItemTemplateContext> | undefined;
+    readonly _itemTemplate = contentChild<TemplateRef<GalleriaItemTemplateContext>>('item', { descendants: false });
     itemTemplate: TemplateRef<GalleriaItemTemplateContext> | undefined;
 
     /**
      * Custom thumbnail template.
      * @group Templates
      */
-    @ContentChild('thumbnail', { descendants: false, static: false }) _thumbnailTemplate: TemplateRef<GalleriaThumbnailTemplateContext> | undefined;
+    readonly _thumbnailTemplate = contentChild<TemplateRef<GalleriaThumbnailTemplateContext>>('thumbnail', { descendants: false });
     thumbnailTemplate: TemplateRef<GalleriaThumbnailTemplateContext> | undefined;
 
     maskVisible: boolean = false;
@@ -400,10 +400,10 @@ export class Galleria extends BaseComponent<GalleriaPassThrough> {
 
     mask: HTMLElement;
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this.headerFacet = item.template;
@@ -478,7 +478,7 @@ export class Galleria extends BaseComponent<GalleriaPassThrough> {
         this.mask = <HTMLElement>event.element?.parentElement;
         this.enableModality();
         setTimeout(() => {
-            const focusTarget = findSingle(this.container?.nativeElement, '[data-pc-section="closebutton"]');
+            const focusTarget = findSingle(this.container()?.nativeElement, '[data-pc-section="closebutton"]');
             if (focusTarget) focus(focusTarget as HTMLElement);
         }, 25);
     }
@@ -536,14 +536,14 @@ export class Galleria extends BaseComponent<GalleriaPassThrough> {
         @if (value && value.length > 0) {
             @if (galleria.fullScreen) {
                 <button type="button" [pBind]="getPTOptions('closeButton')" [class]="cx('closeButton')" (click)="maskHide.emit()" [attr.aria-label]="closeAriaLabel()">
-                    @if (!galleria.closeIconTemplate && !galleria._closeIconTemplate) {
+                    @if (!galleria.closeIconTemplate && !galleria._closeIconTemplate()) {
                         <svg data-p-icon="times" [pBind]="getPTOptions('closeIcon')" [class]="cx('closeIcon')" />
                     }
-                    <ng-template *ngTemplateOutlet="galleria.closeIconTemplate || galleria._closeIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="galleria.closeIconTemplate || galleria._closeIconTemplate()"></ng-template>
                 </button>
             }
-            @if (galleria.templates && (galleria.headerFacet || galleria.headerTemplate)) {
-                <div pGalleriaItemSlot [unstyled]="unstyled()" type="header" [templates]="galleria.templates" [pBind]="getPTOptions('header')" [class]="cx('header')"></div>
+            @if (galleria.templates() && (galleria.headerFacet || galleria.headerTemplate())) {
+                <div pGalleriaItemSlot [unstyled]="unstyled()" type="header" [templates]="galleria.templates()" [pBind]="getPTOptions('header')" [class]="cx('header')"></div>
             }
             <div [pBind]="getPTOptions('content')" [class]="cx('content')" [attr.aria-live]="galleria.autoPlay ? 'polite' : 'off'">
                 <div
@@ -552,7 +552,7 @@ export class Galleria extends BaseComponent<GalleriaPassThrough> {
                     [value]="value"
                     [activeIndex]="activeIndex"
                     [circular]="galleria.circular"
-                    [templates]="galleria.templates"
+                    [templates]="galleria.templates()"
                     (onActiveIndexChange)="onActiveIndexChange($event)"
                     [showIndicators]="galleria.showIndicators"
                     [changeItemOnIndicatorHover]="galleria.changeItemOnIndicatorHover"
@@ -574,7 +574,7 @@ export class Galleria extends BaseComponent<GalleriaPassThrough> {
                         [value]="value"
                         (onActiveIndexChange)="onActiveIndexChange($event)"
                         [activeIndex]="activeIndex"
-                        [templates]="galleria.templates"
+                        [templates]="galleria.templates()"
                         [numVisible]="numVisible"
                         [responsiveOptions]="galleria.responsiveOptions"
                         [circular]="galleria.circular"
@@ -589,7 +589,7 @@ export class Galleria extends BaseComponent<GalleriaPassThrough> {
                 }
             </div>
             @if (shouldRenderFooter()) {
-                <div pGalleriaItemSlot [pBind]="getPTOptions('footer')" [class]="cx('footer')" type="footer" [templates]="galleria.templates" [unstyled]="unstyled()"></div>
+                <div pGalleriaItemSlot [pBind]="getPTOptions('footer')" [class]="cx('footer')" type="footer" [templates]="galleria.templates()" [unstyled]="unstyled()"></div>
             }
         }
     `,
@@ -632,7 +632,7 @@ export class GalleriaContent extends BaseComponent<GalleriaPassThrough> {
 
     @Output() activeItemChange: EventEmitter<number> = new EventEmitter();
 
-    @ViewChild('closeButton') closeButton: ElementRef | undefined;
+    readonly closeButton = viewChild<ElementRef>('closeButton');
 
     _componentStyle = inject(GalleriaStyle);
 
@@ -680,7 +680,8 @@ export class GalleriaContent extends BaseComponent<GalleriaPassThrough> {
     }
 
     shouldRenderFooter() {
-        return (this.galleria.footerFacet && this.galleria.templates && this.galleria.templates.toArray().length > 0) || this.galleria.footerTemplate;
+        const templates = this.galleria.templates();
+        return (this.galleria.footerFacet && templates && templates.length > 0) || this.galleria.footerTemplate();
     }
 
     startSlideShow() {
@@ -761,16 +762,17 @@ export class GalleriaItemSlot extends BaseComponent<GalleriaPassThrough> {
     }
 
     shouldRender() {
+        const captionTemplate = this.galleria.captionTemplate();
         return (
             this.contentTemplate ||
-            this.galleria._itemTemplate ||
+            this.galleria._itemTemplate() ||
             this.galleria.itemTemplate ||
-            this.galleria.captionTemplate ||
-            this.galleria.captionTemplate ||
+            captionTemplate ||
+            captionTemplate ||
             this.galleria.captionFacet ||
             this.galleria.thumbnailTemplate ||
-            this.galleria._thumbnailTemplate ||
-            this.galleria.footerTemplate
+            this.galleria._thumbnailTemplate() ||
+            this.galleria.footerTemplate()
         );
     }
 
@@ -803,34 +805,34 @@ export class GalleriaItemSlot extends BaseComponent<GalleriaPassThrough> {
     }
 
     getTemplateFromQueryList(type: string): TemplateRef<any> | undefined {
-        return this.galleria.templates?.find((item) => item.getType() === type)?.template;
+        return this.galleria.templates()?.find((item) => item.getType() === type)?.template;
     }
 
     getContentTemplate() {
         switch (this.type) {
             case 'item':
                 this.context = { $implicit: this.item };
-                this.contentTemplate = this.galleria._itemTemplate || this.getTemplateFromQueryList('item');
+                this.contentTemplate = this.galleria._itemTemplate() || this.getTemplateFromQueryList('item');
                 break;
             case 'caption':
                 this.context = { $implicit: this.item };
-                this.contentTemplate = this.galleria.captionTemplate || this.getTemplateFromQueryList('caption');
+                this.contentTemplate = this.galleria.captionTemplate() || this.getTemplateFromQueryList('caption');
                 break;
             case 'thumbnail':
                 this.context = { $implicit: this.item };
-                this.contentTemplate = this.galleria._thumbnailTemplate || this.getTemplateFromQueryList('thumbnail');
+                this.contentTemplate = this.galleria._thumbnailTemplate() || this.getTemplateFromQueryList('thumbnail');
                 break;
             case 'indicator':
                 this.context = { $implicit: this.index };
-                this.contentTemplate = this.galleria.indicatorTemplate || this.getTemplateFromQueryList('indicator');
+                this.contentTemplate = this.galleria.indicatorTemplate() || this.getTemplateFromQueryList('indicator');
                 break;
             case 'footer':
                 this.context = { $implicit: this.item };
-                this.contentTemplate = this.galleria.footerTemplate || this.getTemplateFromQueryList('footer');
+                this.contentTemplate = this.galleria.footerTemplate() || this.getTemplateFromQueryList('footer');
                 break;
             default:
                 this.context = { $implicit: this.item };
-                this.contentTemplate = this.galleria._itemTemplate || this.getTemplateFromQueryList('item');
+                this.contentTemplate = this.galleria._itemTemplate() || this.getTemplateFromQueryList('item');
         }
     }
 
@@ -884,10 +886,10 @@ export class GalleriaItemSlot extends BaseComponent<GalleriaPassThrough> {
         <div [pBind]="ptm('items')" [class]="cx('items')">
             @if (showItemNavigators) {
                 <button type="button" role="navigation" [pBind]="ptm('prevButton')" [class]="cx('prevButton')" (click)="navBackward($event)" (focus)="onButtonFocus('left')" (blur)="onButtonBlur('left')" data-pc-group-section="itemnavigator">
-                    @if (!galleria.itemPreviousIconTemplate && !galleria._itemPreviousIconTemplate) {
+                    @if (!galleria.itemPreviousIconTemplate && !galleria._itemPreviousIconTemplate()) {
                         <svg data-p-icon="chevron-left" [pBind]="ptm('prevIcon')" [class]="cx('prevIcon')" />
                     }
-                    <ng-template *ngTemplateOutlet="galleria.itemPreviousIconTemplate || galleria._itemPreviousIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="galleria.itemPreviousIconTemplate || galleria._itemPreviousIconTemplate()"></ng-template>
                 </button>
             }
             <div
@@ -905,13 +907,13 @@ export class GalleriaItemSlot extends BaseComponent<GalleriaPassThrough> {
             ></div>
             @if (showItemNavigators) {
                 <button type="button" [pBind]="ptm('nextButton')" [class]="cx('nextButton')" (click)="navForward($event)" role="navigation" (focus)="onButtonFocus('right')" (blur)="onButtonBlur('right')" data-pc-group-section="itemnavigator">
-                    @if (!galleria.itemNextIconTemplate && !galleria._itemNextIconTemplate) {
+                    @if (!galleria.itemNextIconTemplate && !galleria._itemNextIconTemplate()) {
                         <svg data-p-icon="chevron-right" [pBind]="ptm('nextIcon')" [class]="cx('nextIcon')" />
                     }
-                    <ng-template *ngTemplateOutlet="galleria.itemNextIconTemplate || galleria._itemNextIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="galleria.itemNextIconTemplate || galleria._itemNextIconTemplate()"></ng-template>
                 </button>
             }
-            @if (captionFacet || galleria.captionTemplate) {
+            @if (captionFacet || galleria.captionTemplate()) {
                 <div pGalleriaItemSlot [pBind]="ptm('caption')" [unstyled]="unstyled()" [class]="cx('caption')" type="caption" [item]="activeItem" [templates]="templates"></div>
             }
         </div>
@@ -931,10 +933,10 @@ export class GalleriaItemSlot extends BaseComponent<GalleriaPassThrough> {
                         [pBind]="ptm('indicator', getIndicatorPTOptions(index))"
                         [attr.data-p-active]="isIndicatorItemActive(index)"
                     >
-                        @if (!indicatorFacet && !galleria.indicatorTemplate) {
+                        @if (!indicatorFacet && !galleria.indicatorTemplate()) {
                             <button type="button" tabIndex="-1" [pBind]="ptm('indicatorButton', getIndicatorPTOptions(index))" [class]="cx('indicatorButton')"></button>
                         }
-                        @if (indicatorFacet || galleria.indicatorTemplate) {
+                        @if (indicatorFacet || galleria.indicatorTemplate()) {
                             <div pGalleriaItemSlot type="indicator" [index]="index" [templates]="templates" [pBind]="ptm('item')" [unstyled]="unstyled()"></div>
                         }
                     </li>
@@ -1136,7 +1138,7 @@ export class GalleriaItem extends BaseComponent<GalleriaPassThrough> {
         <div [pBind]="ptm('thumbnailContent')" [class]="cx('thumbnailContent')">
             @if (showThumbnailNavigators) {
                 <button type="button" [pBind]="ptm('thumbnailPrevButton')" [class]="cx('thumbnailPrevButton')" (click)="navBackward($event)" pRipple [attr.aria-label]="ariaPrevButtonLabel()" data-pc-group-section="thumbnailnavigator">
-                    @if (!galleria.previousThumbnailIconTemplate && !galleria._previousThumbnailIconTemplate) {
+                    @if (!galleria.previousThumbnailIconTemplate && !galleria._previousThumbnailIconTemplate()) {
                         @if (!isVertical) {
                             <svg data-p-icon="chevron-left" [pBind]="ptm('thumbnailPrevIcon')" [class]="cx('thumbnailPrevIcon')" />
                         }
@@ -1144,7 +1146,7 @@ export class GalleriaItem extends BaseComponent<GalleriaPassThrough> {
                             <svg data-p-icon="chevron-up" [pBind]="ptm('thumbnailPrevIcon')" [class]="cx('thumbnailPrevIcon')" />
                         }
                     }
-                    <ng-template *ngTemplateOutlet="galleria.previousThumbnailIconTemplate || galleria._previousThumbnailIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="galleria.previousThumbnailIconTemplate || galleria._previousThumbnailIconTemplate()"></ng-template>
                 </button>
             }
             <div [pBind]="ptm('thumbnailsViewport')" [class]="cx('thumbnailsViewport')" [ngStyle]="{ height: isVertical ? contentHeight : '' }">
@@ -1176,7 +1178,7 @@ export class GalleriaItem extends BaseComponent<GalleriaPassThrough> {
             </div>
             @if (showThumbnailNavigators) {
                 <button type="button" [pBind]="ptm('thumbnailNextButton')" [class]="cx('thumbnailNextButton')" (click)="navForward($event)" pRipple [attr.aria-label]="ariaNextButtonLabel()" data-pc-group-section="thumbnailnavigator">
-                    @if (!galleria.nextThumbnailIconTemplate && !galleria._nextThumbnailIconTemplate) {
+                    @if (!galleria.nextThumbnailIconTemplate && !galleria._nextThumbnailIconTemplate()) {
                         @if (!isVertical) {
                             <svg data-p-icon="chevron-right" [pBind]="ptm('thumbnailNextIcon')" [class]="cx('thumbnailNextIcon')" />
                         }
@@ -1184,7 +1186,7 @@ export class GalleriaItem extends BaseComponent<GalleriaPassThrough> {
                             <svg data-p-icon="chevron-down" [pBind]="ptm('thumbnailNextIcon')" [class]="cx('thumbnailNextIcon')" />
                         }
                     }
-                    <ng-template *ngTemplateOutlet="galleria.nextThumbnailIconTemplate || galleria._nextThumbnailIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="galleria.nextThumbnailIconTemplate || galleria._nextThumbnailIconTemplate()"></ng-template>
                 </button>
             }
         </div>
@@ -1229,7 +1231,7 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
 
     @Output() stopSlideShow: EventEmitter<Event> = new EventEmitter();
 
-    @ViewChild('itemsContainer') itemsContainer: ElementRef | undefined;
+    readonly itemsContainer = viewChild<ElementRef>('itemsContainer');
 
     @Input() get numVisible(): number {
         return this._numVisible;
@@ -1289,7 +1291,8 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
     onAfterContentChecked() {
         let totalShiftedItems = this.totalShiftedItems;
 
-        if ((this._oldNumVisible !== this.d_numVisible || this._oldactiveIndex !== this._activeIndex) && this.itemsContainer) {
+        const itemsContainer = this.itemsContainer();
+        if ((this._oldNumVisible !== this.d_numVisible || this._oldactiveIndex !== this._activeIndex) && itemsContainer) {
             if (this._activeIndex <= this.getMedianItemIndex()) {
                 totalShiftedItems = 0;
             } else if ((<any[]>this.value).length - this.d_numVisible + this.getMedianItemIndex() < this._activeIndex) {
@@ -1304,14 +1307,14 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
                 this.totalShiftedItems = totalShiftedItems;
             }
 
-            if (this.itemsContainer && this.itemsContainer.nativeElement) {
-                this.itemsContainer.nativeElement.style.transform = this.isVertical ? `translate3d(0, ${totalShiftedItems * (100 / this.d_numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this.d_numVisible)}%, 0, 0)`;
+            if (itemsContainer && itemsContainer.nativeElement) {
+                itemsContainer.nativeElement.style.transform = this.isVertical ? `translate3d(0, ${totalShiftedItems * (100 / this.d_numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this.d_numVisible)}%, 0, 0)`;
             }
 
             if (this._oldactiveIndex !== this._activeIndex) {
                 this.document.body.setAttribute('data-p-items-hidden', 'false');
-                !this.$unstyled() && removeClass(this.itemsContainer.nativeElement, 'p-items-hidden');
-                this.itemsContainer.nativeElement.style.transition = 'transform 500ms ease 0s';
+                !this.$unstyled() && removeClass(itemsContainer.nativeElement, 'p-items-hidden');
+                itemsContainer.nativeElement.style.transition = 'transform 500ms ease 0s';
             }
 
             this._oldactiveIndex = this._activeIndex;
@@ -1373,7 +1376,7 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
 
     calculatePosition() {
         if (isPlatformBrowser(this.platformId)) {
-            if (this.itemsContainer && this.sortedResponsiveOptions) {
+            if (this.itemsContainer() && this.sortedResponsiveOptions) {
                 let windowWidth = window.innerWidth;
                 let matchedResponsiveData = {
                     numVisible: this._numVisible
@@ -1496,7 +1499,7 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
     }
 
     onRightKey() {
-        const indicators = find(this.itemsContainer?.nativeElement, '[data-pc-section="thumbnailitem"]');
+        const indicators = find(this.itemsContainer()?.nativeElement, '[data-pc-section="thumbnailitem"]');
         const activeIndex = this.findFocusedIndicatorIndex();
 
         this.changedFocusedIndicator(activeIndex, activeIndex + 1 === indicators.length ? indicators.length - 1 : activeIndex + 1);
@@ -1515,17 +1518,18 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
     }
 
     onEndKey() {
-        const indicators = find(this.itemsContainer?.nativeElement, '[data-pc-section="thumbnailitem"]');
+        const indicators = find(this.itemsContainer()?.nativeElement, '[data-pc-section="thumbnailitem"]');
         const activeIndex = this.findFocusedIndicatorIndex();
 
         this.changedFocusedIndicator(activeIndex, indicators.length - 1);
     }
 
     onTabKey() {
-        const indicators = <any>[...find(this.itemsContainer?.nativeElement, '[data-pc-section="thumbnailitem"]')];
+        const itemsContainer = this.itemsContainer();
+        const indicators = <any>[...find(itemsContainer?.nativeElement, '[data-pc-section="thumbnailitem"]')];
         const highlightedIndex = indicators.findIndex((ind: any) => getAttribute(ind, 'data-p-active') === true);
 
-        const activeIndicator = <any>findSingle(this.itemsContainer?.nativeElement, '[tabindex="0"]');
+        const activeIndicator = <any>findSingle(itemsContainer?.nativeElement, '[tabindex="0"]');
 
         const activeIndex = indicators.findIndex((ind: any) => ind === activeIndicator?.parentElement);
 
@@ -1534,14 +1538,15 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
     }
 
     findFocusedIndicatorIndex() {
-        const indicators = [...find(this.itemsContainer?.nativeElement, '[data-pc-section="thumbnailitem"]')];
-        const activeIndicator = findSingle(this.itemsContainer?.nativeElement, '[data-pc-section="thumbnailitem"] > [tabindex="0"]');
+        const itemsContainer = this.itemsContainer();
+        const indicators = [...find(itemsContainer?.nativeElement, '[data-pc-section="thumbnailitem"]')];
+        const activeIndicator = findSingle(itemsContainer?.nativeElement, '[data-pc-section="thumbnailitem"] > [tabindex="0"]');
 
         return indicators.findIndex((ind) => ind === activeIndicator?.parentElement);
     }
 
     changedFocusedIndicator(prevInd: number, nextInd: number) {
-        const indicators = <any>find(this.itemsContainer?.nativeElement, '[data-pc-section="thumbnailitem"]');
+        const indicators = <any>find(this.itemsContainer()?.nativeElement, '[data-pc-section="thumbnailitem"]');
 
         indicators[prevInd].children[0].tabIndex = '-1';
         indicators[nextInd].children[0].tabIndex = '0';
@@ -1565,11 +1570,12 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
             }
         }
 
-        if (this.itemsContainer) {
+        const itemsContainer = this.itemsContainer();
+        if (itemsContainer) {
             this.document.body.setAttribute('data-p-items-hidden', 'false');
-            !this.$unstyled() && removeClass(this.itemsContainer.nativeElement, 'p-items-hidden');
-            this.itemsContainer.nativeElement.style.transform = this.isVertical ? `translate3d(0, ${totalShiftedItems * (100 / this.d_numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this.d_numVisible)}%, 0, 0)`;
-            this.itemsContainer.nativeElement.style.transition = 'transform 500ms ease 0s';
+            !this.$unstyled() && removeClass(itemsContainer.nativeElement, 'p-items-hidden');
+            itemsContainer.nativeElement.style.transform = this.isVertical ? `translate3d(0, ${totalShiftedItems * (100 / this.d_numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this.d_numVisible)}%, 0, 0)`;
+            itemsContainer.nativeElement.style.transition = 'transform 500ms ease 0s';
         }
 
         this.totalShiftedItems = totalShiftedItems;
@@ -1602,10 +1608,11 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
     }
 
     onTransitionEnd() {
-        if (this.itemsContainer && this.itemsContainer.nativeElement) {
+        const itemsContainer = this.itemsContainer();
+        if (itemsContainer && itemsContainer.nativeElement) {
             this.document.body.setAttribute('data-p-items-hidden', 'true');
-            !this.$unstyled() && addClass(this.itemsContainer.nativeElement, 'p-items-hidden');
-            this.itemsContainer.nativeElement.style.transition = '';
+            !this.$unstyled() && addClass(itemsContainer.nativeElement, 'p-items-hidden');
+            itemsContainer.nativeElement.style.transition = '';
         }
     }
 

--- a/packages/optimus-ui/src/galleria/galleria.ts
+++ b/packages/optimus-ui/src/galleria/galleria.ts
@@ -15,7 +15,6 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     SimpleChanges,
     TemplateRef,
@@ -1223,7 +1222,7 @@ export class GalleriaThumbnails extends BaseComponent<GalleriaPassThrough> {
 
     @Input() showThumbnailNavigators = true;
 
-    @Input() templates: QueryList<PrimeTemplate> | undefined;
+    @Input() templates: readonly PrimeTemplate[] | undefined;
 
     @Output() onActiveIndexChange: EventEmitter<number> = new EventEmitter();
 

--- a/packages/optimus-ui/src/image/image.test.ts
+++ b/packages/optimus-ui/src/image/image.test.ts
@@ -500,7 +500,7 @@ describe('Image', () => {
                 }
             };
 
-            imageInstance.templates = mockQueryList as any;
+            (imageInstance as any).templates = () => mockQueryList as any;
             imageInstance.ngAfterContentInit();
 
             expect(imageInstance._indicatorTemplate).toBe(mockIndicatorTemplate);

--- a/packages/optimus-ui/src/image/image.test.ts
+++ b/packages/optimus-ui/src/image/image.test.ts
@@ -5,6 +5,7 @@ import { By } from '@angular/platform-browser';
 import { SharedModule } from '@openng/optimus-ui/api';
 import { Image, ImageModule } from './image';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 // Using image paths from photoservice.ts to ensure consistency
 const mockImageSrc = 'https://primefaces.org/cdn/primeng/images/galleria/galleria1.jpg';
 const mockPreviewImageSrc = 'https://primefaces.org/cdn/primeng/images/galleria/galleria2.jpg';
@@ -1053,5 +1054,33 @@ describe('Image', () => {
                 expect(imageElement.nativeElement.classList.contains('IMAGE_PT')).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Image, SharedModule],
+    template: ` <p-image src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" [preview]="true"> </p-image> `
+})
+class ImageQueryApiHostComponent {}
+
+describe('Image Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ImageQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ImageQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Image)).componentInstance;
+
+        expect(instance.previewButton()).toBeDefined();
+        expect(instance.closeButton()).toBeUndefined();
     });
 });

--- a/packages/optimus-ui/src/image/image.ts
+++ b/packages/optimus-ui/src/image/image.ts
@@ -307,8 +307,6 @@ export class Image extends BaseComponent<ImagePassThrough> {
      */
     @Output() onImageError: EventEmitter<Event> = new EventEmitter<Event>();
 
-    readonly mask = viewChild<ElementRef>('mask');
-
     readonly previewButton = viewChild<ElementRef>('previewButton');
 
     readonly closeButton = viewChild<ElementRef>('closeButton');

--- a/packages/optimus-ui/src/image/image.ts
+++ b/packages/optimus-ui/src/image/image.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     HostListener,
@@ -15,11 +13,12 @@ import {
     Input,
     NgModule,
     Output,
-    QueryList,
     signal,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { SafeUrl } from '@angular/platform-browser';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
@@ -47,7 +46,7 @@ const IMAGE_INSTANCE = new InjectionToken<Image>('IMAGE_INSTANCE');
     standalone: true,
     imports: [CommonModule, RefreshIcon, EyeIcon, UndoIcon, SearchMinusIcon, SearchPlusIcon, TimesIcon, FocusTrap, SharedModule, BindModule, MotionModule],
     template: `
-        @if (!imageTemplate && !_imageTemplate) {
+        @if (!imageTemplate() && !_imageTemplate) {
             <img
                 [attr.src]="src"
                 [attr.srcset]="srcSet"
@@ -63,12 +62,12 @@ const IMAGE_INSTANCE = new InjectionToken<Image>('IMAGE_INSTANCE');
             />
         }
 
-        <ng-container *ngTemplateOutlet="imageTemplate || _imageTemplate; context: { errorCallback: imageError.bind(this) }"></ng-container>
+        <ng-container *ngTemplateOutlet="imageTemplate() || _imageTemplate; context: { errorCallback: imageError.bind(this) }"></ng-container>
 
         @if (preview) {
             <button [attr.aria-label]="zoomImageAriaLabel" type="button" [class]="cx('previewMask')" (click)="onImageClick()" #previewButton [ngStyle]="{ height: height + 'px', width: width + 'px' }" [pBind]="ptm('previewMask')">
-                @if (indicatorTemplate || _indicatorTemplate) {
-                    <ng-container *ngTemplateOutlet="indicatorTemplate || _indicatorTemplate"></ng-container>
+                @if (indicatorTemplate() || _indicatorTemplate) {
+                    <ng-container *ngTemplateOutlet="indicatorTemplate() || _indicatorTemplate"></ng-container>
                 } @else {
                     <svg data-p-icon="eye" [class]="cx('previewIcon')" [pBind]="ptm('previewIcon')" />
                 }
@@ -93,39 +92,39 @@ const IMAGE_INSTANCE = new InjectionToken<Image>('IMAGE_INSTANCE');
             >
                 <div [class]="cx('toolbar')" (click)="handleToolbarClick($event)" [pBind]="ptm('toolbar')">
                     <button [class]="cx('rotateRightButton')" (click)="rotateRight()" type="button" [attr.aria-label]="rightAriaLabel()" [pBind]="ptm('rotateRightButton')">
-                        @if (!rotateRightIconTemplate && !_rotateRightIconTemplate) {
+                        @if (!rotateRightIconTemplate() && !_rotateRightIconTemplate) {
                             <svg data-p-icon="refresh" />
                         }
-                        <ng-template *ngTemplateOutlet="rotateRightIconTemplate || _rotateRightIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="rotateRightIconTemplate() || _rotateRightIconTemplate"></ng-template>
                     </button>
                     <button [class]="cx('rotateLeftButton')" (click)="rotateLeft()" type="button" [attr.aria-label]="leftAriaLabel()" [pBind]="ptm('rotateLeftButton')">
-                        @if (!rotateLeftIconTemplate && !_rotateLeftIconTemplate) {
+                        @if (!rotateLeftIconTemplate() && !_rotateLeftIconTemplate) {
                             <svg data-p-icon="undo" />
                         }
-                        <ng-template *ngTemplateOutlet="rotateLeftIconTemplate || _rotateLeftIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="rotateLeftIconTemplate() || _rotateLeftIconTemplate"></ng-template>
                     </button>
                     <button [class]="cx('zoomOutButton')" (click)="zoomOut()" type="button" [disabled]="isZoomOutDisabled" [attr.aria-label]="zoomOutAriaLabel()" [pBind]="ptm('zoomOutButton')">
-                        @if (!zoomOutIconTemplate && !_zoomOutIconTemplate) {
+                        @if (!zoomOutIconTemplate() && !_zoomOutIconTemplate) {
                             <svg data-p-icon="search-minus" />
                         }
-                        <ng-template *ngTemplateOutlet="zoomOutIconTemplate || _zoomOutIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="zoomOutIconTemplate() || _zoomOutIconTemplate"></ng-template>
                     </button>
                     <button [class]="cx('zoomInButton')" (click)="zoomIn()" type="button" [disabled]="isZoomInDisabled" [attr.aria-label]="zoomInAriaLabel()" [pBind]="ptm('zoomInButton')">
-                        @if (!zoomInIconTemplate && !_zoomInIconTemplate) {
+                        @if (!zoomInIconTemplate() && !_zoomInIconTemplate) {
                             <svg data-p-icon="search-plus" />
                         }
-                        <ng-template *ngTemplateOutlet="zoomInIconTemplate || _zoomInIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="zoomInIconTemplate() || _zoomInIconTemplate"></ng-template>
                     </button>
                     <button [class]="cx('closeButton')" type="button" (click)="closePreview()" [attr.aria-label]="closeAriaLabel()" #closeButton [pBind]="ptm('closeButton')">
-                        @if (!closeIconTemplate && !_closeIconTemplate) {
+                        @if (!closeIconTemplate() && !_closeIconTemplate) {
                             <svg data-p-icon="times" />
                         }
-                        <ng-template *ngTemplateOutlet="closeIconTemplate || _closeIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="closeIconTemplate() || _closeIconTemplate"></ng-template>
                     </button>
                 </div>
                 @if (renderPreview()) {
                     <p-motion [visible]="previewVisible" name="p-image-original" [appear]="true" [options]="computedMotionOptions()" (onBeforeEnter)="onAnimationStart($event)" (onBeforeLeave)="onBeforeLeave()" (onAfterLeave)="onAnimationEnd($event)">
-                        @if (!previewTemplate && !_previewTemplate) {
+                        @if (!previewTemplate() && !_previewTemplate) {
                             <img
                                 [attr.src]="previewImageSrc ? previewImageSrc : src"
                                 [attr.srcset]="previewImageSrcSet"
@@ -138,7 +137,7 @@ const IMAGE_INSTANCE = new InjectionToken<Image>('IMAGE_INSTANCE');
                         }
                         <ng-container
                             *ngTemplateOutlet="
-                                previewTemplate || _previewTemplate;
+                                previewTemplate() || _previewTemplate;
                                 context: {
                                     class: cx('original'),
                                     style: imagePreviewStyle(),
@@ -308,59 +307,59 @@ export class Image extends BaseComponent<ImagePassThrough> {
      */
     @Output() onImageError: EventEmitter<Event> = new EventEmitter<Event>();
 
-    @ViewChild('mask') mask: ElementRef | undefined;
+    readonly mask = viewChild<ElementRef>('mask');
 
-    @ViewChild('previewButton') previewButton: ElementRef | undefined;
+    readonly previewButton = viewChild<ElementRef>('previewButton');
 
-    @ViewChild('closeButton') closeButton: ElementRef | undefined;
+    readonly closeButton = viewChild<ElementRef>('closeButton');
 
     /**
      * Custom indicator template.
      * @group Templates
      */
-    @ContentChild('indicator', { descendants: false }) indicatorTemplate: TemplateRef<void> | undefined;
+    readonly indicatorTemplate = contentChild<TemplateRef<void>>('indicator', { descendants: false });
 
     /**
      * Custom rotate right icon template.
      * @group Templates
      */
-    @ContentChild('rotaterighticon', { descendants: false }) rotateRightIconTemplate: TemplateRef<void> | undefined;
+    readonly rotateRightIconTemplate = contentChild<TemplateRef<void>>('rotaterighticon', { descendants: false });
 
     /**
      * Custom rotate left icon template.
      * @group Templates
      */
-    @ContentChild('rotatelefticon', { descendants: false }) rotateLeftIconTemplate: TemplateRef<void> | undefined;
+    readonly rotateLeftIconTemplate = contentChild<TemplateRef<void>>('rotatelefticon', { descendants: false });
 
     /**
      * Custom zoom out icon template.
      * @group Templates
      */
-    @ContentChild('zoomouticon', { descendants: false }) zoomOutIconTemplate: TemplateRef<void> | undefined;
+    readonly zoomOutIconTemplate = contentChild<TemplateRef<void>>('zoomouticon', { descendants: false });
 
     /**
      * Custom zoom in icon template.
      * @group Templates
      */
-    @ContentChild('zoominicon', { descendants: false }) zoomInIconTemplate: TemplateRef<void> | undefined;
+    readonly zoomInIconTemplate = contentChild<TemplateRef<void>>('zoominicon', { descendants: false });
 
     /**
      * Custom close icon template.
      * @group Templates
      */
-    @ContentChild('closeicon', { descendants: false }) closeIconTemplate: TemplateRef<void> | undefined;
+    readonly closeIconTemplate = contentChild<TemplateRef<void>>('closeicon', { descendants: false });
 
     /**
      * Custom preview template.
      * @group Templates
      */
-    @ContentChild('preview', { descendants: false }) previewTemplate: TemplateRef<ImagePreviewTemplateContext> | undefined;
+    readonly previewTemplate = contentChild<TemplateRef<ImagePreviewTemplateContext>>('preview', { descendants: false });
 
     /**
      * Custom image template.
      * @group Templates
      */
-    @ContentChild('image', { descendants: false }) imageTemplate: TemplateRef<ImageImageTemplateContext> | undefined;
+    readonly imageTemplate = contentChild<TemplateRef<ImageImageTemplateContext>>('image', { descendants: false });
 
     renderMask = signal<boolean>(false);
 
@@ -399,7 +398,7 @@ export class Image extends BaseComponent<ImagePassThrough> {
         min: 0.5
     };
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _indicatorTemplate: TemplateRef<void> | undefined;
 
@@ -422,7 +421,7 @@ export class Image extends BaseComponent<ImagePassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'indicator':
                     this._indicatorTemplate = item.template;
@@ -486,7 +485,7 @@ export class Image extends BaseComponent<ImagePassThrough> {
             case 'Escape':
                 this.onMaskClick();
                 setTimeout(() => {
-                    focus(this.previewButton?.nativeElement);
+                    focus(this.previewButton()?.nativeElement);
                 }, 25);
                 event.preventDefault();
 
@@ -529,7 +528,7 @@ export class Image extends BaseComponent<ImagePassThrough> {
         this.moveOnTop();
         this.onShow.emit({});
         setTimeout(() => {
-            focus(this.closeButton?.nativeElement);
+            focus(this.closeButton()?.nativeElement);
         }, 25);
     }
 

--- a/packages/optimus-ui/src/imagecompare/imagecompare.test.ts
+++ b/packages/optimus-ui/src/imagecompare/imagecompare.test.ts
@@ -390,7 +390,7 @@ describe('ImageCompare', () => {
                 }
             };
 
-            imageCompareInstance.templates = mockTemplates as any;
+            (imageCompareInstance as any).templates = () => mockTemplates as any;
             imageCompareInstance.ngAfterContentInit();
 
             expect(imageCompareInstance._leftTemplate).toBe(mockLeftTemplate);

--- a/packages/optimus-ui/src/imagecompare/imagecompare.ts
+++ b/packages/optimus-ui/src/imagecompare/imagecompare.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ContentChild, ContentChildren, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind, BindModule } from '@openng/optimus-ui/bind';
@@ -17,8 +17,8 @@ const IMAGECOMPARE_INSTANCE = new InjectionToken<ImageCompare>('IMAGECOMPARE_INS
     standalone: true,
     imports: [CommonModule, SharedModule, BindModule],
     template: `
-        <ng-template *ngTemplateOutlet="leftTemplate || _leftTemplate"></ng-template>
-        <ng-template *ngTemplateOutlet="rightTemplate || _rightTemplate"></ng-template>
+        <ng-template *ngTemplateOutlet="leftTemplate() || _leftTemplate"></ng-template>
+        <ng-template *ngTemplateOutlet="rightTemplate() || _rightTemplate"></ng-template>
 
         <input type="range" min="0" max="100" value="50" (input)="onSlide($event)" [class]="cx('slider')" [pBind]="ptm('slider')" />
     `,
@@ -60,19 +60,19 @@ export class ImageCompare extends BaseComponent<ImageComparePassThrough> {
      * Custom left side template.
      * @group Templates
      */
-    @ContentChild('left', { descendants: false }) leftTemplate: TemplateRef<void> | undefined;
+    readonly leftTemplate = contentChild<TemplateRef<void>>('left', { descendants: false });
 
     /**
      * Custom right side template.
      * @group Templates
      */
-    @ContentChild('right', { descendants: false }) rightTemplate: TemplateRef<void> | undefined;
+    readonly rightTemplate = contentChild<TemplateRef<void>>('right', { descendants: false });
 
     _leftTemplate: TemplateRef<void> | undefined;
 
     _rightTemplate: TemplateRef<void> | undefined;
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _componentStyle = inject(ImageCompareStyle);
 
@@ -90,7 +90,7 @@ export class ImageCompare extends BaseComponent<ImageComparePassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'left':
                     this._leftTemplate = item.template;

--- a/packages/optimus-ui/src/inplace/inplace.test.ts
+++ b/packages/optimus-ui/src/inplace/inplace.test.ts
@@ -899,9 +899,9 @@ describe('Inplace', () => {
 
         it('should handle both template types (# and pTemplate)', () => {
             // Component should have both contentTemplate and _contentTemplate defined
-            expect(inplaceComponent.contentTemplate || inplaceComponent._contentTemplate).toBeTruthy();
-            expect(inplaceComponent.displayTemplate || inplaceComponent._displayTemplate).toBeTruthy();
-            expect(inplaceComponent.closeIconTemplate || inplaceComponent._closeIconTemplate).toBeTruthy();
+            expect(inplaceComponent.contentTemplate() || inplaceComponent._contentTemplate).toBeTruthy();
+            expect(inplaceComponent.displayTemplate() || inplaceComponent._displayTemplate).toBeTruthy();
+            expect(inplaceComponent.closeIconTemplate() || inplaceComponent._closeIconTemplate).toBeTruthy();
         });
     });
 

--- a/packages/optimus-ui/src/inplace/inplace.test.ts
+++ b/packages/optimus-ui/src/inplace/inplace.test.ts
@@ -7,6 +7,8 @@ import { SharedModule } from '@openng/optimus-ui/api';
 import { ButtonModule } from '@openng/optimus-ui/button';
 import { Inplace, InplaceContent, InplaceDisplay, InplaceModule } from './inplace';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1669,5 +1671,41 @@ describe('Inplace', () => {
                 expect(hookCalled).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Inplace, PrimeTemplate],
+    template: `
+        <p-inplace>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-inplace>
+    `
+})
+class InplaceQueryApiHostComponent {}
+
+describe('Inplace Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [InplaceQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(InplaceQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Inplace)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/inplace/inplace.ts
+++ b/packages/optimus-ui/src/inplace/inplace.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { AfterContentInit, booleanAttribute, ChangeDetectionStrategy, Component, ContentChild, ContentChildren, EventEmitter, inject, InjectionToken, Input, NgModule, Output, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { AfterContentInit, booleanAttribute, ChangeDetectionStrategy, Component, EventEmitter, inject, InjectionToken, Input, NgModule, Output, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
@@ -40,13 +40,13 @@ export class InplaceContent extends BaseComponent {}
         @if (!active) {
             <div [class]="cx('display')" [pBind]="ptm('display')" (click)="onActivateClick($event)" tabindex="0" role="button" (keydown)="onKeydown($event)" [attr.data-p-disabled]="disabled">
                 <ng-content select="[pInplaceDisplay]"></ng-content>
-                <ng-container *ngTemplateOutlet="displayTemplate || _displayTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="displayTemplate() || _displayTemplate"></ng-container>
             </div>
         }
         @if (active) {
             <div [class]="cx('content')" [pBind]="ptm('content')">
                 <ng-content select="[pInplaceContent]"></ng-content>
-                <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { closeCallback: onDeactivateClick.bind(this) }"></ng-container>
+                <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { closeCallback: onDeactivateClick.bind(this) }"></ng-container>
                 @if (closable) {
                     @if (closeIcon) {
                         <p-button [pt]="ptm('pcButton')" type="button" [icon]="closeIcon" pRipple (click)="onDeactivateClick($event)" [attr.aria-label]="closeAriaLabel"></p-button>
@@ -54,11 +54,11 @@ export class InplaceContent extends BaseComponent {}
                     @if (!closeIcon) {
                         <p-button [pt]="ptm('pcButton')" type="button" pRipple (click)="onDeactivateClick($event)" [attr.aria-label]="closeAriaLabel">
                             <ng-template #icon>
-                                @if (!closeIconTemplate && !_closeIconTemplate) {
+                                @if (!closeIconTemplate() && !_closeIconTemplate) {
                                     <svg data-p-icon="times" />
                                 }
                             </ng-template>
-                            <ng-template *ngTemplateOutlet="closeIconTemplate || _closeIconTemplate"></ng-template>
+                            <ng-template *ngTemplateOutlet="closeIconTemplate() || _closeIconTemplate"></ng-template>
                         </p-button>
                     }
                 }
@@ -141,17 +141,17 @@ export class Inplace extends BaseComponent<InplacePassThrough> {
      * Custom display template.
      * @group Templates
      */
-    @ContentChild('display', { descendants: false }) displayTemplate: TemplateRef<void> | undefined;
+    readonly displayTemplate = contentChild<TemplateRef<void>>('display', { descendants: false });
     /**
      * Custom content template.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<InplaceContentTemplateContext> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<InplaceContentTemplateContext>>('content', { descendants: false });
     /**
      * Custom close icon template.
      * @group Templates
      */
-    @ContentChild('closeicon', { descendants: false }) closeIconTemplate: TemplateRef<void> | undefined;
+    readonly closeIconTemplate = contentChild<TemplateRef<void>>('closeicon', { descendants: false });
 
     _componentStyle = inject(InplaceStyle);
 
@@ -195,7 +195,7 @@ export class Inplace extends BaseComponent<InplacePassThrough> {
         }
     }
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _displayTemplate: TemplateRef<void> | undefined;
 
@@ -204,7 +204,7 @@ export class Inplace extends BaseComponent<InplacePassThrough> {
     _contentTemplate: TemplateRef<InplaceContentTemplateContext> | undefined;
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'display':
                     this._displayTemplate = item.template;

--- a/packages/optimus-ui/src/inputmask/inputmask.test.ts
+++ b/packages/optimus-ui/src/inputmask/inputmask.test.ts
@@ -306,7 +306,7 @@ describe('InputMask', () => {
 
         it('should focus input element', () => {
             component.focus();
-            expect(component.inputViewChild?.nativeElement.focus).toHaveBeenCalled();
+            expect(component.inputViewChild()?.nativeElement.focus).toHaveBeenCalled();
         });
 
         it('should clear input value', () => {
@@ -315,7 +315,7 @@ describe('InputMask', () => {
 
             component.clear();
 
-            expect(component.inputViewChild?.nativeElement.value).toBe('' as any);
+            expect(component.inputViewChild()?.nativeElement.value).toBe('' as any);
             expect(component.value).toBeNull();
             expect(component.onModelChange).toHaveBeenCalledWith(null);
             expect(component.onClear.emit).toHaveBeenCalled();
@@ -483,7 +483,7 @@ describe('InputMask', () => {
             const escapeEvent = new KeyboardEvent('keydown', { keyCode: 27 });
             component.onInputKeydown(escapeEvent as any);
 
-            expect(component.inputViewChild?.nativeElement.value).toBe('123-45-');
+            expect(component.inputViewChild()?.nativeElement.value).toBe('123-45-');
             expect(component.caret).toHaveBeenCalledWith(0, 7);
         });
 
@@ -767,7 +767,7 @@ describe('InputMask', () => {
             const mockSetValue = vi.fn();
             component.writeControlValue(null, mockSetValue);
 
-            expect(component.inputViewChild!.nativeElement.value).toBe('' as any);
+            expect(component.inputViewChild()!.nativeElement.value).toBe('' as any);
             expect(component.value).toBeNull();
         });
     });

--- a/packages/optimus-ui/src/inputmask/inputmask.test.ts
+++ b/packages/optimus-ui/src/inputmask/inputmask.test.ts
@@ -2070,3 +2070,36 @@ describe('InputMaskDirective', () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// Initial form value (guards the pre-view-init write path; the decorator-era
+// query used static: true — this pins the behavior post-migration)
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [InputMask, ReactiveFormsModule],
+    template: `
+        <form [formGroup]="form">
+            <p-inputmask mask="999-999" formControlName="code"></p-inputmask>
+        </form>
+    `
+})
+class InputMaskInitialValueHostComponent {
+    form = new FormGroup({ code: new FormControl('123456') });
+}
+
+describe('InputMask initial form value', () => {
+    it('should render the masked initial reactive-form value into the input element', async () => {
+        TestBed.configureTestingModule({
+            imports: [InputMaskInitialValueHostComponent],
+            providers: [provideZonelessChangeDetection()]
+        });
+        const fixture = TestBed.createComponent(InputMaskInitialValueHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+        expect(input.value).toBe('123-456');
+    });
+});

--- a/packages/optimus-ui/src/inputmask/inputmask.test.ts
+++ b/packages/optimus-ui/src/inputmask/inputmask.test.ts
@@ -242,7 +242,7 @@ describe('InputMask', () => {
     describe('Public Methods', () => {
         beforeEach(() => {
             component.mask = '999-99-9999';
-            component.inputViewChild = {
+            const mockInputElement = {
                 nativeElement: {
                     value: '',
                     focus: vi.fn(),
@@ -252,7 +252,8 @@ describe('InputMask', () => {
                     offsetParent: {},
                     ownerDocument: { activeElement: {} }
                 }
-            } as any;
+            };
+            (component as any).inputViewChild = () => mockInputElement as any;
             fixture.detectChanges();
         });
 
@@ -419,7 +420,7 @@ describe('InputMask', () => {
     describe('Keyboard Input Processing', () => {
         beforeEach(() => {
             component.mask = '999-99-9999';
-            component.inputViewChild = {
+            const mockInputElement = {
                 nativeElement: {
                     value: '',
                     focus: vi.fn(),
@@ -430,7 +431,8 @@ describe('InputMask', () => {
                     ownerDocument: { activeElement: {} },
                     dispatchEvent: vi.fn()
                 }
-            } as any;
+            };
+            (component as any).inputViewChild = () => mockInputElement as any;
             fixture.detectChanges();
         });
 
@@ -660,12 +662,13 @@ describe('InputMask', () => {
         });
 
         it('should handle caret positioning when input is not focused', () => {
-            component.inputViewChild = {
+            const mockInputElement1 = {
                 nativeElement: {
                     offsetParent: null,
                     ownerDocument: { activeElement: null }
                 }
-            } as any;
+            };
+            (component as any).inputViewChild = () => mockInputElement1 as any;
 
             const result = component.caret(0, 5);
             expect(result).toBeUndefined();
@@ -673,11 +676,12 @@ describe('InputMask', () => {
 
         it('should handle android chrome specific behavior', () => {
             component.androidChrome = true;
-            component.inputViewChild = {
+            const mockInputElement2 = {
                 nativeElement: {
                     value: '123'
                 }
-            } as any;
+            };
+            (component as any).inputViewChild = () => mockInputElement2 as any;
 
             vi.spyOn(component, 'handleAndroidInput').mockImplementation(() => {});
             vi.spyOn(component, 'handleInputChange').mockImplementation(() => {});
@@ -721,11 +725,12 @@ describe('InputMask', () => {
         it('should handle autoClear behavior on blur', () => {
             component.mask = '999-99-9999';
             component.autoClear = true;
-            component.inputViewChild = {
+            const mockInputElement3 = {
                 nativeElement: {
                     value: '12_-__-____'
                 }
-            } as any;
+            };
+            (component as any).inputViewChild = () => mockInputElement3 as any;
             fixture.detectChanges();
 
             vi.spyOn(component, 'clearBuffer').mockImplementation(() => {});
@@ -738,11 +743,12 @@ describe('InputMask', () => {
 
         it('should handle writeControlValue correctly', () => {
             component.mask = '999-99-9999';
-            component.inputViewChild = {
+            const mockInputElement4 = {
                 nativeElement: {
                     value: ''
                 }
-            } as any;
+            };
+            (component as any).inputViewChild = () => mockInputElement4 as any;
             fixture.detectChanges();
 
             vi.spyOn(component, 'checkVal').mockImplementation((() => {}) as any);
@@ -757,11 +763,12 @@ describe('InputMask', () => {
 
         it('should handle null value in writeControlValue', () => {
             component.mask = '999-99-9999';
-            component.inputViewChild = {
+            const mockInputElement5 = {
                 nativeElement: {
                     value: 'test'
                 }
-            } as any;
+            };
+            (component as any).inputViewChild = () => mockInputElement5 as any;
             fixture.detectChanges();
 
             const mockSetValue = vi.fn();
@@ -838,7 +845,7 @@ describe('InputMask', () => {
     describe('Complex Mask Patterns', () => {
         it('should handle phone number mask correctly', async () => {
             component.mask = '(999) 999-9999';
-            component.inputViewChild = {
+            const mockInputElement6 = {
                 nativeElement: {
                     value: '',
                     focus: vi.fn(),
@@ -848,7 +855,8 @@ describe('InputMask', () => {
                     offsetParent: {},
                     ownerDocument: { activeElement: {} }
                 }
-            } as any;
+            };
+            (component as any).inputViewChild = () => mockInputElement6 as any;
             fixture.detectChanges();
 
             expect(component.defaultBuffer).toBe('(___) ___-____');

--- a/packages/optimus-ui/src/inputmask/inputmask.ts
+++ b/packages/optimus-ui/src/inputmask/inputmask.ts
@@ -31,8 +31,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     Directive,
     effect,
     ElementRef,
@@ -45,10 +43,11 @@ import {
     NgModule,
     output,
     Output,
-    QueryList,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren,
+    viewChild
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { getUserAgent, isClient } from '@openng/optimus-ui-utils';
@@ -730,12 +729,12 @@ export const INPUTMASK_VALUE_ACCESSOR: any = {
             [fluid]="hasFluid"
         />
         @if (value != null && $filled() && showClear && !$disabled()) {
-            @if (!clearIconTemplate && !_clearIconTemplate) {
+            @if (!clearIconTemplate() && !_clearIconTemplate) {
                 <svg data-p-icon="times" [class]="cx('clearIcon')" [pBind]="ptm('clearIcon')" (click)="clear()" />
             }
-            @if (clearIconTemplate || _clearIconTemplate) {
+            @if (clearIconTemplate() || _clearIconTemplate) {
                 <span [class]="cx('clearIcon')" [pBind]="ptm('clearIcon')" (click)="clear()">
-                    <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="clearIconTemplate() || _clearIconTemplate"></ng-template>
                 </span>
             }
         }
@@ -910,11 +909,11 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
      * Custom clear icon template.
      * @group Templates
      */
-    @ContentChild('clearicon', { descendants: false }) clearIconTemplate: Nullable<TemplateRef<void>>;
+    readonly clearIconTemplate = contentChild<Nullable<TemplateRef<void>>>('clearicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
-    @ViewChild('input', { static: true }) inputViewChild: Nullable<ElementRef>;
+    readonly inputViewChild = viewChild<Nullable<ElementRef>>('input');
 
     value: Nullable<string>;
 
@@ -959,7 +958,7 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
     _clearIconTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'clearicon':
                     this._clearIconTemplate = item.template;
@@ -1016,26 +1015,27 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
     caret(first?: number, last?: number): Caret | undefined {
         let range, begin, end;
 
-        if (!this.inputViewChild?.nativeElement.offsetParent || this.inputViewChild.nativeElement !== this.inputViewChild.nativeElement.ownerDocument.activeElement) {
+        const inputViewChild = this.inputViewChild();
+        if (!inputViewChild?.nativeElement.offsetParent || inputViewChild.nativeElement !== inputViewChild.nativeElement.ownerDocument.activeElement) {
             return;
         }
 
         if (typeof first == 'number') {
             begin = first;
             end = typeof last === 'number' ? last : begin;
-            if (this.inputViewChild.nativeElement.setSelectionRange) {
-                this.inputViewChild.nativeElement.setSelectionRange(begin, end);
-            } else if (this.inputViewChild.nativeElement['createTextRange']) {
-                range = this.inputViewChild.nativeElement['createTextRange']();
+            if (inputViewChild.nativeElement.setSelectionRange) {
+                inputViewChild.nativeElement.setSelectionRange(begin, end);
+            } else if (inputViewChild.nativeElement['createTextRange']) {
+                range = inputViewChild.nativeElement['createTextRange']();
                 range.collapse(true);
                 range.moveEnd('character', end);
                 range.moveStart('character', begin);
                 range.select();
             }
         } else {
-            if (this.inputViewChild.nativeElement.setSelectionRange) {
-                begin = this.inputViewChild.nativeElement.selectionStart;
-                end = this.inputViewChild.nativeElement.selectionEnd;
+            if (inputViewChild.nativeElement.setSelectionRange) {
+                begin = inputViewChild.nativeElement.selectionStart;
+                end = inputViewChild.nativeElement.selectionEnd;
             } else if ((this.document as any['selection']) && (this.document as any)['selection'].createRange) {
                 range = (this.document as any['selection']).createRange();
                 begin = 0 - range.duplicate().moveStart('character', -100000);
@@ -1115,7 +1115,7 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
     }
 
     handleAndroidInput(e: Event) {
-        var curVal = this.inputViewChild?.nativeElement.value;
+        var curVal = this.inputViewChild()?.nativeElement.value;
         var pos = this.caret() as Caret;
         if (this.oldVal && this.oldVal.length && this.oldVal.length > curVal.length) {
             // a deletion or backspace happened
@@ -1158,7 +1158,7 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
             this.updateModel(e);
             let event = this.document.createEvent('HTMLEvents');
             event.initEvent('change', true, false);
-            this.inputViewChild?.nativeElement.dispatchEvent(event);
+            this.inputViewChild()?.nativeElement.dispatchEvent(event);
         }
     }
 
@@ -1175,7 +1175,8 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
         if (isPlatformBrowser(this.platformId)) {
             iPhone = /iphone/i.test(getUserAgent());
         }
-        this.oldVal = this.inputViewChild?.nativeElement.value;
+        const inputViewChild = this.inputViewChild();
+        this.oldVal = inputViewChild?.nativeElement.value;
 
         this.onKeydown.emit(e);
 
@@ -1206,7 +1207,7 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
             this.updateModel(e);
         } else if (k === 27) {
             // escape
-            (this.inputViewChild as ElementRef).nativeElement.value = this.focusText;
+            (inputViewChild as ElementRef).nativeElement.value = this.focusText;
             this.caret(0, this.checkVal());
             this.updateModel(e);
 
@@ -1284,14 +1285,16 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
     }
 
     writeBuffer() {
-        if (this.buffer && this.inputViewChild?.nativeElement) {
-            (this.inputViewChild as ElementRef).nativeElement.value = this.buffer.join('');
+        const inputViewChild = this.inputViewChild();
+        if (this.buffer && inputViewChild?.nativeElement) {
+            (inputViewChild as ElementRef).nativeElement.value = this.buffer.join('');
         }
     }
 
     checkVal(allow?: boolean): number {
         //try to place characters where they belong
-        let test = this.inputViewChild?.nativeElement.value,
+        const inputViewChild = this.inputViewChild();
+        let test = inputViewChild?.nativeElement.value,
             lastMatch = -1,
             i,
             c,
@@ -1329,7 +1332,7 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
             if (this.autoClear || this.buffer.join('') === this.defaultBuffer) {
                 // Invalid value. Remove it and replace it with the
                 // mask, which is the default behavior.
-                if (this.inputViewChild?.nativeElement.value) this.inputViewChild.nativeElement.value = '';
+                if (inputViewChild?.nativeElement.value) inputViewChild.nativeElement.value = '';
                 this.clearBuffer(0, this.len as number);
             } else {
                 // Invalid value, but we opt to show the value to the
@@ -1338,7 +1341,7 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
             }
         } else {
             this.writeBuffer();
-            (this.inputViewChild as ElementRef).nativeElement.value = this.inputViewChild?.nativeElement.value.substring(0, lastMatch + 1);
+            (inputViewChild as ElementRef).nativeElement.value = inputViewChild?.nativeElement.value.substring(0, lastMatch + 1);
         }
         return (this.partialPosition ? i : this.firstNonMaskPos) as number;
     }
@@ -1353,12 +1356,14 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
         clearTimeout(this.caretTimeoutId);
         let pos: number;
 
-        this.focusText = this.inputViewChild?.nativeElement.value;
+        const inputViewChild = this.inputViewChild();
+        this.focusText = inputViewChild?.nativeElement.value;
 
-        pos = this.keepBuffer ? this.inputViewChild?.nativeElement.value.length : this.checkVal();
+        pos = this.keepBuffer ? inputViewChild?.nativeElement.value.length : this.checkVal();
 
         this.caretTimeoutId = setTimeout(() => {
-            if (this.inputViewChild?.nativeElement !== this.inputViewChild?.nativeElement.ownerDocument.activeElement) {
+            const inputViewChildValue = this.inputViewChild();
+            if (inputViewChildValue?.nativeElement !== inputViewChildValue?.nativeElement.ownerDocument.activeElement) {
                 return;
             }
             this.writeBuffer();
@@ -1421,11 +1426,11 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
     }
 
     focus() {
-        this.inputViewChild?.nativeElement.focus();
+        this.inputViewChild()?.nativeElement.focus();
     }
 
     clear() {
-        (this.inputViewChild as ElementRef).nativeElement.value = '';
+        (this.inputViewChild() as ElementRef).nativeElement.value = '';
         this.value = null;
         this.onModelChange(this.value);
         this.onClear.emit();
@@ -1441,12 +1446,13 @@ export class InputMask extends BaseInput<InputMaskPassThrough> {
         this.value = value;
         setModelValue(this.value);
 
-        if (this.inputViewChild && this.inputViewChild.nativeElement) {
-            if (this.value == undefined || this.value == null) this.inputViewChild.nativeElement.value = '';
-            else this.inputViewChild.nativeElement.value = this.value;
+        const inputViewChild = this.inputViewChild();
+        if (inputViewChild && inputViewChild.nativeElement) {
+            if (this.value == undefined || this.value == null) inputViewChild.nativeElement.value = '';
+            else inputViewChild.nativeElement.value = this.value;
 
             this.checkVal();
-            this.focusText = this.inputViewChild.nativeElement.value;
+            this.focusText = inputViewChild.nativeElement.value;
         }
         this.cd.markForCheck();
     }

--- a/packages/optimus-ui/src/inputnumber/inputnumber.test.ts
+++ b/packages/optimus-ui/src/inputnumber/inputnumber.test.ts
@@ -8,6 +8,8 @@ import { provideOptimus } from '@openng/optimus-ui/config';
 import type { InputNumberInputEvent } from '@openng/optimus-ui/types/inputnumber';
 import { InputNumber, InputNumberModule } from './inputnumber';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 // Test Components
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1513,5 +1515,37 @@ describe('InputNumber', () => {
                 }
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [InputNumber, SharedModule],
+    template: `
+        <p-inputnumber>
+            <ng-template pTemplate="incrementbuttonicon">+</ng-template>
+        </p-inputnumber>
+    `
+})
+class InputNumberQueryApiHostComponent {}
+
+describe('InputNumber Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [InputNumberQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(InputNumberQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(InputNumber)).componentInstance;
+
+        expect(instance.input()).toBeDefined();
+        expect(instance.templates().length).toBeGreaterThan(0);
     });
 });

--- a/packages/optimus-ui/src/inputnumber/inputnumber.ts
+++ b/packages/optimus-ui/src/inputnumber/inputnumber.ts
@@ -1454,8 +1454,8 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
 
         const newValueNumber = this.validateValue(this.parseValue(this.input().nativeElement.value));
         const newValueString: any = newValueNumber?.toString();
-        input.nativeElement.value = this.formatValue(newValueString);
-        input.nativeElement.setAttribute('aria-valuenow', newValueString);
+        this.input().nativeElement.value = this.formatValue(newValueString);
+        this.input().nativeElement.setAttribute('aria-valuenow', newValueString);
         this.updateModel(event, newValueNumber);
         this.onModelTouched();
         this.onBlur.emit(event);

--- a/packages/optimus-ui/src/inputnumber/inputnumber.ts
+++ b/packages/optimus-ui/src/inputnumber/inputnumber.ts
@@ -729,7 +729,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
 
     spin(event: Event, dir: number) {
         let step = (this.step() ?? 1) * dir;
-        let currentValue = this.parseValue(this.input()?.nativeElement.value) || 0;
+        let currentValue = this.parseValue(this.input().nativeElement.value) || 0;
         let newValue = this.validateValue((currentValue as number) + step);
         const max = this.maxlength();
         if (max && max < this.formatValue(newValue).length) {
@@ -755,7 +755,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
         }
 
         if (!this.$disabled()) {
-            this.input()?.nativeElement.focus();
+            this.input().nativeElement.focus();
             this.repeat(event, null, 1);
             event.preventDefault();
         }
@@ -791,7 +791,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
             return;
         }
         if (!this.$disabled()) {
-            this.input()?.nativeElement.focus();
+            this.input().nativeElement.focus();
             this.repeat(event, null, -1);
             event.preventDefault();
         }
@@ -912,7 +912,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
                             this._decimal.lastIndex = 0;
 
                             if (decimalLength) {
-                                this.input()?.nativeElement.setSelectionRange(selectionStart - 1, selectionStart - 1);
+                                this.input().nativeElement.setSelectionRange(selectionStart - 1, selectionStart - 1);
                             } else {
                                 newValueStr = inputValue.slice(0, selectionStart - 1) + inputValue.slice(selectionStart);
                             }
@@ -958,7 +958,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
                             this._decimal.lastIndex = 0;
 
                             if (decimalLength) {
-                                this.input()?.nativeElement.setSelectionRange(selectionStart + 1, selectionStart + 1);
+                                this.input().nativeElement.setSelectionRange(selectionStart + 1, selectionStart + 1);
                             } else {
                                 newValueStr = inputValue.slice(0, selectionStart) + inputValue.slice(selectionStart + 1);
                             }
@@ -1258,7 +1258,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
     }
 
     onInputClick() {
-        const currentValue = this.input()?.nativeElement.value;
+        const currentValue = this.input().nativeElement.value;
 
         if (!this.readonly && currentValue !== getSelection()) {
             this.initCursor();
@@ -1282,7 +1282,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
     }
 
     updateValue(event: Event, valueStr: Nullable<string>, insertedValueStr: Nullable<string>, operation: Nullable<string>) {
-        let currentValue = this.input()?.nativeElement.value;
+        let currentValue = this.input().nativeElement.value;
         let newValue: any = null;
 
         if (valueStr != null) {
@@ -1297,7 +1297,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
     handleOnInput(event: Event, currentValue: string, newValue: any) {
         if (this.isValueChanged(currentValue, newValue)) {
             (this.input() as ElementRef).nativeElement.value = this.formatValue(newValue);
-            this.input()?.nativeElement.setAttribute('aria-valuenow', newValue);
+            this.input().nativeElement.setAttribute('aria-valuenow', newValue);
             this.updateModel(event, newValue);
             this.onInput.emit({ originalEvent: event, value: newValue, formattedValue: currentValue });
         }

--- a/packages/optimus-ui/src/inputnumber/inputnumber.ts
+++ b/packages/optimus-ui/src/inputnumber/inputnumber.ts
@@ -3,8 +3,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -15,11 +13,12 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren,
+    viewChild
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, NgControl } from '@angular/forms';
 import { getSelection } from '@openng/optimus-ui-utils';
@@ -97,12 +96,12 @@ export const INPUTNUMBER_VALUE_ACCESSOR: any = {
             [attr.data-p]="dataP"
         />
         @if (buttonLayout != 'vertical' && showClear && value) {
-            @if (!clearIconTemplate && !_clearIconTemplate) {
+            @if (!clearIconTemplate() && !_clearIconTemplate) {
                 <svg data-p-icon="times" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" />
             }
-            @if (clearIconTemplate || _clearIconTemplate) {
+            @if (clearIconTemplate() || _clearIconTemplate) {
                 <span [pBind]="ptm('clearIcon')" (click)="clear()" [class]="cx('clearIcon')">
-                    <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="clearIconTemplate() || _clearIconTemplate"></ng-template>
                 </span>
             }
         }
@@ -126,10 +125,10 @@ export const INPUTNUMBER_VALUE_ACCESSOR: any = {
                         <span [pBind]="ptm('incrementButtonIcon')" [ngClass]="incrementButtonIcon"></span>
                     }
                     @if (!incrementButtonIcon) {
-                        @if (!incrementButtonIconTemplate && !_incrementButtonIconTemplate) {
+                        @if (!incrementButtonIconTemplate() && !_incrementButtonIconTemplate) {
                             <svg data-p-icon="angle-up" [pBind]="ptm('incrementButtonIcon')" />
                         }
-                        <ng-template *ngTemplateOutlet="incrementButtonIconTemplate || _incrementButtonIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="incrementButtonIconTemplate() || _incrementButtonIconTemplate"></ng-template>
                     }
                 </button>
                 <button
@@ -150,10 +149,10 @@ export const INPUTNUMBER_VALUE_ACCESSOR: any = {
                         <span [pBind]="ptm('decrementButtonIcon')" [ngClass]="decrementButtonIcon"></span>
                     }
                     @if (!decrementButtonIcon) {
-                        @if (!decrementButtonIconTemplate && !_decrementButtonIconTemplate) {
+                        @if (!decrementButtonIconTemplate() && !_decrementButtonIconTemplate) {
                             <svg data-p-icon="angle-down" [pBind]="ptm('decrementButtonIcon')" />
                         }
-                        <ng-template *ngTemplateOutlet="decrementButtonIconTemplate || _decrementButtonIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="decrementButtonIconTemplate() || _decrementButtonIconTemplate"></ng-template>
                     }
                 </button>
             </span>
@@ -177,10 +176,10 @@ export const INPUTNUMBER_VALUE_ACCESSOR: any = {
                     <span [pBind]="ptm('incrementButtonIcon')" [ngClass]="incrementButtonIcon"></span>
                 }
                 @if (!incrementButtonIcon) {
-                    @if (!incrementButtonIconTemplate && !_incrementButtonIconTemplate) {
+                    @if (!incrementButtonIconTemplate() && !_incrementButtonIconTemplate) {
                         <svg data-p-icon="angle-up" [pBind]="ptm('incrementButtonIcon')" />
                     }
-                    <ng-template *ngTemplateOutlet="incrementButtonIconTemplate || _incrementButtonIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="incrementButtonIconTemplate() || _incrementButtonIconTemplate"></ng-template>
                 }
             </button>
         }
@@ -203,10 +202,10 @@ export const INPUTNUMBER_VALUE_ACCESSOR: any = {
                     <span [pBind]="ptm('decrementButtonIcon')" [ngClass]="decrementButtonIcon"></span>
                 }
                 @if (!decrementButtonIcon) {
-                    @if (!decrementButtonIconTemplate && !_decrementButtonIconTemplate) {
+                    @if (!decrementButtonIconTemplate() && !_decrementButtonIconTemplate) {
                         <svg data-p-icon="angle-down" [pBind]="ptm('decrementButtonIcon')" />
                     }
-                    <ng-template *ngTemplateOutlet="decrementButtonIconTemplate || _decrementButtonIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="decrementButtonIconTemplate() || _decrementButtonIconTemplate"></ng-template>
                 }
             </button>
         }
@@ -435,22 +434,22 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
      * Custom clear icon template.
      * @group Templates
      */
-    @ContentChild('clearicon', { descendants: false }) clearIconTemplate: Nullable<TemplateRef<void>>;
+    readonly clearIconTemplate = contentChild<Nullable<TemplateRef<void>>>('clearicon', { descendants: false });
     /**
      * Custom increment button icon template.
      * @group Templates
      */
-    @ContentChild('incrementbuttonicon', { descendants: false }) incrementButtonIconTemplate: Nullable<TemplateRef<void>>;
+    readonly incrementButtonIconTemplate = contentChild<Nullable<TemplateRef<void>>>('incrementbuttonicon', { descendants: false });
 
     /**
      * Custom decrement button icon template.
      * @group Templates
      */
-    @ContentChild('decrementbuttonicon', { descendants: false }) decrementButtonIconTemplate: Nullable<TemplateRef<void>>;
+    readonly decrementButtonIconTemplate = contentChild<Nullable<TemplateRef<void>>>('decrementbuttonicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
-    @ViewChild('input') input!: ElementRef<HTMLInputElement>;
+    readonly input = viewChild.required<ElementRef<HTMLInputElement>>('input');
 
     _clearIconTemplate: TemplateRef<void> | undefined;
 
@@ -514,7 +513,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'clearicon':
                     this._clearIconTemplate = item.template;
@@ -730,7 +729,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
 
     spin(event: Event, dir: number) {
         let step = (this.step() ?? 1) * dir;
-        let currentValue = this.parseValue(this.input?.nativeElement.value) || 0;
+        let currentValue = this.parseValue(this.input()?.nativeElement.value) || 0;
         let newValue = this.validateValue((currentValue as number) + step);
         const max = this.maxlength();
         if (max && max < this.formatValue(newValue).length) {
@@ -756,7 +755,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
         }
 
         if (!this.$disabled()) {
-            this.input?.nativeElement.focus();
+            this.input()?.nativeElement.focus();
             this.repeat(event, null, 1);
             event.preventDefault();
         }
@@ -792,7 +791,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
             return;
         }
         if (!this.$disabled()) {
-            this.input?.nativeElement.focus();
+            this.input()?.nativeElement.focus();
             this.repeat(event, null, -1);
             event.preventDefault();
         }
@@ -853,6 +852,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
             event.preventDefault();
         }
 
+        const input = this.input();
         switch (event.key) {
             case 'ArrowUp':
                 this.spin(event, 1);
@@ -868,7 +868,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
                 for (let index = selectionStart; index <= inputValue.length; index++) {
                     const previousCharIndex = index === 0 ? 0 : index - 1;
                     if (this.isNumeralChar(inputValue.charAt(previousCharIndex))) {
-                        this.input.nativeElement.setSelectionRange(index, index);
+                        this.input().nativeElement.setSelectionRange(index, index);
                         break;
                     }
                 }
@@ -877,7 +877,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
             case 'ArrowRight':
                 for (let index = selectionEnd; index >= 0; index--) {
                     if (this.isNumeralChar(inputValue.charAt(index))) {
-                        this.input.nativeElement.setSelectionRange(index, index);
+                        this.input().nativeElement.setSelectionRange(index, index);
                         break;
                     }
                 }
@@ -885,9 +885,9 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
 
             case 'Tab':
             case 'Enter':
-                newValueStr = this.validateValue(this.parseValue(this.input.nativeElement.value));
-                this.input.nativeElement.value = this.formatValue(newValueStr);
-                this.input.nativeElement.setAttribute('aria-valuenow', newValueStr);
+                newValueStr = this.validateValue(this.parseValue(this.input().nativeElement.value));
+                input.nativeElement.value = this.formatValue(newValueStr);
+                input.nativeElement.setAttribute('aria-valuenow', newValueStr);
                 this.updateModel(event, newValueStr);
                 break;
 
@@ -912,7 +912,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
                             this._decimal.lastIndex = 0;
 
                             if (decimalLength) {
-                                this.input?.nativeElement.setSelectionRange(selectionStart - 1, selectionStart - 1);
+                                this.input()?.nativeElement.setSelectionRange(selectionStart - 1, selectionStart - 1);
                             } else {
                                 newValueStr = inputValue.slice(0, selectionStart - 1) + inputValue.slice(selectionStart);
                             }
@@ -958,7 +958,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
                             this._decimal.lastIndex = 0;
 
                             if (decimalLength) {
-                                this.input?.nativeElement.setSelectionRange(selectionStart + 1, selectionStart + 1);
+                                this.input()?.nativeElement.setSelectionRange(selectionStart + 1, selectionStart + 1);
                             } else {
                                 newValueStr = inputValue.slice(0, selectionStart) + inputValue.slice(selectionStart + 1);
                             }
@@ -1021,7 +1021,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
             char = this._decimalChar;
             code = char.charCodeAt(0);
         }
-        const { value, selectionStart, selectionEnd } = this.input.nativeElement;
+        const { value, selectionStart, selectionEnd } = this.input().nativeElement;
         const newValue = this.parseValue(value + char);
         const newValueStr = newValue != null ? newValue.toString() : '';
         const selectedValue = value.substring(selectionStart as number, selectionEnd as number);
@@ -1127,9 +1127,10 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
             return;
         }
 
-        let selectionStart: any = this.input?.nativeElement.selectionStart;
-        let selectionEnd: any = this.input?.nativeElement.selectionEnd;
-        let inputValue = this.input?.nativeElement.value.trim();
+        const input = this.input();
+        let selectionStart: any = input?.nativeElement.selectionStart;
+        let selectionEnd: any = input?.nativeElement.selectionEnd;
+        let inputValue = input?.nativeElement.value.trim();
         const { decimalCharIndex, minusCharIndex, suffixCharIndex, currencyCharIndex } = this.getCharIndexes(inputValue);
         let newValueStr;
 
@@ -1200,9 +1201,10 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
     }
 
     initCursor() {
-        let selectionStart: any = this.input?.nativeElement.selectionStart;
-        let selectionEnd: any = this.input?.nativeElement.selectionEnd;
-        let inputValue = this.input?.nativeElement.value;
+        const input = this.input();
+        let selectionStart: any = input?.nativeElement.selectionStart;
+        let selectionEnd: any = input?.nativeElement.selectionEnd;
+        let inputValue = input?.nativeElement.value;
         let valueLength = inputValue.length;
         let index: any = null;
 
@@ -1234,7 +1236,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
         }
 
         if (index !== null) {
-            this.input?.nativeElement.setSelectionRange(index + 1, index + 1);
+            input?.nativeElement.setSelectionRange(index + 1, index + 1);
         } else {
             i = selectionStart;
             while (i < valueLength) {
@@ -1248,7 +1250,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
             }
 
             if (index !== null) {
-                this.input?.nativeElement.setSelectionRange(index, index);
+                input?.nativeElement.setSelectionRange(index, index);
             }
         }
 
@@ -1256,7 +1258,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
     }
 
     onInputClick() {
-        const currentValue = this.input?.nativeElement.value;
+        const currentValue = this.input()?.nativeElement.value;
 
         if (!this.readonly && currentValue !== getSelection()) {
             this.initCursor();
@@ -1280,7 +1282,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
     }
 
     updateValue(event: Event, valueStr: Nullable<string>, insertedValueStr: Nullable<string>, operation: Nullable<string>) {
-        let currentValue = this.input?.nativeElement.value;
+        let currentValue = this.input()?.nativeElement.value;
         let newValue: any = null;
 
         if (valueStr != null) {
@@ -1294,8 +1296,8 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
 
     handleOnInput(event: Event, currentValue: string, newValue: any) {
         if (this.isValueChanged(currentValue, newValue)) {
-            (this.input as ElementRef).nativeElement.value = this.formatValue(newValue);
-            this.input?.nativeElement.setAttribute('aria-valuenow', newValue);
+            (this.input() as ElementRef).nativeElement.value = this.formatValue(newValue);
+            this.input()?.nativeElement.setAttribute('aria-valuenow', newValue);
             this.updateModel(event, newValue);
             this.onInput.emit({ originalEvent: event, value: newValue, formattedValue: currentValue });
         }
@@ -1335,7 +1337,8 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
     updateInput(value: any, insertedValueStr: Nullable<string>, operation: Nullable<string>, valueStr: Nullable<string>) {
         insertedValueStr = insertedValueStr || '';
 
-        let inputValue = this.input?.nativeElement.value;
+        const input = this.input();
+        let inputValue = input?.nativeElement.value;
         let newValue = this.formatValue(value);
         let currentLength = inputValue.length;
 
@@ -1344,14 +1347,14 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
         }
 
         if (currentLength === 0) {
-            this.input.nativeElement.value = newValue;
-            this.input.nativeElement.setSelectionRange(0, 0);
+            input.nativeElement.value = newValue;
+            input.nativeElement.setSelectionRange(0, 0);
             const index = this.initCursor();
             const selectionEnd = index + insertedValueStr.length;
-            this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+            input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
         } else {
-            let selectionStart: any = this.input.nativeElement.selectionStart;
-            let selectionEnd: any = this.input.nativeElement.selectionEnd;
+            let selectionStart: any = input.nativeElement.selectionStart;
+            let selectionEnd: any = input.nativeElement.selectionEnd;
             const maxlength = this.maxlength();
             if (maxlength && newValue.length > maxlength) {
                 newValue = newValue.slice(0, maxlength);
@@ -1363,7 +1366,7 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
                 return;
             }
 
-            this.input.nativeElement.value = newValue;
+            input.nativeElement.value = newValue;
             let newLength = newValue.length;
 
             if (operation === 'range-insert') {
@@ -1378,11 +1381,11 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
                 tRegex.test(newValue.slice(sRegex.lastIndex));
 
                 selectionEnd = sRegex.lastIndex + tRegex.lastIndex;
-                this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
             } else if (newLength === currentLength) {
-                if (operation === 'insert' || operation === 'delete-back-single') this.input.nativeElement.setSelectionRange(selectionEnd + 1, selectionEnd + 1);
-                else if (operation === 'delete-single') this.input.nativeElement.setSelectionRange(selectionEnd - 1, selectionEnd - 1);
-                else if (operation === 'delete-range' || operation === 'spin') this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                if (operation === 'insert' || operation === 'delete-back-single') input.nativeElement.setSelectionRange(selectionEnd + 1, selectionEnd + 1);
+                else if (operation === 'delete-single') input.nativeElement.setSelectionRange(selectionEnd - 1, selectionEnd - 1);
+                else if (operation === 'delete-range' || operation === 'spin') input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
             } else if (operation === 'delete-back-single') {
                 let prevChar = inputValue.charAt(selectionEnd - 1);
                 let nextChar = inputValue.charAt(selectionEnd);
@@ -1396,19 +1399,19 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
                 }
 
                 this._group.lastIndex = 0;
-                this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
             } else if (inputValue === '-' && operation === 'insert') {
-                this.input.nativeElement.setSelectionRange(0, 0);
+                input.nativeElement.setSelectionRange(0, 0);
                 const index = this.initCursor();
                 const selectionEnd = index + insertedValueStr.length + 1;
-                this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
             } else {
                 selectionEnd = selectionEnd + (newLength - currentLength);
-                this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
             }
         }
 
-        this.input.nativeElement.setAttribute('aria-valuenow', value);
+        input.nativeElement.setAttribute('aria-valuenow', value);
     }
 
     concatValues(val1: string, val2: string) {
@@ -1449,10 +1452,10 @@ export class InputNumber extends BaseInput<InputNumberPassThrough> {
     onInputBlur(event: Event) {
         this.focused = false;
 
-        const newValueNumber = this.validateValue(this.parseValue(this.input.nativeElement.value));
+        const newValueNumber = this.validateValue(this.parseValue(this.input().nativeElement.value));
         const newValueString: any = newValueNumber?.toString();
-        this.input.nativeElement.value = this.formatValue(newValueString);
-        this.input.nativeElement.setAttribute('aria-valuenow', newValueString);
+        input.nativeElement.value = this.formatValue(newValueString);
+        input.nativeElement.setAttribute('aria-valuenow', newValueString);
         this.updateModel(event, newValueNumber);
         this.onModelTouched();
         this.onBlur.emit(event);

--- a/packages/optimus-ui/src/inputotp/inputotp.test.ts
+++ b/packages/optimus-ui/src/inputotp/inputotp.test.ts
@@ -5,6 +5,8 @@ import { By } from '@angular/platform-browser';
 import { InputOtp, InputOtpChangeEvent } from './inputotp';
 import { provideOptimus } from '@openng/optimus-ui/config';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 // Temel test component'i
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -927,5 +929,41 @@ describe('InputOtp PassThrough Tests', () => {
 
             expect(hooksCalled).toContain('onDestroy');
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [InputOtp, PrimeTemplate],
+    template: `
+        <p-inputotp>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-inputotp>
+    `
+})
+class InputOtpQueryApiHostComponent {}
+
+describe('InputOtp Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [InputOtpQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(InputOtpQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(InputOtp)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/inputotp/inputotp.test.ts
+++ b/packages/optimus-ui/src/inputotp/inputotp.test.ts
@@ -620,7 +620,7 @@ describe('InputOtp', () => {
 
         it('should have input pTemplate', () => {
             expect(inputOtpInstance).toBeTruthy();
-            expect(() => inputOtpInstance.inputTemplate).not.toThrow();
+            expect(() => inputOtpInstance.inputTemplate()).not.toThrow();
         });
 
         it('should pass context parameters to input template', async () => {
@@ -706,7 +706,7 @@ describe('InputOtp', () => {
 
         it('should have input #template', () => {
             expect(inputOtpInstance).toBeTruthy();
-            expect(() => inputOtpInstance.inputTemplate).not.toThrow();
+            expect(() => inputOtpInstance.inputTemplate()).not.toThrow();
         });
 
         it('should pass context parameters to input template', async () => {

--- a/packages/optimus-ui/src/inputotp/inputotp.ts
+++ b/packages/optimus-ui/src/inputotp/inputotp.ts
@@ -14,7 +14,6 @@ import {
     Input,
     NgModule,
     Output,
-    QueryList,
     TemplateRef,
     ViewEncapsulation,
     contentChild,
@@ -196,7 +195,7 @@ export class InputOtp extends BaseEditableHolder<InputOtpPassThrough> implements
     }
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'input':
                     this._inputTemplate = item.template;

--- a/packages/optimus-ui/src/inputotp/inputotp.ts
+++ b/packages/optimus-ui/src/inputotp/inputotp.ts
@@ -6,8 +6,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     EventEmitter,
     forwardRef,
     inject,
@@ -18,7 +16,9 @@ import {
     Output,
     QueryList,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
@@ -52,7 +52,7 @@ export { InputOtpChangeEvent, InputOtpInputTemplateContext, InputOtpTemplateEven
     imports: [CommonModule, InputText, AutoFocus, SharedModule, BindModule],
     template: `
         @for (i of getRange(length); track trackByFn($index)) {
-            @if (!inputTemplate && !_inputTemplate) {
+            @if (!inputTemplate() && !_inputTemplate) {
                 <input
                     type="text"
                     pInputText
@@ -79,8 +79,8 @@ export { InputOtpChangeEvent, InputOtpInputTemplateContext, InputOtpTemplateEven
                     [unstyled]="unstyled()"
                 />
             }
-            @if (inputTemplate || _inputTemplate) {
-                <ng-container *ngTemplateOutlet="inputTemplate || _inputTemplate; context: { $implicit: getToken(i - 1), events: getTemplateEvents(i - 1), index: i }"> </ng-container>
+            @if (inputTemplate() || _inputTemplate) {
+                <ng-container *ngTemplateOutlet="inputTemplate() || _inputTemplate; context: { $implicit: getToken(i - 1), events: getTemplateEvents(i - 1), index: i }"> </ng-container>
             }
         }
     `,
@@ -175,9 +175,9 @@ export class InputOtp extends BaseEditableHolder<InputOtpPassThrough> implements
      * @see {@link InputOtpInputTemplateContext}
      * @group Templates
      */
-    @ContentChild('input', { descendants: false }) inputTemplate: TemplateRef<InputOtpInputTemplateContext> | undefined;
+    readonly inputTemplate = contentChild<TemplateRef<InputOtpInputTemplateContext>>('input', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _inputTemplate: TemplateRef<InputOtpInputTemplateContext> | undefined;
 
@@ -196,7 +196,7 @@ export class InputOtp extends BaseEditableHolder<InputOtpPassThrough> implements
     }
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'input':
                     this._inputTemplate = item.template;

--- a/packages/optimus-ui/src/listbox/listbox.test.ts
+++ b/packages/optimus-ui/src/listbox/listbox.test.ts
@@ -9,6 +9,7 @@ import { ListboxChangeEvent } from '@openng/optimus-ui/types/listbox';
 import { BehaviorSubject, Observable, delay, of } from 'rxjs';
 import { Listbox } from './listbox';
 
+import { SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -2860,3 +2861,44 @@ class TestFormIsolationListboxComponent {
     form = new FormGroup({ value: new FormControl<string[]>([]) });
     options = ['A', 'B'];
 }
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Listbox, SharedModule],
+    template: `
+        <p-listbox [options]="opts">
+            <p-header>H</p-header>
+            <p-footer>F</p-footer>
+            <ng-template pTemplate="item">i</ng-template>
+        </p-listbox>
+    `
+})
+class ListboxQueryApiHostComponent {
+    opts = [{ label: 'a', value: 1 }];
+}
+
+describe('Listbox Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ListboxQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ListboxQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Listbox)).componentInstance;
+
+        expect(instance.headerFacet()).toBeDefined();
+        expect(instance.footerFacet()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'item')).toBe(true);
+        expect(instance.firstHiddenFocusableElement()).toBeDefined();
+        expect(instance.lastHiddenFocusableElement()).toBeDefined();
+        expect(instance.scroller()).toBeUndefined();
+        expect(instance.headerCheckboxViewChild()).toBeUndefined();
+    });
+});

--- a/packages/optimus-ui/src/listbox/listbox.test.ts
+++ b/packages/optimus-ui/src/listbox/listbox.test.ts
@@ -1775,7 +1775,6 @@ describe('Listbox ViewChild and Advanced Scenarios', () => {
             const listboxComponent = listboxElement.componentInstance;
 
             expect(listboxComponent).toBeTruthy();
-            expect(() => listboxComponent.containerViewChild).not.toThrow();
             expect(() => listboxComponent.filterViewChild).not.toThrow();
             expect(() => listboxComponent.scrollerViewChild).not.toThrow();
         });

--- a/packages/optimus-ui/src/listbox/listbox.ts
+++ b/packages/optimus-ui/src/listbox/listbox.ts
@@ -712,8 +712,6 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
 
     readonly listViewChild = viewChild<Nullable<ElementRef>>('list');
 
-    readonly containerViewChild = viewChild<Nullable<ElementRef>>('container');
-
     readonly headerFacet = contentChild(Header);
 
     readonly footerFacet = contentChild(Footer);

--- a/packages/optimus-ui/src/listbox/listbox.ts
+++ b/packages/optimus-ui/src/listbox/listbox.ts
@@ -702,7 +702,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
 
     readonly headerCheckboxViewChild = viewChild<Nullable<ElementRef>>('headerchkbox');
 
-    readonly filterViewChild = viewChild<Nullable<ElementRef>>('filter');
+    readonly filterViewChild = viewChild<Nullable<ElementRef>>('filterInput');
 
     readonly lastHiddenFocusableElement = viewChild.required<ElementRef>('lastHiddenFocusableElement');
 

--- a/packages/optimus-ui/src/listbox/listbox.ts
+++ b/packages/optimus-ui/src/listbox/listbox.ts
@@ -1161,6 +1161,8 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
     onFirstHiddenFocus(event: FocusEvent) {
         focus(this.listViewChild()?.nativeElement);
         const firstFocusableEl = getFirstFocusableElement(this.el?.nativeElement, ':not([data-p-hidden-focusable="true"])');
+        const lastHiddenFocusableElement = this.lastHiddenFocusableElement();
+        const firstHiddenFocusableElement = this.firstHiddenFocusableElement();
         lastHiddenFocusableElement?.nativeElement && (lastHiddenFocusableElement.nativeElement.tabIndex = isEmpty(firstFocusableEl) ? -1 : undefined);
         firstHiddenFocusableElement?.nativeElement && (firstHiddenFocusableElement.nativeElement.tabIndex = -1);
     }
@@ -1172,10 +1174,12 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
             const firstFocusableEl = <any>getFirstFocusableElement(this.el?.nativeElement, ':not([data-p-hidden-focusable="true"])');
 
             focus(firstFocusableEl);
+            const firstHiddenFocusableElement = this.firstHiddenFocusableElement();
             firstHiddenFocusableElement?.nativeElement && (firstHiddenFocusableElement.nativeElement.tabIndex = undefined);
         } else {
             focus(this.firstHiddenFocusableElement()?.nativeElement);
         }
+        const lastHiddenFocusableElement = this.lastHiddenFocusableElement();
         lastHiddenFocusableElement?.nativeElement && (lastHiddenFocusableElement.nativeElement.tabIndex = -1);
     }
 

--- a/packages/optimus-ui/src/listbox/listbox.ts
+++ b/packages/optimus-ui/src/listbox/listbox.ts
@@ -3,8 +3,6 @@ import { CommonModule } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     HostListener,
@@ -12,9 +10,7 @@ import {
     Input,
     NgModule,
     Output,
-    QueryList,
     TemplateRef,
-    ViewChild,
     ViewEncapsulation,
     booleanAttribute,
     computed,
@@ -22,7 +18,10 @@ import {
     inject,
     input,
     numberAttribute,
-    signal
+    signal,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { equals, findLastIndex, findSingle, focus, getFirstFocusableElement, isEmpty, isFunction, isNotEmpty, isPrintableCharacter, resolveFieldData, uuid } from '@openng/optimus-ui-utils';
@@ -84,9 +83,9 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
             [pBind]="ptm('hiddenFirstFocusableElement')"
         >
         </span>
-        <div [class]="cx('header')" *ngIf="headerFacet || headerTemplate || _headerTemplate" [pBind]="ptm('header')">
+        <div [class]="cx('header')" *ngIf="headerFacet() || headerTemplate() || _headerTemplate" [pBind]="ptm('header')">
             <ng-content select="p-header"></ng-content>
-            <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate; context: { $implicit: modelValue(), options: visibleOptions() }"></ng-container>
+            <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate; context: { $implicit: modelValue(), options: visibleOptions() }"></ng-container>
         </div>
         <div [class]="cx('header')" *ngIf="(checkbox && multiple && showToggleAll) || filter" [pBind]="ptm('header')">
             <p-checkbox
@@ -104,14 +103,14 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
                 [pt]="ptm('pcCheckbox')"
                 [unstyled]="unstyled()"
             >
-                <ng-container *ngIf="checkIconTemplate || _checkIconTemplate">
+                <ng-container *ngIf="checkIconTemplate() || _checkIconTemplate">
                     <ng-template #icon>
-                        <ng-template *ngTemplateOutlet="checkIconTemplate || _checkIconTemplate; context: { $implicit: allSelected() }"></ng-template>
+                        <ng-template *ngTemplateOutlet="checkIconTemplate() || _checkIconTemplate; context: { $implicit: allSelected() }"></ng-template>
                     </ng-template>
                 </ng-container>
             </p-checkbox>
-            <ng-container *ngIf="filterTemplate || _filterTemplate; else builtInFilterElement">
-                <ng-container *ngTemplateOutlet="filterTemplate || _filterTemplate; context: { options: filterOptions }"></ng-container>
+            <ng-container *ngIf="filterTemplate() || _filterTemplate; else builtInFilterElement">
+                <ng-container *ngTemplateOutlet="filterTemplate() || _filterTemplate; context: { options: filterOptions }"></ng-container>
             </ng-container>
             <ng-template #builtInFilterElement>
                 @if (filter) {
@@ -137,9 +136,9 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
                             hostName="listbox"
                         />
                         <p-inputicon [pt]="ptm('pcFilterIconContainer')" [unstyled]="unstyled()">
-                            <svg data-p-icon="search" *ngIf="!filterIconTemplate && !_filterIconTemplate" [attr.aria-hidden]="true" [pBind]="ptm('filterIcon')" />
-                            <span *ngIf="filterIconTemplate || _filterIconTemplate" [attr.aria-hidden]="true">
-                                <ng-template *ngTemplateOutlet="filterIconTemplate || _filterIconTemplate"></ng-template>
+                            <svg data-p-icon="search" *ngIf="!filterIconTemplate() && !_filterIconTemplate" [attr.aria-hidden]="true" [pBind]="ptm('filterIcon')" />
+                            <span *ngIf="filterIconTemplate() || _filterIconTemplate" [attr.aria-hidden]="true">
+                                <ng-template *ngTemplateOutlet="filterIconTemplate() || _filterIconTemplate"></ng-template>
                             </span>
                         </p-inputicon>
                     </p-iconfield>
@@ -163,18 +162,18 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
         >
             @if (hasFilter() && isEmpty()) {
                 <div [class]="cx('emptyMessage')" [pBind]="ptm('emptyMessage')">
-                    @if (!emptyFilterTemplate && !_emptyFilterTemplate && !_emptyTemplate && !emptyTemplate) {
+                    @if (!emptyFilterTemplate() && !_emptyFilterTemplate && !_emptyTemplate && !emptyTemplate()) {
                         {{ emptyFilterMessageText }}
                     } @else {
-                        <ng-container #emptyFilter *ngTemplateOutlet="emptyFilterTemplate || _emptyFilterTemplate || _emptyTemplate || emptyTemplate"></ng-container>
+                        <ng-container #emptyFilter *ngTemplateOutlet="emptyFilterTemplate() || _emptyFilterTemplate || _emptyTemplate || emptyTemplate()"></ng-container>
                     }
                 </div>
             } @else if (!hasFilter() && isEmpty()) {
                 <div [class]="cx('emptyMessage')" [pBind]="ptm('emptyMessage')">
-                    @if (!emptyTemplate && !_emptyTemplate) {
+                    @if (!emptyTemplate() && !_emptyTemplate) {
                         {{ emptyMessage }}
                     } @else {
-                        <ng-container #empty *ngTemplateOutlet="emptyTemplate || _emptyTemplate"></ng-container>
+                        <ng-container #empty *ngTemplateOutlet="emptyTemplate() || _emptyTemplate"></ng-container>
                     }
                 </div>
             } @else {
@@ -195,9 +194,9 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
                     <ng-template #content let-items let-scrollerOptions="options">
                         <ng-container *ngTemplateOutlet="buildInItems; context: { $implicit: items, options: scrollerOptions }"></ng-container>
                     </ng-template>
-                    @if (loaderTemplate || _loaderTemplate) {
+                    @if (loaderTemplate() || _loaderTemplate) {
                         <ng-template #loader let-scrollerOptions="options">
-                            <ng-container *ngTemplateOutlet="loaderTemplate || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
+                            <ng-container *ngTemplateOutlet="loaderTemplate() || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
                         </ng-template>
                     }
                 </p-scroller>
@@ -237,8 +236,8 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
                                     (cdkDragStarted)="isDragging.set(true)"
                                     (cdkDragEnded)="isDragging.set(false)"
                                 >
-                                    <span *ngIf="!groupTemplate && !_groupTemplate">{{ getOptionGroupLabel(option.optionGroup) }}</span>
-                                    <ng-container *ngTemplateOutlet="groupTemplate || _groupTemplate; context: { $implicit: option.optionGroup }"></ng-container>
+                                    <span *ngIf="!groupTemplate() && !_groupTemplate">{{ getOptionGroupLabel(option.optionGroup) }}</span>
+                                    <ng-container *ngTemplateOutlet="groupTemplate() || _groupTemplate; context: { $implicit: option.optionGroup }"></ng-container>
                                 </li>
                             </ng-container>
                             <ng-container *ngIf="!isOptionGroup(option)">
@@ -282,23 +281,23 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
                                         hostName="listbox"
                                         [unstyled]="unstyled()"
                                     >
-                                        <ng-container *ngIf="checkIconTemplate || _checkIconTemplate">
+                                        <ng-container *ngIf="checkIconTemplate() || _checkIconTemplate">
                                             <ng-template #icon>
-                                                <ng-template *ngTemplateOutlet="checkIconTemplate || _checkIconTemplate; context: { $implicit: isSelected(option) }"></ng-template>
+                                                <ng-template *ngTemplateOutlet="checkIconTemplate() || _checkIconTemplate; context: { $implicit: isSelected(option) }"></ng-template>
                                             </ng-template>
                                         </ng-container>
                                     </p-checkbox>
                                     <ng-container *ngIf="checkmark">
-                                        <ng-container *ngIf="!checkmarkTemplate && !_checkmarkTemplate">
+                                        <ng-container *ngIf="!checkmarkTemplate() && !_checkmarkTemplate">
                                             <svg data-p-icon="blank" *ngIf="!isSelected(option)" [class]="cx('optionBlankIcon')" [pBind]="ptm('optionBlankIcon')" />
                                             <svg data-p-icon="check" *ngIf="isSelected(option)" [class]="cx('optionCheckIcon')" [pBind]="ptm('optionCheckIcon')" />
                                         </ng-container>
-                                        <ng-container *ngTemplateOutlet="checkmarkTemplate || _checkmarkTemplate; context: { implicit: isSelected(option) }"></ng-container>
+                                        <ng-container *ngTemplateOutlet="checkmarkTemplate() || _checkmarkTemplate; context: { implicit: isSelected(option) }"></ng-container>
                                     </ng-container>
-                                    <span *ngIf="!itemTemplate && !_itemTemplate">{{ getOptionLabel(option) }}</span>
+                                    <span *ngIf="!itemTemplate() && !_itemTemplate">{{ getOptionLabel(option) }}</span>
                                     <ng-container
                                         *ngTemplateOutlet="
-                                            itemTemplate || _itemTemplate;
+                                            itemTemplate() || _itemTemplate;
                                             context: {
                                                 $implicit: option,
                                                 index: getOptionIndex(i, scrollerOptions),
@@ -314,9 +313,9 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
                 </ng-template>
             }
         </div>
-        <div *ngIf="footerFacet || footerTemplate || _footerTemplate">
+        <div *ngIf="footerFacet() || footerTemplate() || _footerTemplate">
             <ng-content select="p-footer"></ng-content>
-            <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate; context: { $implicit: modelValue(), options: visibleOptions() }"></ng-container>
+            <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate; context: { $implicit: modelValue(), options: visibleOptions() }"></ng-container>
         </div>
         <span *ngIf="isEmpty()" role="status" aria-live="polite" class="p-hidden-accessible" [pBind]="ptm('hiddenEmptyMessage')">
             {{ emptyMessage }}
@@ -701,23 +700,23 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
      */
     @Output() onDrop: EventEmitter<CdkDragDrop<string[]>> = new EventEmitter<CdkDragDrop<string[]>>();
 
-    @ViewChild('headerchkbox') headerCheckboxViewChild: Nullable<ElementRef>;
+    readonly headerCheckboxViewChild = viewChild<Nullable<ElementRef>>('headerchkbox');
 
-    @ViewChild('filter') filterViewChild: Nullable<ElementRef>;
+    readonly filterViewChild = viewChild<Nullable<ElementRef>>('filter');
 
-    @ViewChild('lastHiddenFocusableElement') lastHiddenFocusableElement: Nullable<ElementRef>;
+    readonly lastHiddenFocusableElement = viewChild<Nullable<ElementRef>>('lastHiddenFocusableElement');
 
-    @ViewChild('firstHiddenFocusableElement') firstHiddenFocusableElement: Nullable<ElementRef>;
+    readonly firstHiddenFocusableElement = viewChild<Nullable<ElementRef>>('firstHiddenFocusableElement');
 
-    @ViewChild('scroller') scroller: Nullable<Scroller>;
+    readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
-    @ViewChild('list') listViewChild: Nullable<ElementRef>;
+    readonly listViewChild = viewChild<Nullable<ElementRef>>('list');
 
-    @ViewChild('container') containerViewChild: Nullable<ElementRef>;
+    readonly containerViewChild = viewChild<Nullable<ElementRef>>('container');
 
-    @ContentChild(Header) headerFacet: Nullable<TemplateRef<any>>;
+    readonly headerFacet = contentChild(Header);
 
-    @ContentChild(Footer) footerFacet: Nullable<TemplateRef<any>>;
+    readonly footerFacet = contentChild(Footer);
 
     /**
      * Custom item template.
@@ -725,7 +724,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
      * @see {@link ListboxItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<ListboxItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<ListboxItemTemplateContext>>('item', { descendants: false });
 
     /**
      * Custom group template.
@@ -733,7 +732,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
      * @see {@link ListboxGroupTemplateContext}
      * @group Templates
      */
-    @ContentChild('group', { descendants: false }) groupTemplate: TemplateRef<ListboxGroupTemplateContext> | undefined;
+    readonly groupTemplate = contentChild<TemplateRef<ListboxGroupTemplateContext>>('group', { descendants: false });
 
     /**
      * Custom header template.
@@ -741,7 +740,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
      * @see {@link ListboxHeaderTemplateContext}
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<ListboxHeaderTemplateContext> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<ListboxHeaderTemplateContext>>('header', { descendants: false });
 
     /**
      * Custom filter template.
@@ -749,7 +748,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
      * @see {@link ListboxFilterTemplateContext}
      * @group Templates
      */
-    @ContentChild('filter', { descendants: false }) filterTemplate: TemplateRef<ListboxFilterTemplateContext> | undefined;
+    readonly filterTemplate = contentChild<TemplateRef<ListboxFilterTemplateContext>>('filter', { descendants: false });
 
     /**
      * Custom footer template.
@@ -757,25 +756,25 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
      * @see {@link ListboxFooterTemplateContext}
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: TemplateRef<ListboxFooterTemplateContext> | undefined;
+    readonly footerTemplate = contentChild<TemplateRef<ListboxFooterTemplateContext>>('footer', { descendants: false });
 
     /**
      * Custom empty filter message template.
      * @group Templates
      */
-    @ContentChild('emptyfilter', { descendants: false }) emptyFilterTemplate: TemplateRef<void> | undefined;
+    readonly emptyFilterTemplate = contentChild<TemplateRef<void>>('emptyfilter', { descendants: false });
 
     /**
      * Custom empty message template.
      * @group Templates
      */
-    @ContentChild('empty', { descendants: false }) emptyTemplate: TemplateRef<void> | undefined;
+    readonly emptyTemplate = contentChild<TemplateRef<void>>('empty', { descendants: false });
 
     /**
      * Custom filter icon template.
      * @group Templates
      */
-    @ContentChild('filtericon', { descendants: false }) filterIconTemplate: TemplateRef<void> | undefined;
+    readonly filterIconTemplate = contentChild<TemplateRef<void>>('filtericon', { descendants: false });
 
     /**
      * Custom check icon template.
@@ -783,7 +782,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
      * @see {@link ListboxCheckIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('checkicon', { descendants: false }) checkIconTemplate: TemplateRef<ListboxCheckIconTemplateContext> | undefined;
+    readonly checkIconTemplate = contentChild<TemplateRef<ListboxCheckIconTemplateContext>>('checkicon', { descendants: false });
 
     /**
      * Custom checkmark icon template.
@@ -791,7 +790,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
      * @see {@link ListboxCheckmarkTemplateContext}
      * @group Templates
      */
-    @ContentChild('checkmark', { descendants: false }) checkmarkTemplate: TemplateRef<ListboxCheckmarkTemplateContext> | undefined;
+    readonly checkmarkTemplate = contentChild<TemplateRef<ListboxCheckmarkTemplateContext>>('checkmark', { descendants: false });
 
     /**
      * Custom loader template.
@@ -799,9 +798,9 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
      * @see {@link ListboxLoaderTemplateContext}
      * @group Templates
      */
-    @ContentChild('loader', { descendants: false }) loaderTemplate: TemplateRef<ListboxLoaderTemplateContext> | undefined;
+    readonly loaderTemplate = contentChild<TemplateRef<ListboxLoaderTemplateContext>>('loader', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _itemTemplate: TemplateRef<ListboxItemTemplateContext> | undefined;
 
@@ -938,7 +937,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -1106,7 +1105,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
         if (this.$disabled() || this.readonly) {
             return;
         }
-        focus(this.headerCheckboxViewChild?.nativeElement);
+        focus(this.headerCheckboxViewChild()?.nativeElement);
 
         if (this.selectAll !== null) {
             this.onSelectAllChange.emit({
@@ -1160,29 +1159,31 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
     }
 
     onFirstHiddenFocus(event: FocusEvent) {
-        focus(this.listViewChild?.nativeElement);
+        focus(this.listViewChild()?.nativeElement);
         const firstFocusableEl = getFirstFocusableElement(this.el?.nativeElement, ':not([data-p-hidden-focusable="true"])');
-        this.lastHiddenFocusableElement?.nativeElement && (this.lastHiddenFocusableElement.nativeElement.tabIndex = isEmpty(firstFocusableEl) ? -1 : undefined);
-        this.firstHiddenFocusableElement?.nativeElement && (this.firstHiddenFocusableElement.nativeElement.tabIndex = -1);
+        lastHiddenFocusableElement?.nativeElement && (lastHiddenFocusableElement.nativeElement.tabIndex = isEmpty(firstFocusableEl) ? -1 : undefined);
+        firstHiddenFocusableElement?.nativeElement && (firstHiddenFocusableElement.nativeElement.tabIndex = -1);
     }
 
     onLastHiddenFocus(event: FocusEvent) {
         const relatedTarget = event.relatedTarget;
 
-        if (relatedTarget === this.listViewChild?.nativeElement) {
+        if (relatedTarget === this.listViewChild()?.nativeElement) {
             const firstFocusableEl = <any>getFirstFocusableElement(this.el?.nativeElement, ':not([data-p-hidden-focusable="true"])');
 
             focus(firstFocusableEl);
-            this.firstHiddenFocusableElement?.nativeElement && (this.firstHiddenFocusableElement.nativeElement.tabIndex = undefined);
+            firstHiddenFocusableElement?.nativeElement && (firstHiddenFocusableElement.nativeElement.tabIndex = undefined);
         } else {
-            focus(this.firstHiddenFocusableElement?.nativeElement);
+            focus(this.firstHiddenFocusableElement()?.nativeElement);
         }
-        this.lastHiddenFocusableElement?.nativeElement && (this.lastHiddenFocusableElement.nativeElement.tabIndex = -1);
+        lastHiddenFocusableElement?.nativeElement && (lastHiddenFocusableElement.nativeElement.tabIndex = -1);
     }
 
     onFocusout(event: FocusEvent) {
-        if (!this.el.nativeElement.contains(event.relatedTarget) && this.lastHiddenFocusableElement && this.firstHiddenFocusableElement) {
-            this.firstHiddenFocusableElement.nativeElement.tabIndex = this.lastHiddenFocusableElement.nativeElement.tabIndex = undefined;
+        const lastHiddenFocusableElement = this.lastHiddenFocusableElement();
+        const firstHiddenFocusableElement = this.firstHiddenFocusableElement();
+        if (!this.el.nativeElement.contains(event.relatedTarget) && lastHiddenFocusableElement && firstHiddenFocusableElement) {
+            firstHiddenFocusableElement.nativeElement.tabIndex = lastHiddenFocusableElement.nativeElement.tabIndex = undefined;
             this.scrollerTabIndex = '0';
         }
     }
@@ -1228,7 +1229,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
     }
 
     onHeaderCheckboxTabKeyDown(event) {
-        focus(this.listViewChild?.nativeElement);
+        focus(this.listViewChild()?.nativeElement);
         event.preventDefault();
     }
 
@@ -1239,7 +1240,7 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
         this.startRangeIndex.set(-1);
         this.onFilter.emit({ originalEvent: event, filter: this._filterValue() });
 
-        !this.virtualScrollerDisabled && this.scroller?.scrollToIndex(0);
+        !this.virtualScrollerDisabled && this.scroller()?.scrollToIndex(0);
     }
 
     onFilterBlur(event: FocusEvent) {
@@ -1551,12 +1552,12 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
 
     scrollInView(index = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
-        const element = findSingle(this.listViewChild?.nativeElement, `li[id="${id}"]`);
+        const element = findSingle(this.listViewChild()?.nativeElement, `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
         } else if (!this.virtualScrollerDisabled) {
-            this.virtualScroll && this.scroller?.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex());
+            this.virtualScroll && this.scroller()?.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex());
         }
     }
 
@@ -1694,8 +1695,9 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
     }
 
     resetFilter() {
-        if (this.filterViewChild && this.filterViewChild.nativeElement) {
-            this.filterViewChild.nativeElement.value = '';
+        const filterViewChild = this.filterViewChild();
+        if (filterViewChild && filterViewChild.nativeElement) {
+            filterViewChild.nativeElement.value = '';
         }
 
         this._filterValue.set(null);

--- a/packages/optimus-ui/src/listbox/listbox.ts
+++ b/packages/optimus-ui/src/listbox/listbox.ts
@@ -704,9 +704,9 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
 
     readonly filterViewChild = viewChild<Nullable<ElementRef>>('filter');
 
-    readonly lastHiddenFocusableElement = viewChild<Nullable<ElementRef>>('lastHiddenFocusableElement');
+    readonly lastHiddenFocusableElement = viewChild.required<ElementRef>('lastHiddenFocusableElement');
 
-    readonly firstHiddenFocusableElement = viewChild<Nullable<ElementRef>>('firstHiddenFocusableElement');
+    readonly firstHiddenFocusableElement = viewChild.required<ElementRef>('firstHiddenFocusableElement');
 
     readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
@@ -1161,8 +1161,8 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
         const firstFocusableEl = getFirstFocusableElement(this.el?.nativeElement, ':not([data-p-hidden-focusable="true"])');
         const lastHiddenFocusableElement = this.lastHiddenFocusableElement();
         const firstHiddenFocusableElement = this.firstHiddenFocusableElement();
-        lastHiddenFocusableElement?.nativeElement && (lastHiddenFocusableElement.nativeElement.tabIndex = isEmpty(firstFocusableEl) ? -1 : undefined);
-        firstHiddenFocusableElement?.nativeElement && (firstHiddenFocusableElement.nativeElement.tabIndex = -1);
+        lastHiddenFocusableElement.nativeElement.tabIndex = isEmpty(firstFocusableEl) ? -1 : undefined;
+        firstHiddenFocusableElement.nativeElement.tabIndex = -1;
     }
 
     onLastHiddenFocus(event: FocusEvent) {
@@ -1172,19 +1172,17 @@ export class Listbox extends BaseEditableHolder<ListBoxPassThrough> {
             const firstFocusableEl = <any>getFirstFocusableElement(this.el?.nativeElement, ':not([data-p-hidden-focusable="true"])');
 
             focus(firstFocusableEl);
-            const firstHiddenFocusableElement = this.firstHiddenFocusableElement();
-            firstHiddenFocusableElement?.nativeElement && (firstHiddenFocusableElement.nativeElement.tabIndex = undefined);
+            this.firstHiddenFocusableElement().nativeElement.tabIndex = undefined;
         } else {
-            focus(this.firstHiddenFocusableElement()?.nativeElement);
+            focus(this.firstHiddenFocusableElement().nativeElement);
         }
-        const lastHiddenFocusableElement = this.lastHiddenFocusableElement();
-        lastHiddenFocusableElement?.nativeElement && (lastHiddenFocusableElement.nativeElement.tabIndex = -1);
+        this.lastHiddenFocusableElement().nativeElement.tabIndex = -1;
     }
 
     onFocusout(event: FocusEvent) {
         const lastHiddenFocusableElement = this.lastHiddenFocusableElement();
         const firstHiddenFocusableElement = this.firstHiddenFocusableElement();
-        if (!this.el.nativeElement.contains(event.relatedTarget) && lastHiddenFocusableElement && firstHiddenFocusableElement) {
+        if (!this.el.nativeElement.contains(event.relatedTarget)) {
             firstHiddenFocusableElement.nativeElement.tabIndex = lastHiddenFocusableElement.nativeElement.tabIndex = undefined;
             this.scrollerTabIndex = '0';
         }

--- a/packages/optimus-ui/src/megamenu/megamenu.test.ts
+++ b/packages/optimus-ui/src/megamenu/megamenu.test.ts
@@ -7,6 +7,7 @@ import { MegaMenuItem, SharedModule } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { MegaMenu } from './megamenu';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1740,5 +1741,40 @@ describe('MegaMenu', () => {
                 }
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [MegaMenu, SharedModule],
+    template: `
+        <p-megamenu [model]="model">
+            <ng-template #submenuicon>si</ng-template>
+        </p-megamenu>
+    `
+})
+class MegaMenuQueryApiHostComponent {
+    model = [{ label: 'a' }];
+}
+
+describe('MegaMenu Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [MegaMenuQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(MegaMenuQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(MegaMenu)).componentInstance;
+
+        expect(instance.submenuIconTemplate()).toBeDefined();
+        expect(instance.rootmenu()).toBeDefined();
+        expect(instance.menubuttonViewChild()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/megamenu/megamenu.ts
+++ b/packages/optimus-ui/src/megamenu/megamenu.ts
@@ -531,11 +531,6 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
      */
     readonly endTemplate = contentChild<TemplateRef<void>>('end', { descendants: false });
     /**
-     * Defines template option for menu icon.
-     * @group Templates
-     */
-    readonly menuIconTemplate = contentChild<TemplateRef<void>>('menuicon', { descendants: false });
-    /**
      * Defines template option for submenu icon.
      * @group Templates
      */

--- a/packages/optimus-ui/src/megamenu/megamenu.ts
+++ b/packages/optimus-ui/src/megamenu/megamenu.ts
@@ -3,8 +3,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     effect,
     ElementRef,
     EventEmitter,
@@ -15,11 +13,12 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren,
+    viewChild
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { findLastIndex, findSingle, focus, isEmpty, isNotEmpty, isPrintableCharacter, isTouchDevice, resolve, uuid } from '@openng/optimus-ui-utils';
@@ -114,7 +113,7 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
                                         <p-badge [class]="getItemProp(processedItem, 'badgeStyleClass')" [value]="getItemProp(processedItem, 'badge')" [unstyled]="unstyled()" />
                                     }
                                     @if (isItemGroup(processedItem)) {
-                                        @if (!megaMenu.submenuIconTemplate && !megaMenu._submenuIconTemplate) {
+                                        @if (!megaMenu.submenuIconTemplate() && !megaMenu._submenuIconTemplate) {
                                             @if (orientation === 'horizontal' || mobileActive) {
                                                 <svg data-p-icon="angle-down" [class]="cx('submenuIcon')" [pBind]="getPTOptions(processedItem, index, 'submenuIcon')" [attr.aria-hidden]="true" />
                                             } @else {
@@ -123,7 +122,7 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
                                                 }
                                             }
                                         }
-                                        <ng-template *ngTemplateOutlet="megaMenu.submenuIconTemplate || megaMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
+                                        <ng-template *ngTemplateOutlet="megaMenu.submenuIconTemplate() || megaMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
                                     }
                                 </a>
                             }
@@ -172,7 +171,7 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
                                         <p-badge [styleClass]="getItemProp(processedItem, 'badgeStyleClass')" [value]="getItemProp(processedItem, 'badge')" [unstyled]="unstyled()" />
                                     }
                                     @if (isItemGroup(processedItem)) {
-                                        @if (!megaMenu.submenuIconTemplate && !megaMenu._submenuIconTemplate) {
+                                        @if (!megaMenu.submenuIconTemplate() && !megaMenu._submenuIconTemplate) {
                                             @if (orientation === 'horizontal') {
                                                 <svg data-p-icon="angle-down" [class]="cx('submenuIcon')" [pBind]="getPTOptions(processedItem, index, 'submenuIcon')" [attr.aria-hidden]="true" />
                                             }
@@ -180,7 +179,7 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
                                                 <svg data-p-icon="angle-right" [class]="cx('submenuIcon')" [pBind]="getPTOptions(processedItem, index, 'submenuIcon')" [attr.aria-hidden]="true" />
                                             }
                                         }
-                                        <ng-template *ngTemplateOutlet="megaMenu.submenuIconTemplate || megaMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
+                                        <ng-template *ngTemplateOutlet="megaMenu.submenuIconTemplate() || megaMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
                                     }
                                 </a>
                             }
@@ -389,12 +388,12 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
     standalone: true,
     imports: [CommonModule, RouterModule, MegaMenuSub, TooltipModule, BarsIcon, BadgeModule, SharedModule, Bind],
     template: `
-        @if (startTemplate || _startTemplate) {
+        @if (startTemplate() || _startTemplate) {
             <div [class]="cx('start')" [pBind]="ptm('start')">
-                <ng-container *ngTemplateOutlet="startTemplate || _startTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="startTemplate() || _startTemplate"></ng-container>
             </div>
         }
-        @if (!buttonTemplate && !_buttonTemplate) {
+        @if (!buttonTemplate() && !_buttonTemplate) {
             @if (model && model.length > 0) {
                 <a
                     #menubutton
@@ -409,18 +408,18 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
                     (click)="menuButtonClick($event)"
                     (keydown)="menuButtonKeydown($event)"
                 >
-                    @if (!buttonIconTemplate && !_buttonIconTemplate) {
+                    @if (!buttonIconTemplate() && !_buttonIconTemplate) {
                         <svg data-p-icon="bars" [pBind]="ptm('buttonIcon')" />
                     }
-                    <ng-template *ngTemplateOutlet="buttonIconTemplate || _buttonIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="buttonIconTemplate() || _buttonIconTemplate"></ng-template>
                 </a>
             }
         }
-        <ng-container *ngTemplateOutlet="buttonTemplate || _buttonTemplate"></ng-container>
+        <ng-container *ngTemplateOutlet="buttonTemplate() || _buttonTemplate"></ng-container>
         <ul
             pMegaMenuSub
             #rootmenu
-            [itemTemplate]="itemTemplate || _itemTemplate"
+            [itemTemplate]="itemTemplate() || _itemTemplate"
             [items]="processedItems"
             [attr.id]="id + '_list'"
             [menuId]="id"
@@ -445,9 +444,9 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
             [pt]="pt()"
             [unstyled]="unstyled()"
         ></ul>
-        @if (endTemplate || _endTemplate) {
+        @if (endTemplate() || _endTemplate) {
             <div [class]="cx('end')" [pBind]="ptm('end')">
-                <ng-container *ngTemplateOutlet="endTemplate || _endTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="endTemplate() || _endTemplate"></ng-container>
             </div>
         }
     `,
@@ -525,45 +524,45 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
      * Defines template option for start.
      * @group Templates
      */
-    @ContentChild('start', { descendants: false }) startTemplate: TemplateRef<void> | undefined;
+    readonly startTemplate = contentChild<TemplateRef<void>>('start', { descendants: false });
     /**
      * Defines template option for end.
      * @group Templates
      */
-    @ContentChild('end', { descendants: false }) endTemplate: TemplateRef<void> | undefined;
+    readonly endTemplate = contentChild<TemplateRef<void>>('end', { descendants: false });
     /**
      * Defines template option for menu icon.
      * @group Templates
      */
-    @ContentChild('menuicon', { descendants: false }) menuIconTemplate: TemplateRef<void> | undefined;
+    readonly menuIconTemplate = contentChild<TemplateRef<void>>('menuicon', { descendants: false });
     /**
      * Defines template option for submenu icon.
      * @group Templates
      */
-    @ContentChild('submenuicon', { descendants: false }) submenuIconTemplate: TemplateRef<void> | undefined;
+    readonly submenuIconTemplate = contentChild<TemplateRef<void>>('submenuicon', { descendants: false });
     /**
      * Custom item template.
      * @param {MegaMenuItemTemplateContext} context - item context.
      * @see {@link MegaMenuItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<MegaMenuItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<MegaMenuItemTemplateContext>>('item', { descendants: false });
     /**
      * Custom menu button template on responsive mode.
      * @group Templates
      */
-    @ContentChild('button', { descendants: false }) buttonTemplate: TemplateRef<void> | undefined;
+    readonly buttonTemplate = contentChild<TemplateRef<void>>('button', { descendants: false });
     /**
      * Custom menu button icon template on responsive mode.
      * @group Templates
      */
-    @ContentChild('buttonicon', { descendants: false }) buttonIconTemplate: TemplateRef<void> | undefined;
+    readonly buttonIconTemplate = contentChild<TemplateRef<void>>('buttonicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
-    @ViewChild('menubutton') menubuttonViewChild: ElementRef | undefined;
+    readonly menubuttonViewChild = viewChild<ElementRef>('menubutton');
 
-    @ViewChild('rootmenu') rootmenu: MegaMenuSub | undefined;
+    readonly rootmenu = viewChild<MegaMenuSub>('rootmenu');
 
     _startTemplate: TemplateRef<void> | undefined;
 
@@ -661,7 +660,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'start':
                     this._startTemplate = item.template;
@@ -768,7 +767,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
 
             this.dirty = !root;
             if (!this.mobileActive) {
-                focus(this.rootmenu?.el?.nativeElement, { preventScroll: true });
+                focus(this.rootmenu()?.el?.nativeElement, { preventScroll: true });
             }
         } else {
             if (grouped) {
@@ -796,11 +795,11 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     toggle(event: MouseEvent) {
         if (this.mobileActive) {
             this.mobileActive = false;
-            ZIndexUtils.clear(this.rootmenu?.el.nativeElement);
+            ZIndexUtils.clear(this.rootmenu()?.el.nativeElement);
             this.hide();
         } else {
             this.mobileActive = true;
-            ZIndexUtils.set('menu', this.rootmenu?.el.nativeElement, this.config.zIndex.menu);
+            ZIndexUtils.set('menu', this.rootmenu()?.el.nativeElement, this.config.zIndex.menu);
             setTimeout(() => {
                 this.show();
             }, 0);
@@ -813,7 +812,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     show() {
         this.focusedItemInfo.set({ index: this.findFirstFocusedItemIndex(), level: 0, parentKey: '' });
 
-        focus(this.rootmenu?.el.nativeElement);
+        focus(this.rootmenu()?.el.nativeElement);
     }
 
     scrollInView(index: number = -1) {
@@ -822,9 +821,9 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
         let element;
 
         if (id === null && this.queryMatches()) {
-            element = this.menubuttonViewChild?.nativeElement;
+            element = this.menubuttonViewChild()?.nativeElement;
         } else {
-            element = findSingle(this.rootmenu?.el?.nativeElement, `li[id="${id}"]`);
+            element = findSingle(this.rootmenu()?.el?.nativeElement, `li[id="${id}"]`);
         }
 
         if (element) {
@@ -846,14 +845,14 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
         this.focusedItemInfo.set({ index, key, parentKey, item });
 
         grouped && (this.dirty = true);
-        isFocus && focus(this.rootmenu?.el?.nativeElement);
+        isFocus && focus(this.rootmenu()?.el?.nativeElement);
     }
 
     hide(event?, isFocus?: boolean) {
         if (this.mobileActive) {
             this.mobileActive = false;
             setTimeout(() => {
-                focus(this.menubuttonViewChild?.nativeElement);
+                focus(this.menubuttonViewChild()?.nativeElement);
                 this.scrollInView();
             }, 100);
         }
@@ -861,7 +860,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
         this.activeItem.set(null);
         this.focusedItemInfo.set({ index: -1, key: '', parentKey: '', item: null });
 
-        isFocus && focus(this.rootmenu?.el?.nativeElement);
+        isFocus && focus(this.rootmenu()?.el?.nativeElement);
         this.dirty = false;
     }
 
@@ -1223,7 +1222,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
 
     onEnterKey(event: KeyboardEvent) {
         if (this.focusedItemInfo().index !== -1) {
-            const element = <any>findSingle(this.rootmenu?.el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+            const element = <any>findSingle(this.rootmenu()?.el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
             const anchorElement = element && (<any>findSingle(element, '[data-pc-section="itemlink"]') || findSingle(element, 'a,button'));
 
             anchorElement ? anchorElement.click() : element && element.click();

--- a/packages/optimus-ui/src/megamenu/megamenu.ts
+++ b/packages/optimus-ui/src/megamenu/megamenu.ts
@@ -557,7 +557,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
 
     readonly menubuttonViewChild = viewChild<ElementRef>('menubutton');
 
-    readonly rootmenu = viewChild<MegaMenuSub>('rootmenu');
+    readonly rootmenu = viewChild.required<MegaMenuSub>('rootmenu');
 
     _startTemplate: TemplateRef<void> | undefined;
 
@@ -762,7 +762,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
 
             this.dirty = !root;
             if (!this.mobileActive) {
-                focus(this.rootmenu()?.el?.nativeElement, { preventScroll: true });
+                focus(this.rootmenu().el?.nativeElement, { preventScroll: true });
             }
         } else {
             if (grouped) {
@@ -790,11 +790,11 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     toggle(event: MouseEvent) {
         if (this.mobileActive) {
             this.mobileActive = false;
-            ZIndexUtils.clear(this.rootmenu()?.el.nativeElement);
+            ZIndexUtils.clear(this.rootmenu().el.nativeElement);
             this.hide();
         } else {
             this.mobileActive = true;
-            ZIndexUtils.set('menu', this.rootmenu()?.el.nativeElement, this.config.zIndex.menu);
+            ZIndexUtils.set('menu', this.rootmenu().el.nativeElement, this.config.zIndex.menu);
             setTimeout(() => {
                 this.show();
             }, 0);
@@ -807,7 +807,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     show() {
         this.focusedItemInfo.set({ index: this.findFirstFocusedItemIndex(), level: 0, parentKey: '' });
 
-        focus(this.rootmenu()?.el.nativeElement);
+        focus(this.rootmenu().el.nativeElement);
     }
 
     scrollInView(index: number = -1) {
@@ -818,7 +818,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
         if (id === null && this.queryMatches()) {
             element = this.menubuttonViewChild()?.nativeElement;
         } else {
-            element = findSingle(this.rootmenu()?.el?.nativeElement, `li[id="${id}"]`);
+            element = findSingle(this.rootmenu().el?.nativeElement, `li[id="${id}"]`);
         }
 
         if (element) {
@@ -840,7 +840,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
         this.focusedItemInfo.set({ index, key, parentKey, item });
 
         grouped && (this.dirty = true);
-        isFocus && focus(this.rootmenu()?.el?.nativeElement);
+        isFocus && focus(this.rootmenu().el?.nativeElement);
     }
 
     hide(event?, isFocus?: boolean) {
@@ -855,7 +855,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
         this.activeItem.set(null);
         this.focusedItemInfo.set({ index: -1, key: '', parentKey: '', item: null });
 
-        isFocus && focus(this.rootmenu()?.el?.nativeElement);
+        isFocus && focus(this.rootmenu().el?.nativeElement);
         this.dirty = false;
     }
 
@@ -1217,7 +1217,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
 
     onEnterKey(event: KeyboardEvent) {
         if (this.focusedItemInfo().index !== -1) {
-            const element = <any>findSingle(this.rootmenu()?.el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+            const element = <any>findSingle(this.rootmenu().el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
             const anchorElement = element && (<any>findSingle(element, '[data-pc-section="itemlink"]') || findSingle(element, 'a,button'));
 
             anchorElement ? anchorElement.click() : element && element.click();

--- a/packages/optimus-ui/src/menu/menu.test.ts
+++ b/packages/optimus-ui/src/menu/menu.test.ts
@@ -2112,3 +2112,38 @@ describe('Menu', () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Menu, SharedModule],
+    template: `
+        <p-menu [model]="model">
+            <ng-template #submenuheader let-item>{{ item?.label }}</ng-template>
+        </p-menu>
+    `
+})
+class MenuQueryApiHostComponent {
+    model = [{ label: 'a' }];
+}
+
+describe('Menu Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [MenuQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(MenuQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Menu)).componentInstance;
+
+        expect(instance.submenuHeaderTemplate()).toBeDefined();
+        expect(instance.listViewChild()).toBeDefined();
+        expect(instance.containerViewChild()).toBeDefined();
+    });
+});

--- a/packages/optimus-ui/src/menu/menu.test.ts
+++ b/packages/optimus-ui/src/menu/menu.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DebugElement, provideZonelessChangeDetection, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -80,7 +80,7 @@ class TestBasicMenuComponent {
     `
 })
 class TestPopupMenuComponent {
-    @ViewChild('menu') menu!: Menu;
+    readonly menu = viewChild.required<Menu>('menu');
 
     popupItems: MenuItem[] = [
         {
@@ -1119,7 +1119,7 @@ describe('Menu', () => {
             popupComponent = popupFixture.componentInstance;
             popupFixture.detectChanges();
 
-            popupMenuInstance = popupComponent.menu;
+            popupMenuInstance = popupComponent.menu();
         });
 
         it('should create popup menu', () => {

--- a/packages/optimus-ui/src/menu/menu.ts
+++ b/packages/optimus-ui/src/menu/menu.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -18,12 +16,13 @@ import {
     Pipe,
     PipeTransform,
     PLATFORM_ID,
-    QueryList,
     signal,
     TemplateRef,
     viewChild,
     ViewEncapsulation,
-    ViewRef
+    ViewRef,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
@@ -189,9 +188,9 @@ export class MenuItemContent extends BaseComponent {
                 (pMotionOnBeforeEnter)="onOverlayBeforeEnter($event)"
                 (pMotionOnAfterLeave)="onOverlayAfterLeave()"
             >
-                @if (startTemplate ?? _startTemplate) {
+                @if (startTemplate() ?? _startTemplate) {
                     <div [class]="cx('start')" [pBind]="ptm('start')" [attr.data-pc-section]="'start'">
-                        <ng-container *ngTemplateOutlet="startTemplate ?? _startTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="startTemplate() ?? _startTemplate"></ng-container>
                     </div>
                 }
                 <ul
@@ -226,7 +225,7 @@ export class MenuItemContent extends BaseComponent {
                                         [attr.id]="menuitemId(submenu, id, i)"
                                         [attr.data-pc-section]="'submenulabel'"
                                     >
-                                        @let submenuHeader = submenuHeaderTemplate ?? _submenuHeaderTemplate;
+                                        @let submenuHeader = submenuHeaderTemplate() ?? _submenuHeaderTemplate;
                                         @if (submenuHeader) {
                                             <ng-container *ngTemplateOutlet="submenuHeader; context: { $implicit: submenu }"></ng-container>
                                         } @else {
@@ -248,7 +247,7 @@ export class MenuItemContent extends BaseComponent {
                                         [class]="cn(cx('item', { item, id: menuitemId(item, id, i, j) }), item?.styleClass)"
                                         [pBind]="ptm('item')"
                                         [pMenuItemContent]="item"
-                                        [itemTemplate]="itemTemplate ?? _itemTemplate"
+                                        [itemTemplate]="itemTemplate() ?? _itemTemplate"
                                         [idx]="j"
                                         [menuitemId]="menuitemId(item, id, i, j)"
                                         [style]="item.style"
@@ -278,7 +277,7 @@ export class MenuItemContent extends BaseComponent {
                                     [class]="cn(cx('item', { item, id: menuitemId(item, id, i) }), item?.styleClass)"
                                     [pBind]="ptm('item')"
                                     [pMenuItemContent]="item"
-                                    [itemTemplate]="itemTemplate ?? _itemTemplate"
+                                    [itemTemplate]="itemTemplate() ?? _itemTemplate"
                                     [idx]="i"
                                     [menuitemId]="menuitemId(item, id, i)"
                                     [ngStyle]="item.style"
@@ -298,9 +297,9 @@ export class MenuItemContent extends BaseComponent {
                         }
                     }
                 </ul>
-                @if (endTemplate ?? _endTemplate) {
+                @if (endTemplate() ?? _endTemplate) {
                     <div [class]="cx('end')" [pBind]="ptm('end')" [attr.data-pc-section]="'end'">
-                        <ng-container *ngTemplateOutlet="endTemplate ?? _endTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="endTemplate() ?? _endTemplate"></ng-container>
                     </div>
                 }
             </div>
@@ -517,21 +516,21 @@ export class Menu extends BaseComponent<MenuPassThrough> {
      * Defines template option for start.
      * @group Templates
      */
-    @ContentChild('start', { descendants: false }) startTemplate: TemplateRef<void> | undefined;
+    readonly startTemplate = contentChild<TemplateRef<void>>('start', { descendants: false });
     _startTemplate: TemplateRef<void> | undefined;
 
     /**
      * Defines template option for end.
      * @group Templates
      */
-    @ContentChild('end', { descendants: false }) endTemplate: TemplateRef<void> | undefined;
+    readonly endTemplate = contentChild<TemplateRef<void>>('end', { descendants: false });
     _endTemplate: TemplateRef<void> | undefined;
 
     /**
      * Defines template option for header.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
     _headerTemplate: TemplateRef<void> | undefined;
 
     /**
@@ -540,7 +539,7 @@ export class Menu extends BaseComponent<MenuPassThrough> {
      * @see {@link MenuItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<MenuItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<MenuItemTemplateContext>>('item', { descendants: false });
     _itemTemplate: TemplateRef<MenuItemTemplateContext> | undefined;
 
     /**
@@ -549,13 +548,13 @@ export class Menu extends BaseComponent<MenuPassThrough> {
      * @see {@link MenuSubmenuHeaderTemplateContext}
      * @group Templates
      */
-    @ContentChild('submenuheader', { descendants: false }) submenuHeaderTemplate: TemplateRef<MenuSubmenuHeaderTemplateContext> | undefined;
+    readonly submenuHeaderTemplate = contentChild<TemplateRef<MenuSubmenuHeaderTemplateContext>>('submenuheader', { descendants: false });
     _submenuHeaderTemplate: TemplateRef<MenuSubmenuHeaderTemplateContext> | undefined;
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'start':
                     this._startTemplate = item.template;

--- a/packages/optimus-ui/src/menu/menu.ts
+++ b/packages/optimus-ui/src/menu/menu.ts
@@ -527,13 +527,6 @@ export class Menu extends BaseComponent<MenuPassThrough> {
     _endTemplate: TemplateRef<void> | undefined;
 
     /**
-     * Defines template option for header.
-     * @group Templates
-     */
-    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
-    _headerTemplate: TemplateRef<void> | undefined;
-
-    /**
      * Custom item template.
      * @param {MenuItemTemplateContext} context - item context.
      * @see {@link MenuItemTemplateContext}

--- a/packages/optimus-ui/src/menubar/menubar.test.ts
+++ b/packages/optimus-ui/src/menubar/menubar.test.ts
@@ -628,11 +628,12 @@ describe('Menubar', () => {
             menubarInstance.focusedItemInfo.set({ index: 0, level: 0, parentKey: '', item: null });
 
             // Mock the rootmenu property to prevent undefined errors
-            menubarInstance.rootmenu = {
-                el: {
-                    nativeElement: document.createElement('ul')
-                }
-            } as any;
+            (menubarInstance as any).rootmenu = () =>
+                ({
+                    el: {
+                        nativeElement: document.createElement('ul')
+                    }
+                }) as any;
         });
 
         it('should handle arrow right key', () => {

--- a/packages/optimus-ui/src/menubar/menubar.test.ts
+++ b/packages/optimus-ui/src/menubar/menubar.test.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MenuItem, SharedModule } from '@openng/optimus-ui/api';
 import { Menubar, MenubarSub } from './menubar';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1403,5 +1404,34 @@ describe('Menubar', () => {
 
             expect(hookCalled).toBe(true);
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Menubar, SharedModule],
+    template: ` <p-menubar [model]="model"> </p-menubar> `
+})
+class MenubarQueryApiHostComponent {
+    model = [{ label: 'a' }];
+}
+
+describe('Menubar Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [MenubarQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(MenubarQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Menubar)).componentInstance;
+
+        expect(instance.menubutton()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/menubar/menubar.test.ts
+++ b/packages/optimus-ui/src/menubar/menubar.test.ts
@@ -1078,7 +1078,7 @@ describe('Menubar', () => {
             fixture.componentRef.setInput('model', [{ label: 'Test', items: [{ label: 'Subitem' }] }]);
             fixture.detectChanges();
 
-            const menubarSub = menubar.rootmenu as MenubarSub;
+            const menubarSub = menubar.rootmenu() as MenubarSub;
             const processedItem = {
                 item: { label: 'Test Item', disabled: false },
                 key: '0',
@@ -1108,7 +1108,7 @@ describe('Menubar', () => {
             fixture.componentRef.setInput('model', [{ label: 'Test', items: [{ label: 'Subitem' }] }]);
             fixture.detectChanges();
 
-            const menubarSub = menubar.rootmenu as MenubarSub;
+            const menubarSub = menubar.rootmenu() as MenubarSub;
             const processedItem = {
                 item: { label: 'Test Item' },
                 key: '0',
@@ -1127,7 +1127,7 @@ describe('Menubar', () => {
             fixture.componentRef.setInput('model', [{ label: 'Test', items: [{ label: 'Subitem' }] }]);
             fixture.detectChanges();
 
-            const menubarSub = menubar.rootmenu as MenubarSub;
+            const menubarSub = menubar.rootmenu() as MenubarSub;
             const processedItem = {
                 item: { label: 'Test Item' },
                 key: '0',
@@ -1154,7 +1154,7 @@ describe('Menubar', () => {
             fixture.componentRef.setInput('model', [{ label: 'Test', items: [{ label: 'Subitem' }] }]);
             fixture.detectChanges();
 
-            const menubarSub = menubar.rootmenu as MenubarSub;
+            const menubarSub = menubar.rootmenu() as MenubarSub;
             const processedItem = {
                 item: { label: 'Test Item', id: 'test-item-0' },
                 key: '0',
@@ -1181,7 +1181,7 @@ describe('Menubar', () => {
             fixture.componentRef.setInput('model', [{ label: 'Test', items: [{ label: 'Subitem', disabled: true }] }]);
             fixture.detectChanges();
 
-            const menubarSub = menubar.rootmenu as MenubarSub;
+            const menubarSub = menubar.rootmenu() as MenubarSub;
             const processedItem = {
                 item: { label: 'Disabled Item', disabled: true },
                 key: '0',
@@ -1208,7 +1208,7 @@ describe('Menubar', () => {
             fixture.componentRef.setInput('model', [{ label: 'Test', items: [{ label: 'Subitem' }] }]);
             fixture.detectChanges();
 
-            const menubarSub = menubar.rootmenu as MenubarSub;
+            const menubarSub = menubar.rootmenu() as MenubarSub;
             const processedItem = {
                 item: { label: 'Test Item' },
                 key: '0',
@@ -1229,7 +1229,7 @@ describe('Menubar', () => {
             fixture.componentRef.setInput('model', [{ label: 'Test', items: [{ label: 'Subitem' }] }]);
             fixture.detectChanges();
 
-            const menubarSub = menubar.rootmenu as MenubarSub;
+            const menubarSub = menubar.rootmenu() as MenubarSub;
             const processedItem = {
                 item: { label: 'Test Item' },
                 key: '0',
@@ -1254,7 +1254,7 @@ describe('Menubar', () => {
             fixture.componentRef.setInput('model', [{ label: 'Item 1' }, { label: 'Item 2' }, { label: 'Item 3' }]);
             fixture.detectChanges();
 
-            const menubarSub = menubar.rootmenu as MenubarSub;
+            const menubarSub = menubar.rootmenu() as MenubarSub;
             const processedItem = {
                 item: { label: 'Item 2' },
                 key: '1',

--- a/packages/optimus-ui/src/menubar/menubar.ts
+++ b/packages/optimus-ui/src/menubar/menubar.ts
@@ -545,7 +545,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
 
     readonly menubutton = viewChild<ElementRef>('menubutton');
 
-    readonly rootmenu = viewChild<MenubarSub>('rootmenu');
+    readonly rootmenu = viewChild.required<MenubarSub>('rootmenu');
 
     mobileActive: boolean | undefined;
 
@@ -770,7 +770,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
             this.focusedItemInfo.set({ index, level, parentKey, item });
 
             this.dirty = !root;
-            focus(this.rootmenu()?.el.nativeElement);
+            focus(this.rootmenu().el.nativeElement);
         } else {
             if (grouped) {
                 this.onItemChange(event);
@@ -780,7 +780,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
                 this.changeFocusedItemIndex(originalEvent, rootProcessedItem ? rootProcessedItem.index : -1);
 
                 this.mobileActive = false;
-                focus(this.rootmenu()?.el.nativeElement);
+                focus(this.rootmenu().el.nativeElement);
             }
         }
     }
@@ -817,7 +817,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
 
     scrollInView(index: number = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedItemId;
-        const element = findSingle(this.rootmenu()?.el.nativeElement, `li[id="${id}"]`);
+        const element = findSingle(this.rootmenu().el.nativeElement, `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -837,7 +837,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
         this.focusedItemInfo.set({ index, level, parentKey, item });
 
         grouped && (this.dirty = true);
-        isFocus && focus(this.rootmenu()?.el.nativeElement);
+        isFocus && focus(this.rootmenu().el.nativeElement);
 
         if (type === 'hover' && this.queryMatches()) {
             return;
@@ -849,11 +849,11 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
     toggle(event: MouseEvent) {
         if (this.mobileActive) {
             this.mobileActive = false;
-            ZIndexUtils.clear(this.rootmenu()?.el.nativeElement);
+            ZIndexUtils.clear(this.rootmenu().el.nativeElement);
             this.hide();
         } else {
             this.mobileActive = true;
-            ZIndexUtils.set('menu', this.rootmenu()?.el.nativeElement, this.config.zIndex.menu);
+            ZIndexUtils.set('menu', this.rootmenu().el.nativeElement, this.config.zIndex.menu);
             setTimeout(() => {
                 this.show();
             }, 0);
@@ -873,14 +873,14 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
         this.activeItemPath.set([]);
         this.focusedItemInfo.set({ index: -1, level: 0, parentKey: '', item: null });
 
-        isFocus && focus(this.rootmenu()?.el.nativeElement);
+        isFocus && focus(this.rootmenu().el.nativeElement);
         this.dirty = false;
     }
 
     show() {
         const processedItem = this.findVisibleItem(this.findFirstFocusedItemIndex());
         this.focusedItemInfo.set({ index: this.findFirstFocusedItemIndex(), level: 0, parentKey: '', item: processedItem?.item });
-        focus(this.rootmenu()?.el.nativeElement);
+        focus(this.rootmenu().el.nativeElement);
     }
 
     onMenuMouseDown(event: any) {
@@ -1199,7 +1199,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
 
     onEnterKey(event: KeyboardEvent) {
         if (this.focusedItemInfo().index !== -1) {
-            const element = <any>findSingle(this.rootmenu()?.el.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+            const element = <any>findSingle(this.rootmenu().el.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
             const anchorElement = element && (<any>findSingle(element, '[data-pc-section="itemlink"]') || findSingle(element, 'a,button'));
 
             anchorElement ? anchorElement.click() : element && element.click();
@@ -1248,7 +1248,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = this.renderer.listen(this.document, 'click', (event) => {
                     const rootmenu = this.rootmenu();
-                    const isOutsideContainer = rootmenu?.el.nativeElement !== event.target && !rootmenu?.el.nativeElement?.contains(event.target);
+                    const isOutsideContainer = rootmenu.el.nativeElement !== event.target && !rootmenu.el.nativeElement?.contains(event.target);
                     const menubutton = this.menubutton();
                     const isOutsideMenuButton = this.mobileActive && menubutton?.nativeElement !== event.target && !menubutton?.nativeElement?.contains(event.target);
 

--- a/packages/optimus-ui/src/menubar/menubar.ts
+++ b/packages/optimus-ui/src/menubar/menubar.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    ContentChild,
-    ContentChildren,
     effect,
     ElementRef,
     EventEmitter,
@@ -17,12 +15,13 @@ import {
     numberAttribute,
     Output,
     PLATFORM_ID,
-    QueryList,
     Renderer2,
     signal,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { findLastIndex, findSingle, focus, isEmpty, isNotEmpty, isPrintableCharacter, isTouchDevice, resolve, uuid } from '@openng/optimus-ui-utils';
@@ -379,9 +378,9 @@ export class MenubarSub extends BaseComponent<MenubarPassThrough> {
     standalone: true,
     imports: [CommonModule, RouterModule, MenubarSub, TooltipModule, BarsIcon, BadgeModule, SharedModule, BindModule],
     template: `
-        @if (startTemplate || _startTemplate) {
+        @if (startTemplate() || _startTemplate) {
             <div [class]="cx('start')" [pBind]="ptm('start')">
-                <ng-container *ngTemplateOutlet="startTemplate || _startTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="startTemplate() || _startTemplate"></ng-container>
             </div>
         }
         @if (model && model.length > 0) {
@@ -398,17 +397,17 @@ export class MenubarSub extends BaseComponent<MenubarPassThrough> {
                 (click)="menuButtonClick($event)"
                 (keydown)="menuButtonKeydown($event)"
             >
-                @if (!menuIconTemplate && !_menuIconTemplate) {
+                @if (!menuIconTemplate() && !_menuIconTemplate) {
                     <svg data-p-icon="bars" [pBind]="ptm('buttonIcon')" />
                 }
-                <ng-template *ngTemplateOutlet="menuIconTemplate || _menuIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="menuIconTemplate() || _menuIconTemplate"></ng-template>
             </a>
         }
         <ul
             pMenubarSub
             #rootmenu
             [items]="processedItems"
-            [itemTemplate]="itemTemplate"
+            [itemTemplate]="itemTemplate()"
             tabindex="0"
             [menuId]="id"
             [root]="true"
@@ -419,7 +418,7 @@ export class MenubarSub extends BaseComponent<MenubarPassThrough> {
             [attr.aria-label]="ariaLabel"
             [attr.aria-labelledby]="ariaLabelledBy"
             [focusedItemId]="focused ? focusedItemId : undefined"
-            [submenuiconTemplate]="submenuIconTemplate || _submenuIconTemplate"
+            [submenuiconTemplate]="submenuIconTemplate() || _submenuIconTemplate"
             [activeItemPath]="activeItemPath()"
             (itemClick)="onItemClick($event)"
             (mousedown)="onMenuMouseDown($event)"
@@ -432,9 +431,9 @@ export class MenubarSub extends BaseComponent<MenubarPassThrough> {
             [pBind]="ptm('rootList')"
             [unstyled]="unstyled()"
         ></ul>
-        @if (endTemplate || _endTemplate) {
+        @if (endTemplate() || _endTemplate) {
             <div [class]="cx('end')" [pBind]="ptm('end')">
-                <ng-container *ngTemplateOutlet="endTemplate || _endTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="endTemplate() || _endTemplate"></ng-container>
             </div>
         } @else {
             <div [class]="cx('end')">
@@ -544,9 +543,9 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
      */
     @Output() onBlur: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
 
-    @ViewChild('menubutton') menubutton: ElementRef | undefined;
+    readonly menubutton = viewChild<ElementRef>('menubutton');
 
-    @ViewChild('rootmenu') rootmenu: MenubarSub | undefined;
+    readonly rootmenu = viewChild<MenubarSub>('rootmenu');
 
     mobileActive: boolean | undefined;
 
@@ -629,13 +628,13 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
      * Defines template option for start.
      * @group Templates
      */
-    @ContentChild('start', { descendants: false }) startTemplate: TemplateRef<void> | undefined;
+    readonly startTemplate = contentChild<TemplateRef<void>>('start', { descendants: false });
 
     /**
      * Defines template option for end.
      * @group Templates
      */
-    @ContentChild('end', { descendants: false }) endTemplate: TemplateRef<void> | undefined;
+    readonly endTemplate = contentChild<TemplateRef<void>>('end', { descendants: false });
 
     /**
      * Custom item template.
@@ -643,19 +642,19 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
      * @see {@link MenubarItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<MenubarItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<MenubarItemTemplateContext>>('item', { descendants: false });
     /**
      * Defines template option for menu icon.
      * @group Templates
      */
-    @ContentChild('menuicon', { descendants: false }) menuIconTemplate: TemplateRef<void> | undefined;
+    readonly menuIconTemplate = contentChild<TemplateRef<void>>('menuicon', { descendants: false });
     /**
      * Defines template option for submenu icon.
      * @group Templates
      */
-    @ContentChild('submenuicon', { descendants: false }) submenuIconTemplate: TemplateRef<void> | undefined;
+    readonly submenuIconTemplate = contentChild<TemplateRef<void>>('submenuicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _startTemplate: TemplateRef<void> | undefined;
 
@@ -668,7 +667,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
     _submenuIconTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'start':
                     this._startTemplate = item.template;
@@ -771,7 +770,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
             this.focusedItemInfo.set({ index, level, parentKey, item });
 
             this.dirty = !root;
-            focus(this.rootmenu?.el.nativeElement);
+            focus(this.rootmenu()?.el.nativeElement);
         } else {
             if (grouped) {
                 this.onItemChange(event);
@@ -781,7 +780,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
                 this.changeFocusedItemIndex(originalEvent, rootProcessedItem ? rootProcessedItem.index : -1);
 
                 this.mobileActive = false;
-                focus(this.rootmenu?.el.nativeElement);
+                focus(this.rootmenu()?.el.nativeElement);
             }
         }
     }
@@ -818,7 +817,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
 
     scrollInView(index: number = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedItemId;
-        const element = findSingle(this.rootmenu?.el.nativeElement, `li[id="${id}"]`);
+        const element = findSingle(this.rootmenu()?.el.nativeElement, `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -838,7 +837,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
         this.focusedItemInfo.set({ index, level, parentKey, item });
 
         grouped && (this.dirty = true);
-        isFocus && focus(this.rootmenu?.el.nativeElement);
+        isFocus && focus(this.rootmenu()?.el.nativeElement);
 
         if (type === 'hover' && this.queryMatches()) {
             return;
@@ -850,11 +849,11 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
     toggle(event: MouseEvent) {
         if (this.mobileActive) {
             this.mobileActive = false;
-            ZIndexUtils.clear(this.rootmenu?.el.nativeElement);
+            ZIndexUtils.clear(this.rootmenu()?.el.nativeElement);
             this.hide();
         } else {
             this.mobileActive = true;
-            ZIndexUtils.set('menu', this.rootmenu?.el.nativeElement, this.config.zIndex.menu);
+            ZIndexUtils.set('menu', this.rootmenu()?.el.nativeElement, this.config.zIndex.menu);
             setTimeout(() => {
                 this.show();
             }, 0);
@@ -867,21 +866,21 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
     hide(event?, isFocus?: boolean) {
         if (this.mobileActive) {
             setTimeout(() => {
-                focus(this.menubutton?.nativeElement);
+                focus(this.menubutton()?.nativeElement);
             }, 0);
         }
 
         this.activeItemPath.set([]);
         this.focusedItemInfo.set({ index: -1, level: 0, parentKey: '', item: null });
 
-        isFocus && focus(this.rootmenu?.el.nativeElement);
+        isFocus && focus(this.rootmenu()?.el.nativeElement);
         this.dirty = false;
     }
 
     show() {
         const processedItem = this.findVisibleItem(this.findFirstFocusedItemIndex());
         this.focusedItemInfo.set({ index: this.findFirstFocusedItemIndex(), level: 0, parentKey: '', item: processedItem?.item });
-        focus(this.rootmenu?.el.nativeElement);
+        focus(this.rootmenu()?.el.nativeElement);
     }
 
     onMenuMouseDown(event: any) {
@@ -1200,7 +1199,7 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
 
     onEnterKey(event: KeyboardEvent) {
         if (this.focusedItemInfo().index !== -1) {
-            const element = <any>findSingle(this.rootmenu?.el.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+            const element = <any>findSingle(this.rootmenu()?.el.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
             const anchorElement = element && (<any>findSingle(element, '[data-pc-section="itemlink"]') || findSingle(element, 'a,button'));
 
             anchorElement ? anchorElement.click() : element && element.click();
@@ -1248,8 +1247,10 @@ export class Menubar extends BaseComponent<MenubarPassThrough> {
         if (isPlatformBrowser(this.platformId)) {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = this.renderer.listen(this.document, 'click', (event) => {
-                    const isOutsideContainer = this.rootmenu?.el.nativeElement !== event.target && !this.rootmenu?.el.nativeElement?.contains(event.target);
-                    const isOutsideMenuButton = this.mobileActive && this.menubutton?.nativeElement !== event.target && !this.menubutton?.nativeElement?.contains(event.target);
+                    const rootmenu = this.rootmenu();
+                    const isOutsideContainer = rootmenu?.el.nativeElement !== event.target && !rootmenu?.el.nativeElement?.contains(event.target);
+                    const menubutton = this.menubutton();
+                    const isOutsideMenuButton = this.mobileActive && menubutton?.nativeElement !== event.target && !menubutton?.nativeElement?.contains(event.target);
 
                     if (isOutsideContainer) {
                         isOutsideMenuButton ? (this.mobileActive = false) : this.hide();

--- a/packages/optimus-ui/src/message/message.test.ts
+++ b/packages/optimus-ui/src/message/message.test.ts
@@ -6,6 +6,7 @@ import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { Message } from './message';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1782,5 +1783,41 @@ describe('Message', () => {
             expect(callOrder.indexOf('onInit')).toBeLessThan(callOrder.indexOf('onAfterContentInit'));
             expect(callOrder.indexOf('onAfterContentInit')).toBeLessThan(callOrder.indexOf('onAfterViewInit'));
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Message, PrimeTemplate],
+    template: `
+        <p-message>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-message>
+    `
+})
+class MessageQueryApiHostComponent {}
+
+describe('Message Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [MessageQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(MessageQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Message)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/message/message.ts
+++ b/packages/optimus-ui/src/message/message.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, ContentChild, ContentChildren, EventEmitter, inject, InjectionToken, input, Input, NgModule, Output, QueryList, signal, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, EventEmitter, inject, InjectionToken, input, Input, NgModule, Output, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { MotionOptions } from '@openng/optimus-ui-motion';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -23,15 +23,15 @@ const MESSAGE_INSTANCE = new InjectionToken<Message>('MESSAGE_INSTANCE');
     template: `
         <div [pBind]="ptm('contentWrapper')" [class]="cx('contentWrapper')" [attr.data-p]="dataP">
             <div [pBind]="ptm('content')" [class]="cx('content')" [attr.data-p]="dataP">
-                @if (iconTemplate || _iconTemplate) {
-                    <ng-container *ngTemplateOutlet="iconTemplate || _iconTemplate"></ng-container>
+                @if (iconTemplate() || _iconTemplate) {
+                    <ng-container *ngTemplateOutlet="iconTemplate() || _iconTemplate"></ng-container>
                 }
                 @if (icon) {
                     <i [pBind]="ptm('icon')" [class]="cn(cx('icon'), icon)" [attr.data-p]="dataP"></i>
                 }
 
-                @if (containerTemplate || _containerTemplate) {
-                    <ng-container *ngTemplateOutlet="containerTemplate || _containerTemplate; context: { closeCallback: closeCallback }"></ng-container>
+                @if (containerTemplate() || _containerTemplate) {
+                    <ng-container *ngTemplateOutlet="containerTemplate() || _containerTemplate; context: { closeCallback: closeCallback }"></ng-container>
                 } @else {
                     @if (!escape) {
                         <div>
@@ -54,10 +54,10 @@ const MESSAGE_INSTANCE = new InjectionToken<Message>('MESSAGE_INSTANCE');
                         @if (closeIcon) {
                             <i [pBind]="ptm('closeIcon')" [class]="cn(cx('closeIcon'), closeIcon)" [ngClass]="closeIcon" [attr.data-p]="dataP"></i>
                         }
-                        @if (closeIconTemplate || _closeIconTemplate) {
-                            <ng-container *ngTemplateOutlet="closeIconTemplate || _closeIconTemplate"></ng-container>
+                        @if (closeIconTemplate() || _closeIconTemplate) {
+                            <ng-container *ngTemplateOutlet="closeIconTemplate() || _closeIconTemplate"></ng-container>
                         }
-                        @if (!closeIconTemplate && !_closeIconTemplate && !closeIcon) {
+                        @if (!closeIconTemplate() && !_closeIconTemplate && !closeIcon) {
                             <svg [pBind]="ptm('closeIcon')" data-p-icon="times" [class]="cx('closeIcon')" [attr.data-p]="dataP" />
                         }
                     </button>
@@ -198,21 +198,21 @@ export class Message extends BaseComponent<MessagePassThrough> {
      * @see {@link MessageContainerTemplateContext}
      * @group Templates
      */
-    @ContentChild('container', { descendants: false }) containerTemplate: TemplateRef<MessageContainerTemplateContext> | undefined;
+    readonly containerTemplate = contentChild<TemplateRef<MessageContainerTemplateContext>>('container', { descendants: false });
 
     /**
      * Custom template of the message icon.
      * @group Templates
      */
-    @ContentChild('icon', { descendants: false }) iconTemplate: TemplateRef<void> | undefined;
+    readonly iconTemplate = contentChild<TemplateRef<void>>('icon', { descendants: false });
 
     /**
      * Custom template of the close icon.
      * @group Templates
      */
-    @ContentChild('closeicon', { descendants: false }) closeIconTemplate: TemplateRef<void> | undefined;
+    readonly closeIconTemplate = contentChild<TemplateRef<void>>('closeicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _containerTemplate: TemplateRef<MessageContainerTemplateContext> | undefined;
 
@@ -233,7 +233,7 @@ export class Message extends BaseComponent<MessagePassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'container':
                     this._containerTemplate = item.template;

--- a/packages/optimus-ui/src/metergroup/metergroup.test.ts
+++ b/packages/optimus-ui/src/metergroup/metergroup.test.ts
@@ -5,6 +5,8 @@ import { By } from '@angular/platform-browser';
 import { MeterItem } from '@openng/optimus-ui/types/metergroup';
 import { MeterGroup, MeterGroupLabel, MeterGroupModule } from './metergroup';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -924,5 +926,43 @@ describe('MeterGroup', () => {
 
             expect(totalPercent).toBe(Math.round((totalUsed / totalStorage) * 100));
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [MeterGroup, PrimeTemplate],
+    template: `
+        <p-metergroup [value]="meterValue">
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-metergroup>
+    `
+})
+class MeterGroupQueryApiHostComponent {
+    meterValue = [{ label: 'm', value: 10, color: 'red' }];
+}
+
+describe('MeterGroup Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [MeterGroupQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(MeterGroupQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(MeterGroup)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/metergroup/metergroup.test.ts
+++ b/packages/optimus-ui/src/metergroup/metergroup.test.ts
@@ -401,7 +401,7 @@ describe('MeterGroup', () => {
             // Since we're using a custom label template, the icon template won't be used
             // (MeterGroupLabel is only rendered when there's no custom label template)
             // The icon template is stored but not rendered in this test case
-            expect(meterGroup._iconTemplate || meterGroup.iconTemplate).toBeDefined();
+            expect(meterGroup._iconTemplate || meterGroup.iconTemplate()).toBeDefined();
         });
 
         it('should pass correct context to label template', () => {
@@ -417,11 +417,11 @@ describe('MeterGroup', () => {
 
         it('should handle template processing in ngAfterContentInit', () => {
             // Templates should already be processed during component initialization
-            expect(meterGroup._labelTemplate || meterGroup.labelTemplate).toBeDefined();
-            expect(meterGroup._meterTemplate || meterGroup.meterTemplate).toBeDefined();
-            expect(meterGroup._startTemplate || meterGroup.startTemplate).toBeDefined();
-            expect(meterGroup._endTemplate || meterGroup.endTemplate).toBeDefined();
-            expect(meterGroup._iconTemplate || meterGroup.iconTemplate).toBeDefined();
+            expect(meterGroup._labelTemplate || meterGroup.labelTemplate()).toBeDefined();
+            expect(meterGroup._meterTemplate || meterGroup.meterTemplate()).toBeDefined();
+            expect(meterGroup._startTemplate || meterGroup.startTemplate()).toBeDefined();
+            expect(meterGroup._endTemplate || meterGroup.endTemplate()).toBeDefined();
+            expect(meterGroup._iconTemplate || meterGroup.iconTemplate()).toBeDefined();
 
             // Calling ngAfterContentInit again should not throw
             expect(() => meterGroup.ngAfterContentInit()).not.toThrow();

--- a/packages/optimus-ui/src/metergroup/metergroup.ts
+++ b/packages/optimus-ui/src/metergroup/metergroup.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { AfterContentInit, ChangeDetectionStrategy, Component, ContentChild, ContentChildren, ElementRef, forwardRef, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, Component, ElementRef, forwardRef, inject, InjectionToken, Input, NgModule, TemplateRef, ViewChild, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { getOuterHeight } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -66,17 +66,17 @@ export class MeterGroupLabel extends BaseComponent<MeterGroupPassThrough> {
     imports: [CommonModule, MeterGroupLabel, SharedModule, Bind],
     template: `
         @if (labelPosition === 'start') {
-            @if (!labelTemplate && !_labelTemplate) {
-                <p-meterGroupLabel [value]="value" [labelPosition]="labelPosition" [labelOrientation]="labelOrientation" [min]="min" [max]="max" [iconTemplate]="iconTemplate || _iconTemplate" [pt]="pt" [unstyled]="unstyled()" />
+            @if (!labelTemplate() && !_labelTemplate) {
+                <p-meterGroupLabel [value]="value" [labelPosition]="labelPosition" [labelOrientation]="labelOrientation" [min]="min" [max]="max" [iconTemplate]="iconTemplate() || _iconTemplate" [pt]="pt" [unstyled]="unstyled()" />
             }
-            <ng-container *ngTemplateOutlet="labelTemplate || labelTemplate; context: { $implicit: value, totalPercent: totalPercent(), percentages: percentages() }"></ng-container>
+            <ng-container *ngTemplateOutlet="labelTemplate() || labelTemplate(); context: { $implicit: value, totalPercent: totalPercent(), percentages: percentages() }"></ng-container>
         }
-        <ng-container *ngTemplateOutlet="startTemplate || _startTemplate; context: { $implicit: value, totalPercent: totalPercent(), percentages: percentages() }"></ng-container>
+        <ng-container *ngTemplateOutlet="startTemplate() || _startTemplate; context: { $implicit: value, totalPercent: totalPercent(), percentages: percentages() }"></ng-container>
         <div [class]="cx('meters')" [pBind]="ptm('meters')" [attr.data-p]="dataP">
             @for (meterItem of value; track trackByFn(index); let index = $index) {
                 <ng-container
                     *ngTemplateOutlet="
-                        meterTemplate || _meterTemplate;
+                        meterTemplate() || _meterTemplate;
                         context: {
                             $implicit: meterItem,
                             index: index,
@@ -89,17 +89,17 @@ export class MeterGroupLabel extends BaseComponent<MeterGroupPassThrough> {
                     "
                 >
                 </ng-container>
-                @if (!meterTemplate && !_meterTemplate && meterItem.value > 0) {
+                @if (!meterTemplate() && !_meterTemplate && meterItem.value > 0) {
                     <span [class]="cx('meter')" [attr.data-p]="dataP" [pBind]="ptm('meter')" [ngStyle]="meterStyle(meterItem)"></span>
                 }
             }
         </div>
-        <ng-container *ngTemplateOutlet="endTemplate || _endTemplate; context: { $implicit: value, totalPercent: totalPercent(), percentages: percentages() }"></ng-container>
+        <ng-container *ngTemplateOutlet="endTemplate() || _endTemplate; context: { $implicit: value, totalPercent: totalPercent(), percentages: percentages() }"></ng-container>
         @if (labelPosition === 'end') {
-            @if (!labelTemplate && !_labelTemplate) {
-                <p-meterGroupLabel [value]="value" [labelPosition]="labelPosition" [labelOrientation]="labelOrientation" [min]="min" [max]="max" [iconTemplate]="iconTemplate || _iconTemplate" [pt]="pt" [unstyled]="unstyled()" />
+            @if (!labelTemplate() && !_labelTemplate) {
+                <p-meterGroupLabel [value]="value" [labelPosition]="labelPosition" [labelOrientation]="labelOrientation" [min]="min" [max]="max" [iconTemplate]="iconTemplate() || _iconTemplate" [pt]="pt" [unstyled]="unstyled()" />
             }
-            <ng-container *ngTemplateOutlet="labelTemplate || _labelTemplate; context: { $implicit: value, totalPercent: totalPercent(), percentages: percentages() }"></ng-container>
+            <ng-container *ngTemplateOutlet="labelTemplate() || _labelTemplate; context: { $implicit: value, totalPercent: totalPercent(), percentages: percentages() }"></ng-container>
         }
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -169,7 +169,7 @@ export class MeterGroup extends BaseComponent<MeterGroupPassThrough> {
      * @see {@link MeterGroupLabelTemplateContext}
      * @group Templates
      */
-    @ContentChild('label', { descendants: false }) labelTemplate: TemplateRef<MeterGroupLabelTemplateContext> | undefined;
+    readonly labelTemplate = contentChild<TemplateRef<MeterGroupLabelTemplateContext>>('label', { descendants: false });
 
     /**
      * Custom meter template.
@@ -177,7 +177,7 @@ export class MeterGroup extends BaseComponent<MeterGroupPassThrough> {
      * @see {@link MeterGroupMeterTemplateContext}
      * @group Templates
      */
-    @ContentChild('meter', { descendants: false }) meterTemplate: TemplateRef<MeterGroupMeterTemplateContext> | undefined;
+    readonly meterTemplate = contentChild<TemplateRef<MeterGroupMeterTemplateContext>>('meter', { descendants: false });
 
     /**
      * Custom end template.
@@ -185,7 +185,7 @@ export class MeterGroup extends BaseComponent<MeterGroupPassThrough> {
      * @see {@link MeterGroupLabelTemplateContext}
      * @group Templates
      */
-    @ContentChild('end', { descendants: false }) endTemplate: TemplateRef<MeterGroupLabelTemplateContext> | undefined;
+    readonly endTemplate = contentChild<TemplateRef<MeterGroupLabelTemplateContext>>('end', { descendants: false });
 
     /**
      * Custom start template.
@@ -193,7 +193,7 @@ export class MeterGroup extends BaseComponent<MeterGroupPassThrough> {
      * @see {@link MeterGroupLabelTemplateContext}
      * @group Templates
      */
-    @ContentChild('start', { descendants: false }) startTemplate: TemplateRef<MeterGroupLabelTemplateContext> | undefined;
+    readonly startTemplate = contentChild<TemplateRef<MeterGroupLabelTemplateContext>>('start', { descendants: false });
 
     /**
      * Custom icon template.
@@ -201,9 +201,9 @@ export class MeterGroup extends BaseComponent<MeterGroupPassThrough> {
      * @see {@link MeterGroupIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('icon', { descendants: false }) iconTemplate: TemplateRef<MeterGroupIconTemplateContext> | undefined;
+    readonly iconTemplate = contentChild<TemplateRef<MeterGroupIconTemplateContext>>('icon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _labelTemplate: TemplateRef<MeterGroupLabelTemplateContext> | undefined;
 
@@ -228,7 +228,7 @@ export class MeterGroup extends BaseComponent<MeterGroupPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'label':
                     this._labelTemplate = item.template;

--- a/packages/optimus-ui/src/multiselect/multiselect.test.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.test.ts
@@ -9,6 +9,7 @@ import { BehaviorSubject, of } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { MultiSelect, MultiSelectModule } from './multiselect';
 import type { MultiSelectBlurEvent, MultiSelectChangeEvent, MultiSelectFilterEvent, MultiSelectFocusEvent } from '@openng/optimus-ui/types/multiselect';
+import { SharedModule } from '@openng/optimus-ui/api';
 interface City {
     name: string;
     code: string;
@@ -3951,3 +3952,64 @@ class TestFormIsolationMultiSelectComponent {
         { name: 'Rotterdam', code: 'RTM' }
     ];
 }
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [MultiSelect, SharedModule],
+    template: `
+        <p-multiselect [options]="opts">
+            <p-footer>F</p-footer>
+            <ng-template #group>g</ng-template>
+            <ng-template #loader>l</ng-template>
+            <ng-template #filter>f</ng-template>
+            <ng-template #loadingicon>li</ng-template>
+            <ng-template #filtericon>fi</ng-template>
+            <ng-template #removetokenicon>rti</ng-template>
+            <ng-template #chipicon>ci</ng-template>
+            <ng-template #clearicon>cli</ng-template>
+            <ng-template #dropdownicon>di</ng-template>
+            <ng-template #itemcheckboxicon>ici</ng-template>
+            <ng-template #headercheckboxicon>hci</ng-template>
+            <ng-template pTemplate="item">i</ng-template>
+        </p-multiselect>
+    `
+})
+class MultiSelectQueryApiHostComponent {
+    opts = [{ label: 'a', value: 1 }];
+}
+
+describe('MultiSelect Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [MultiSelectQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(MultiSelectQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(MultiSelect)).componentInstance;
+
+        for (const hook of [
+            'groupTemplate',
+            'loaderTemplate',
+            'filterTemplate',
+            'loadingIconTemplate',
+            'filterIconTemplate',
+            'removeTokenIconTemplate',
+            'chipIconTemplate',
+            'clearIconTemplate',
+            'dropdownIconTemplate',
+            'itemCheckboxIconTemplate',
+            'headerCheckboxIconTemplate'
+        ]) {
+            expect((instance as any)[hook](), `${hook} should resolve`).toBeDefined();
+        }
+        expect(instance.footerFacet()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'item')).toBe(true);
+    });
+});

--- a/packages/optimus-ui/src/multiselect/multiselect.test.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.test.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, provideZonelessChangeDetection, signal, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, provideZonelessChangeDetection, signal, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, NgForm, NgModel, ReactiveFormsModule, Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -941,7 +941,7 @@ describe('MultiSelect', () => {
 
             it('should move focus to the first hidden focusable element and keep the overlay open', async () => {
                 vi.spyOn(component, 'onSelectionChange').mockImplementation(() => {});
-                const firstHiddenFocusableElement = multiSelect.firstHiddenFocusableElementOnOverlay!.nativeElement;
+                const firstHiddenFocusableElement = multiSelect.firstHiddenFocusableElementOnOverlay()!.nativeElement;
                 vi.spyOn(firstHiddenFocusableElement, 'focus').mockImplementation(() => {});
                 multiSelect.focusedOptionIndex.set(2);
 
@@ -955,7 +955,7 @@ describe('MultiSelect', () => {
             });
 
             it('should move focus to the last hidden focusable element on shift+tab', async () => {
-                const lastHiddenFocusableElement = multiSelect.lastHiddenFocusableElementOnOverlay!.nativeElement;
+                const lastHiddenFocusableElement = multiSelect.lastHiddenFocusableElementOnOverlay()!.nativeElement;
                 vi.spyOn(lastHiddenFocusableElement, 'focus').mockImplementation(() => {});
                 multiSelect.focusedOptionIndex.set(2);
 
@@ -1626,12 +1626,12 @@ describe('MultiSelect Content Child Templates', () => {
         await fixture.whenStable();
 
         // After content init should process templates - check if they exist or component is initialized
-        const hasItemTemplate = !!(multiSelect.itemTemplate || multiSelect._itemTemplate);
-        const hasSelectedItemsTemplate = !!(multiSelect.selectedItemsTemplate || multiSelect._selectedItemsTemplate);
-        const hasHeaderTemplate = !!(multiSelect.headerTemplate || multiSelect._headerTemplate);
-        const hasFooterTemplate = !!(multiSelect.footerTemplate || multiSelect._footerTemplate);
-        const hasEmptyTemplate = !!(multiSelect.emptyTemplate || multiSelect._emptyTemplate);
-        const hasEmptyFilterTemplate = !!(multiSelect.emptyFilterTemplate || multiSelect._emptyFilterTemplate);
+        const hasItemTemplate = !!(multiSelect.itemTemplate() || multiSelect._itemTemplate);
+        const hasSelectedItemsTemplate = !!(multiSelect.selectedItemsTemplate() || multiSelect._selectedItemsTemplate);
+        const hasHeaderTemplate = !!(multiSelect.headerTemplate() || multiSelect._headerTemplate);
+        const hasFooterTemplate = !!(multiSelect.footerTemplate() || multiSelect._footerTemplate);
+        const hasEmptyTemplate = !!(multiSelect.emptyTemplate() || multiSelect._emptyTemplate);
+        const hasEmptyFilterTemplate = !!(multiSelect.emptyFilterTemplate() || multiSelect._emptyFilterTemplate);
 
         // At least some templates should be processed, or component should be properly initialized
         expect(hasItemTemplate || hasSelectedItemsTemplate || hasHeaderTemplate || hasFooterTemplate || hasEmptyTemplate || hasEmptyFilterTemplate || multiSelect).toBeDefined();
@@ -1860,8 +1860,9 @@ describe('MultiSelect Virtual Scrolling', () => {
         fixture.detectChanges();
 
         // Virtual scroller should emit lazy load events
-        if (multiSelect.scroller) {
-            multiSelect.scroller.onLazyLoad.emit({
+        const scroller = multiSelect.scroller();
+        if (scroller) {
+            scroller.onLazyLoad.emit({
                 first: 0,
                 last: 10
             });
@@ -1879,8 +1880,9 @@ describe('MultiSelect Virtual Scrolling', () => {
         fixture.detectChanges();
 
         // First check if scroller exists and if scrollInView method exists
-        if (multiSelect.scroller && typeof multiSelect.scroller.scrollToIndex === 'function') {
-            const scrollSpy = vi.spyOn(multiSelect.scroller, 'scrollToIndex').mockImplementation(() => {});
+        const scroller = multiSelect.scroller();
+        if (scroller && typeof scroller.scrollToIndex === 'function') {
+            const scrollSpy = vi.spyOn(scroller, 'scrollToIndex').mockImplementation(() => {});
 
             if (typeof multiSelect.scrollInView === 'function') {
                 // scrollInView uses setTimeout(0) internally, so we need to wait
@@ -1896,7 +1898,7 @@ describe('MultiSelect Virtual Scrolling', () => {
                 }
             } else {
                 // Call scrollToIndex directly if scrollInView doesn't exist
-                multiSelect.scroller.scrollToIndex(500);
+                scroller.scrollToIndex(500);
                 expect(scrollSpy).toHaveBeenCalledWith(500);
             }
         } else if (typeof multiSelect.scrollInView === 'function') {
@@ -1972,12 +1974,12 @@ describe('MultiSelect Virtual Scrolling', () => {
     `
 })
 class TestDynamicDataSourcesMultiSelectComponent {
-    @ViewChild('signalMultiSelect') signalMultiSelect!: MultiSelect;
-    @ViewChild('asyncMultiSelect') asyncMultiSelect!: MultiSelect;
-    @ViewChild('getterMultiSelect') getterMultiSelect!: MultiSelect;
-    @ViewChild('functionMultiSelect') functionMultiSelect!: MultiSelect;
-    @ViewChild('lateLoadMultiSelect') lateLoadMultiSelect!: MultiSelect;
-    @ViewChild('computedMultiSelect') computedMultiSelect!: MultiSelect;
+    readonly signalMultiSelect = viewChild.required<MultiSelect>('signalMultiSelect');
+    readonly asyncMultiSelect = viewChild.required<MultiSelect>('asyncMultiSelect');
+    readonly getterMultiSelect = viewChild.required<MultiSelect>('getterMultiSelect');
+    readonly functionMultiSelect = viewChild.required<MultiSelect>('functionMultiSelect');
+    readonly lateLoadMultiSelect = viewChild.required<MultiSelect>('lateLoadMultiSelect');
+    readonly computedMultiSelect = viewChild.required<MultiSelect>('computedMultiSelect');
 
     // Signals
     citySignal = signal<City[]>([
@@ -2208,13 +2210,13 @@ class TestDynamicDataSourcesMultiSelectComponent {
     `
 })
 class TestComprehensiveFormMultiSelectComponent {
-    @ViewChild('reactiveMultiSelect') reactiveMultiSelect!: MultiSelect;
-    @ViewChild('validatedMultiSelect') validatedMultiSelect!: MultiSelect;
-    @ViewChild('ngModelMultiSelect') ngModelMultiSelect!: MultiSelect;
-    @ViewChild('ngModelValidatedMultiSelect') ngModelValidatedMultiSelect!: MultiSelect;
-    @ViewChild('templateForm') templateForm!: NgForm;
-    @ViewChild('citiesModel') citiesModel!: NgModel;
-    @ViewChild('validatedModel') validatedModel!: NgModel;
+    readonly reactiveMultiSelect = viewChild.required<MultiSelect>('reactiveMultiSelect');
+    readonly validatedMultiSelect = viewChild.required<MultiSelect>('validatedMultiSelect');
+    readonly ngModelMultiSelect = viewChild.required<MultiSelect>('ngModelMultiSelect');
+    readonly ngModelValidatedMultiSelect = viewChild.required<MultiSelect>('ngModelValidatedMultiSelect');
+    readonly templateForm = viewChild.required<NgForm>('templateForm');
+    readonly citiesModel = viewChild.required<NgModel>('citiesModel');
+    readonly validatedModel = viewChild.required<NgModel>('validatedModel');
 
     allCities: City[] = [
         { name: 'New York', code: 'NY' },
@@ -2327,7 +2329,7 @@ class TestComprehensiveFormMultiSelectComponent {
     `
 })
 class TestViewChildMultiSelectComponent {
-    @ViewChild('mainMultiSelect') mainMultiSelect!: MultiSelect;
+    readonly mainMultiSelect = viewChild.required<MultiSelect>('mainMultiSelect');
 
     cities: City[] = [
         { name: 'ViewChild City 1', code: 'VC1' },
@@ -2339,80 +2341,82 @@ class TestViewChildMultiSelectComponent {
 
     // Methods to test ViewChild properties
     getOverlayViewChild() {
-        return this.mainMultiSelect.overlayViewChild;
+        return this.mainMultiSelect().overlayViewChild();
     }
 
     getFilterInputChild() {
-        return this.mainMultiSelect.filterInputChild;
+        return this.mainMultiSelect().filterInputChild();
     }
 
     getFocusInputViewChild() {
-        return this.mainMultiSelect.focusInputViewChild;
+        return this.mainMultiSelect().focusInputViewChild();
     }
 
     getItemsViewChild() {
-        return this.mainMultiSelect.itemsViewChild;
+        return this.mainMultiSelect().itemsViewChild();
     }
 
     getScroller() {
-        return this.mainMultiSelect.scroller;
+        return this.mainMultiSelect().scroller();
     }
 
     getLastHiddenFocusableElement() {
-        return this.mainMultiSelect.lastHiddenFocusableElementOnOverlay;
+        return this.mainMultiSelect().lastHiddenFocusableElementOnOverlay();
     }
 
     getFirstHiddenFocusableElement() {
-        return this.mainMultiSelect.firstHiddenFocusableElementOnOverlay;
+        return this.mainMultiSelect().firstHiddenFocusableElementOnOverlay();
     }
 
     getHeaderCheckbox() {
-        return this.mainMultiSelect.headerCheckboxViewChild;
+        return this.mainMultiSelect().headerCheckboxViewChild();
     }
 
     // Test method access
     callShowMethod() {
-        this.mainMultiSelect.show();
+        this.mainMultiSelect().show();
     }
 
     callHideMethod() {
-        this.mainMultiSelect.hide();
+        this.mainMultiSelect().hide();
     }
 
     callClearMethod() {
-        this.mainMultiSelect.clear(new Event('click'));
+        this.mainMultiSelect().clear(new Event('click'));
     }
 
     callUpdateModelMethod(value: City[]) {
-        this.mainMultiSelect.updateModel(value);
+        this.mainMultiSelect().updateModel(value);
     }
 
     callResetFilterMethod() {
-        this.mainMultiSelect.resetFilter();
+        this.mainMultiSelect().resetFilter();
     }
 
     getModelValue() {
-        return this.mainMultiSelect.modelValue();
+        return this.mainMultiSelect().modelValue();
     }
 
     isMaxSelectionLimitReached() {
-        return this.mainMultiSelect.maxSelectionLimitReached?.() ?? (this.mainMultiSelect.selectionLimit && this.mainMultiSelect.modelValue() && this.mainMultiSelect.modelValue().length >= this.mainMultiSelect.selectionLimit);
+        const mainMultiSelect = this.mainMultiSelect();
+        return mainMultiSelect.maxSelectionLimitReached?.() ?? (mainMultiSelect.selectionLimit && mainMultiSelect.modelValue() && mainMultiSelect.modelValue().length >= mainMultiSelect.selectionLimit);
     }
 
     isEmpty() {
-        return this.mainMultiSelect.isEmpty?.() ?? (!this.mainMultiSelect.modelValue() || (Array.isArray(this.mainMultiSelect.modelValue()) && this.mainMultiSelect.modelValue().length === 0));
+        const mainMultiSelect = this.mainMultiSelect();
+        return mainMultiSelect.isEmpty?.() ?? (!mainMultiSelect.modelValue() || (Array.isArray(mainMultiSelect.modelValue()) && mainMultiSelect.modelValue().length === 0));
     }
 
     getVisibleOptions() {
-        return this.mainMultiSelect.visibleOptions();
+        return this.mainMultiSelect().visibleOptions();
     }
 
     getFocusedOptionIndex() {
-        return this.mainMultiSelect.focusedOptionIndex();
+        return this.mainMultiSelect().focusedOptionIndex();
     }
 
     getFilterValue() {
-        return this.mainMultiSelect._filterValue();
+        return this.mainMultiSelect()._filterValue();
     }
 }
 
@@ -2466,12 +2470,12 @@ class TestViewChildMultiSelectComponent {
     `
 })
 class TestComplexEdgeCasesMultiSelectComponent {
-    @ViewChild('largeDataMultiSelect') largeDataMultiSelect!: MultiSelect;
-    @ViewChild('unicodeMultiSelect') unicodeMultiSelect!: MultiSelect;
-    @ViewChild('xssMultiSelect') xssMultiSelect!: MultiSelect;
-    @ViewChild('memoryMultiSelect') memoryMultiSelect!: MultiSelect;
-    @ViewChild('nullHandlingMultiSelect') nullHandlingMultiSelect!: MultiSelect;
-    @ViewChild('circularMultiSelect') circularMultiSelect!: MultiSelect;
+    readonly largeDataMultiSelect = viewChild.required<MultiSelect>('largeDataMultiSelect');
+    readonly unicodeMultiSelect = viewChild.required<MultiSelect>('unicodeMultiSelect');
+    readonly xssMultiSelect = viewChild.required<MultiSelect>('xssMultiSelect');
+    readonly memoryMultiSelect = viewChild.required<MultiSelect>('memoryMultiSelect');
+    readonly nullHandlingMultiSelect = viewChild.required<MultiSelect>('nullHandlingMultiSelect');
+    readonly circularMultiSelect = viewChild.required<MultiSelect>('circularMultiSelect');
 
     // Large dataset for performance testing
     largeDataset: City[] = [];
@@ -2642,57 +2646,57 @@ describe('MultiSelect Dynamic Data Sources', () => {
 
     describe('Signal-based Data Sources', () => {
         it('should work with signal options', async () => {
-            expect(component.signalMultiSelect.options!.length).toBe(3);
-            expect(component.signalMultiSelect.options![0].name).toBe('Signal City 1');
+            expect(component.signalMultiSelect().options!.length).toBe(3);
+            expect(component.signalMultiSelect().options![0].name).toBe('Signal City 1');
 
             // Test signal updates
             component.updateSignalData();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.signalMultiSelect.options!.length).toBe(2);
-            expect(component.signalMultiSelect.options![0].name).toBe('Updated Signal 1');
+            expect(component.signalMultiSelect().options!.length).toBe(2);
+            expect(component.signalMultiSelect().options![0].name).toBe('Updated Signal 1');
         });
 
         it('should work with signal placeholder', async () => {
-            expect(component.signalMultiSelect.placeholder()).toBe('Select from signal');
+            expect(component.signalMultiSelect().placeholder()).toBe('Select from signal');
 
             component.updatePlaceholder();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.signalMultiSelect.placeholder()).toBe('Updated placeholder');
+            expect(component.signalMultiSelect().placeholder()).toBe('Updated placeholder');
         });
 
         it('should work with signal disabled state', async () => {
-            expect(component.signalMultiSelect.$disabled()).toBe(false);
+            expect(component.signalMultiSelect().$disabled()).toBe(false);
 
             component.toggleDisabled();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.signalMultiSelect.$disabled()).toBe(true);
+            expect(component.signalMultiSelect().$disabled()).toBe(true);
         });
 
         it('should work with signal filter state', async () => {
-            expect(component.signalMultiSelect.filter).toBe(true);
+            expect(component.signalMultiSelect().filter).toBe(true);
 
             component.toggleFilter();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.signalMultiSelect.filter).toBe(false);
+            expect(component.signalMultiSelect().filter).toBe(false);
         });
 
         it('should add items to signal dynamically', async () => {
-            const initialCount = component.signalMultiSelect.options!.length;
+            const initialCount = component.signalMultiSelect().options!.length;
 
             component.addToSignal();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.signalMultiSelect.options!.length).toBe(initialCount + 1);
-            expect(component.signalMultiSelect.options![initialCount].name).toContain('New City');
+            expect(component.signalMultiSelect().options!.length).toBe(initialCount + 1);
+            expect(component.signalMultiSelect().options![initialCount].name).toContain('New City');
         });
     });
 
@@ -2742,8 +2746,9 @@ describe('MultiSelect Dynamic Data Sources', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.asyncMultiSelect.options?.length).toBe(2);
-            expect(component.asyncMultiSelect.options?.[0].name).toBe('Observable City 1');
+            const asyncMultiSelect = component.asyncMultiSelect();
+            expect(asyncMultiSelect.options?.length).toBe(2);
+            expect(asyncMultiSelect.options?.[0].name).toBe('Observable City 1');
         });
 
         it('should update when observable data changes', async () => {
@@ -2755,8 +2760,9 @@ describe('MultiSelect Dynamic Data Sources', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.asyncMultiSelect.options?.length).toBe(3);
-            expect(component.asyncMultiSelect.options?.[0].name).toBe('Updated Observable 1');
+            const asyncMultiSelect = component.asyncMultiSelect();
+            expect(asyncMultiSelect.options?.length).toBe(3);
+            expect(asyncMultiSelect.options?.[0].name).toBe('Updated Observable 1');
         });
 
         it('should work with observable placeholder via async pipe', async () => {
@@ -2764,7 +2770,7 @@ describe('MultiSelect Dynamic Data Sources', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            const placeholder = component.asyncMultiSelect.placeholder();
+            const placeholder = component.asyncMultiSelect().placeholder();
             // Async pipe may not have resolved yet, so allow for null/undefined
             if (placeholder !== null && placeholder !== undefined) {
                 expect(placeholder).toBe('Select from observable');
@@ -2777,64 +2783,64 @@ describe('MultiSelect Dynamic Data Sources', () => {
 
     describe('Getter-based Data Sources', () => {
         it('should work with getter options', async () => {
-            expect(component.getterMultiSelect.options!.length).toBe(2);
-            expect(component.getterMultiSelect.options![0].name).toBe('Getter City 1');
+            expect(component.getterMultiSelect().options!.length).toBe(2);
+            expect(component.getterMultiSelect().options![0].name).toBe('Getter City 1');
 
             component.updateGetterData();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.getterMultiSelect.options![0].name).toBe('Updated Getter 1');
+            expect(component.getterMultiSelect().options![0].name).toBe('Updated Getter 1');
         });
 
         it('should work with getter placeholder', () => {
-            expect(component.getterMultiSelect.placeholder()).toBe('Select from getter');
+            expect(component.getterMultiSelect().placeholder()).toBe('Select from getter');
         });
 
         it('should work with getter disabled state', async () => {
-            expect(component.getterMultiSelect.$disabled()).toBe(false);
+            expect(component.getterMultiSelect().$disabled()).toBe(false);
 
             component.toggleGetterDisabled();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.getterMultiSelect.$disabled()).toBe(true);
+            expect(component.getterMultiSelect().$disabled()).toBe(true);
         });
     });
 
     describe('Function-based Property Data Sources', () => {
         it('should work with function options', () => {
-            const options = component.functionMultiSelect.options;
+            const options = component.functionMultiSelect().options;
             expect(options!.length).toBe(3);
             expect(options![0].name).toBe('Function City 1');
             expect(options![1].disabled).toBe(true);
         });
 
         it('should work with function optionLabel', () => {
-            expect(component.functionMultiSelect.optionLabel).toBe('name');
+            expect(component.functionMultiSelect().optionLabel).toBe('name');
         });
 
         it('should work with function optionValue', () => {
-            expect(component.functionMultiSelect.optionValue).toBeUndefined();
+            expect(component.functionMultiSelect().optionValue).toBeUndefined();
         });
 
         it('should work with function optionDisabled', () => {
-            expect(component.functionMultiSelect.optionDisabled).toBe('disabled');
+            expect(component.functionMultiSelect().optionDisabled).toBe('disabled');
         });
 
         it('should work with function placeholder', () => {
-            expect(component.functionMultiSelect.placeholder()).toBe('Select from function');
+            expect(component.functionMultiSelect().placeholder()).toBe('Select from function');
         });
 
         it('should work with function filter', () => {
-            expect(component.functionMultiSelect.filter).toBe(true);
+            expect(component.functionMultiSelect().filter).toBe(true);
         });
     });
 
     describe('Late-loaded Data Sources', () => {
         it('should handle initially empty late-loaded data', () => {
-            expect(component.lateLoadMultiSelect.options!.length).toBe(0);
-            expect(component.lateLoadMultiSelect.loading).toBe(true);
+            expect(component.lateLoadMultiSelect().options!.length).toBe(0);
+            expect(component.lateLoadMultiSelect().loading).toBe(true);
         });
 
         it('should populate late-loaded data after timeout', async () => {
@@ -2845,9 +2851,9 @@ describe('MultiSelect Dynamic Data Sources', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.lateLoadMultiSelect.options!.length).toBe(3);
-            expect(component.lateLoadMultiSelect.loading).toBe(false);
-            expect(component.lateLoadMultiSelect.options![0].name).toBe('Late Loaded City 1');
+            expect(component.lateLoadMultiSelect().options!.length).toBe(3);
+            expect(component.lateLoadMultiSelect().loading).toBe(false);
+            expect(component.lateLoadMultiSelect().options![0].name).toBe('Late Loaded City 1');
         });
     });
 });
@@ -2882,7 +2888,7 @@ describe('MultiSelect Comprehensive Form Integration', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.reactiveMultiSelect.modelValue()).toEqual(cities);
+            expect(component.reactiveMultiSelect().modelValue()).toEqual(cities);
             expect(component.reactiveForm.get('cities')?.value).toEqual(cities);
         });
 
@@ -2892,7 +2898,7 @@ describe('MultiSelect Comprehensive Form Integration', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.reactiveMultiSelect.modelValue()).toEqual(cities);
+            expect(component.reactiveMultiSelect().modelValue()).toEqual(cities);
         });
 
         it('should work with FormControl reset', async () => {
@@ -2903,24 +2909,24 @@ describe('MultiSelect Comprehensive Form Integration', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.reactiveMultiSelect.modelValue()).toBeNull();
+            expect(component.reactiveMultiSelect().modelValue()).toBeNull();
             expect(component.reactiveForm.get('cities')?.pristine).toBe(true);
         });
 
         it('should work with FormControl disable/enable', async () => {
-            expect(component.reactiveMultiSelect.$disabled()).toBe(false);
+            expect(component.reactiveMultiSelect().$disabled()).toBe(false);
 
             component.disableReactiveControl();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.reactiveMultiSelect.$disabled()).toBe(true);
+            expect(component.reactiveMultiSelect().$disabled()).toBe(true);
 
             component.enableReactiveControl();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.reactiveMultiSelect.$disabled()).toBe(false);
+            expect(component.reactiveMultiSelect().$disabled()).toBe(false);
         });
 
         it('should work with FormControl markAsTouched', async () => {
@@ -3016,13 +3022,13 @@ describe('MultiSelect Comprehensive Form Integration', () => {
 
     describe('Template-driven Forms (NgModel) Integration', () => {
         it('should work with NgModel', async () => {
-            expect(component.ngModelMultiSelect.modelValue()).toEqual([]);
+            expect(component.ngModelMultiSelect().modelValue()).toEqual([]);
 
             component.ngModelValue = [component.allCities[0]];
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.ngModelMultiSelect.modelValue()).toEqual([component.allCities[0]]);
+            expect(component.ngModelMultiSelect().modelValue()).toEqual([component.allCities[0]]);
         });
 
         it('should work with NgModel validation', async () => {
@@ -3030,28 +3036,30 @@ describe('MultiSelect Comprehensive Form Integration', () => {
             await fixture.whenStable();
 
             // Should be invalid initially due to required
-            expect(component.citiesModel?.invalid).toBe(true);
-            expect(component.citiesModel?.errors?.['required']).toBe(true);
+            const citiesModel = component.citiesModel();
+            expect(citiesModel?.invalid).toBe(true);
+            expect(citiesModel?.errors?.['required']).toBe(true);
 
             // Add a value
             component.ngModelValue = [component.allCities[0]];
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.citiesModel?.valid).toBe(true);
+            expect(citiesModel?.valid).toBe(true);
         });
 
         it('should work with NgModel required validation', async () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.citiesModel?.hasError('required')).toBe(true);
+            const citiesModel = component.citiesModel();
+            expect(citiesModel?.hasError('required')).toBe(true);
 
             component.ngModelValue = [component.allCities[0]];
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(component.citiesModel?.hasError('required')).toBe(false);
+            expect(citiesModel?.hasError('required')).toBe(false);
         });
 
         it('should track form validity through template form', async () => {
@@ -3059,7 +3067,8 @@ describe('MultiSelect Comprehensive Form Integration', () => {
             await fixture.whenStable();
 
             // Initially should be invalid due to required fields
-            expect(component.templateForm?.valid).toBe(false);
+            const templateForm = component.templateForm();
+            expect(templateForm?.valid).toBe(false);
 
             // Set both required fields
             component.ngModelValue = [component.allCities[0]];
@@ -3072,12 +3081,12 @@ describe('MultiSelect Comprehensive Form Integration', () => {
             await fixture.whenStable();
 
             // Check if valid or at least not still false due to async validation
-            if (component.templateForm?.valid !== undefined) {
+            if (templateForm?.valid !== undefined) {
                 // Template form validation might be async, check that values are set at least
                 expect(component.ngModelValue.length).toBeGreaterThan(0);
                 expect(component.ngModelValidatedValue.length).toBeGreaterThan(0);
                 // Form validity depends on all controls being valid, just check it exists
-                expect(typeof component.templateForm.valid).toBe('boolean');
+                expect(typeof templateForm.valid).toBe('boolean');
             } else {
                 // Fallback: just check that values are set
                 expect(component.ngModelValue.length).toBeGreaterThan(0);
@@ -3106,7 +3115,7 @@ describe('MultiSelect ViewChild Properties', () => {
 
     it('should expose ViewChild properties correctly', async () => {
         // Test initial ViewChild access
-        expect(component.mainMultiSelect).toBeTruthy();
+        expect(component.mainMultiSelect()).toBeTruthy();
 
         // Show overlay to ensure ViewChild elements are rendered
         component.callShowMethod();
@@ -3136,15 +3145,15 @@ describe('MultiSelect ViewChild Properties', () => {
 
     it('should allow method calls through ViewChild', async () => {
         // Test show method
-        expect(component.mainMultiSelect.overlayVisible).toBeFalsy();
+        expect(component.mainMultiSelect().overlayVisible).toBeFalsy();
         component.callShowMethod();
         await fixture.whenStable();
-        expect(component.mainMultiSelect.overlayVisible).toBe(true);
+        expect(component.mainMultiSelect().overlayVisible).toBe(true);
 
         // Test hide method
         component.callHideMethod();
         await fixture.whenStable();
-        expect(component.mainMultiSelect.overlayVisible).toBe(false);
+        expect(component.mainMultiSelect().overlayVisible).toBe(false);
     });
 
     it('should allow model manipulation through ViewChild', async () => {
@@ -3200,7 +3209,7 @@ describe('MultiSelect ViewChild Properties', () => {
         await fixture.whenStable();
 
         // Set filter value
-        component.mainMultiSelect._filterValue.set('ViewChild City 1');
+        component.mainMultiSelect()._filterValue.set('ViewChild City 1');
         await fixture.whenStable();
 
         expect(component.getFilterValue()).toBe('ViewChild City 1');
@@ -3217,14 +3226,14 @@ describe('MultiSelect ViewChild Properties', () => {
             expect(limitResult).toBe(false);
 
             // Set selection limit
-            component.mainMultiSelect.selectionLimit = 2;
+            component.mainMultiSelect().selectionLimit = 2;
             component.callUpdateModelMethod([component.cities[0], component.cities[1]]);
             await fixture.whenStable();
 
             expect(component.isMaxSelectionLimitReached()).toBe(true);
         } else {
             // Method doesn't exist, test selection limit directly
-            component.mainMultiSelect.selectionLimit = 2;
+            component.mainMultiSelect().selectionLimit = 2;
             component.callUpdateModelMethod([component.cities[0], component.cities[1]]);
             await fixture.whenStable();
 
@@ -3255,9 +3264,9 @@ describe('MultiSelect Complex Edge Cases', () => {
     describe('Performance and Large Datasets', () => {
         it('should handle large datasets efficiently', async () => {
             expect(component.largeDataset.length).toBe(10000);
-            expect(component.largeDataMultiSelect.virtualScroll).toBe(true);
+            expect(component.largeDataMultiSelect().virtualScroll).toBe(true);
 
-            component.largeDataMultiSelect.show();
+            component.largeDataMultiSelect().show();
             await fixture.whenStable();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
@@ -3306,7 +3315,7 @@ describe('MultiSelect Complex Edge Cases', () => {
         it('should handle Unicode characters correctly', async () => {
             expect(component.unicodeOptions.length).toBe(7);
 
-            component.unicodeMultiSelect.show();
+            component.unicodeMultiSelect().show();
             await fixture.whenStable();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
@@ -3362,7 +3371,7 @@ describe('MultiSelect Complex Edge Cases', () => {
         });
 
         it('should render XSS content safely in the DOM', async () => {
-            component.xssMultiSelect.show();
+            component.xssMultiSelect().show();
             await fixture.whenStable();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
@@ -3378,7 +3387,7 @@ describe('MultiSelect Complex Edge Cases', () => {
     describe('Null and Undefined Handling', () => {
         it('should handle null options gracefully', async () => {
             expect(() => {
-                component.nullHandlingMultiSelect.show();
+                component.nullHandlingMultiSelect().show();
             }).not.toThrow();
 
             await fixture.whenStable();
@@ -3411,7 +3420,7 @@ describe('MultiSelect Complex Edge Cases', () => {
 
         it('should not crash with circular object references', async () => {
             expect(() => {
-                component.circularMultiSelect.show();
+                component.circularMultiSelect().show();
             }).not.toThrow();
 
             await fixture.whenStable();

--- a/packages/optimus-ui/src/multiselect/multiselect.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.ts
@@ -929,11 +929,11 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
      */
     @Output() onSelectAllChange: EventEmitter<MultiSelectSelectAllChangeEvent> = new EventEmitter<MultiSelectSelectAllChangeEvent>();
 
-    readonly overlayViewChild = viewChild<Nullable<Overlay>>('overlay');
+    readonly overlayViewChild = viewChild.required<Overlay>('overlay');
 
     readonly filterInputChild = viewChild<Nullable<ElementRef>>('filterInput');
 
-    readonly focusInputViewChild = viewChild<Nullable<ElementRef>>('focusInput');
+    readonly focusInputViewChild = viewChild.required<ElementRef>('focusInput');
 
     readonly itemsViewChild = viewChild<Nullable<ElementRef>>('items');
 
@@ -1358,7 +1358,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         if (this.filtered) {
             this.zone.runOutsideAngular(() => {
                 setTimeout(() => {
-                    this.overlayViewChild()?.alignOverlay();
+                    this.overlayViewChild().alignOverlay();
                 }, 1);
             });
             this.filtered = false;
@@ -1419,7 +1419,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         this.updateModel(value, originalEvent);
         index !== -1 && this.focusedOptionIndex.set(index);
 
-        isFocus && focus(this.focusInputViewChild()?.nativeElement);
+        isFocus && focus(this.focusInputViewChild().nativeElement);
 
         this.onChange.emit({
             originalEvent: event,
@@ -1844,12 +1844,12 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     onContainerClick(event: any) {
         const focusInputViewChild = this.focusInputViewChild();
-        if (this.$disabled() || this.loading || this.readonly || event.target?.isSameNode?.(focusInputViewChild?.nativeElement)) {
+        if (this.$disabled() || this.loading || this.readonly || event.target?.isSameNode?.(focusInputViewChild.nativeElement)) {
             return;
         }
 
         const overlayViewChild = this.overlayViewChild();
-        if (!overlayViewChild || !overlayViewChild.el.nativeElement.contains(event.target)) {
+        if (!overlayViewChild.el.nativeElement.contains(event.target)) {
             if (this.clickInProgress) {
                 return;
             }
@@ -1862,7 +1862,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
             this.overlayVisible ? this.hide(true) : this.show(true);
         }
-        focusInputViewChild?.nativeElement.focus({ preventScroll: true });
+        focusInputViewChild.nativeElement.focus({ preventScroll: true });
         this.onClick.emit(event);
         this.cd.detectChanges();
     }
@@ -1870,7 +1870,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     onFirstHiddenFocus(event) {
         const focusInputViewChild = this.focusInputViewChild();
         const focusableEl =
-            event.relatedTarget === focusInputViewChild?.nativeElement ? getFirstFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
+            event.relatedTarget === focusInputViewChild.nativeElement ? getFirstFocusableElement(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild.nativeElement;
 
         focus(focusableEl);
     }
@@ -1901,14 +1901,14 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
         !this.virtualScrollerDisabled && this.scroller()?.scrollToIndex(0);
         setTimeout(() => {
-            this.overlayViewChild()?.alignOverlay();
+            this.overlayViewChild().alignOverlay();
         });
     }
 
     onLastHiddenFocus(event) {
         const focusInputViewChild = this.focusInputViewChild();
         const focusableEl =
-            event.relatedTarget === focusInputViewChild?.nativeElement ? getLastFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
+            event.relatedTarget === focusInputViewChild.nativeElement ? getLastFocusableElement(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild.nativeElement;
 
         focus(focusableEl);
     }
@@ -2021,7 +2021,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         this.focusedOptionIndex.set(focusedOptionIndex);
 
         if (isFocus) {
-            focus(this.focusInputViewChild()?.nativeElement);
+            focus(this.focusInputViewChild().nativeElement);
         }
 
         this.cd.markForCheck();
@@ -2042,12 +2042,12 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
             unblockBodyScroll();
         }
 
-        isFocus && focus(this.focusInputViewChild()?.nativeElement);
+        isFocus && focus(this.focusInputViewChild().nativeElement);
         this.cd.markForCheck();
     }
 
     onOverlayBeforeEnter(event: any) {
-        this.itemsWrapper = <any>findSingle(this.overlayViewChild()?.overlayViewChild()?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
+        this.itemsWrapper = <any>findSingle(this.overlayViewChild().overlayViewChild()?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
         this.virtualScroll && this.scroller()?.setContentEl(this.itemsViewChild()?.nativeElement);
 
         if (this.options && this.options.length) {
@@ -2214,7 +2214,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     hasFocusableElements() {
-        return getFocusableElements(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
+        return getFocusableElements(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
     }
 
     hasFilter() {

--- a/packages/optimus-ui/src/multiselect/multiselect.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.ts
@@ -1869,8 +1869,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     onFirstHiddenFocus(event) {
         const focusInputViewChild = this.focusInputViewChild();
-        const focusableEl =
-            event.relatedTarget === focusInputViewChild.nativeElement ? getFirstFocusableElement(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild.nativeElement;
+        const focusableEl = event.relatedTarget === focusInputViewChild.nativeElement ? getFirstFocusableElement(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild.nativeElement;
 
         focus(focusableEl);
     }
@@ -1907,8 +1906,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     onLastHiddenFocus(event) {
         const focusInputViewChild = this.focusInputViewChild();
-        const focusableEl =
-            event.relatedTarget === focusInputViewChild.nativeElement ? getLastFocusableElement(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild.nativeElement;
+        const focusableEl = event.relatedTarget === focusInputViewChild.nativeElement ? getLastFocusableElement(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild.nativeElement;
 
         focus(focusableEl);
     }

--- a/packages/optimus-ui/src/multiselect/multiselect.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.ts
@@ -16,7 +16,6 @@ import {
     NgZone,
     numberAttribute,
     Output,
-    QueryList,
     Signal,
     signal,
     TemplateRef,
@@ -1123,7 +1122,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;

--- a/packages/optimus-ui/src/multiselect/multiselect.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     effect,
     ElementRef,
     EventEmitter,
@@ -22,8 +20,10 @@ import {
     Signal,
     signal,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionOptions } from '@openng/optimus-ui-motion';
@@ -231,7 +231,7 @@ export class MultiSelectItem extends BaseComponent {
             [tooltipStyleClass]="tooltipStyleClass"
         >
             <div [pBind]="ptm('label')" [class]="cx('label')" [attr.data-p]="labelDataP">
-                <ng-container *ngIf="!selectedItemsTemplate && !_selectedItemsTemplate">
+                <ng-container *ngIf="!selectedItemsTemplate() && !_selectedItemsTemplate">
                     <ng-container *ngIf="display === 'comma'">{{ label() || 'empty' }}</ng-container>
                     <ng-container *ngIf="display === 'chip'">
                         @if (chipSelectedItems() && chipSelectedItems().length === maxSelectedLabels) {
@@ -239,17 +239,17 @@ export class MultiSelectItem extends BaseComponent {
                         } @else {
                             <div #token *ngFor="let item of chipSelectedItems(); let i = index" [pBind]="ptm('chipItem')" [class]="cx('chipItem')">
                                 <p-chip [pt]="ptm('pcChip')" [unstyled]="unstyled()" [class]="cx('pcChip')" [label]="getLabelByValue(item)" [removable]="!$disabled() && !readonly" (onRemove)="removeOption(item, $event)" [removeIcon]="chipIcon">
-                                    <ng-container *ngIf="chipIconTemplate || _chipIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate">
+                                    <ng-container *ngIf="chipIconTemplate() || _chipIconTemplate || removeTokenIconTemplate() || _removeTokenIconTemplate">
                                         <ng-template #removeicon>
                                             <ng-container *ngIf="!$disabled() && !readonly">
                                                 <span
                                                     [class]="cx('chipIcon')"
-                                                    *ngIf="chipIconTemplate || _chipIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate"
+                                                    *ngIf="chipIconTemplate() || _chipIconTemplate || removeTokenIconTemplate() || _removeTokenIconTemplate"
                                                     (click)="removeOption(item, $event)"
                                                     [attr.aria-hidden]="true"
                                                     [pBind]="ptm('chipIcon')"
                                                 >
-                                                    <ng-container *ngTemplateOutlet="chipIconTemplate || _chipIconTemplate || removeTokenIconTemplate || _removeTokenIconTemplate; context: { class: 'p-multiselect-chip-icon' }"></ng-container>
+                                                    <ng-container *ngTemplateOutlet="chipIconTemplate() || _chipIconTemplate || removeTokenIconTemplate() || _removeTokenIconTemplate; context: { class: 'p-multiselect-chip-icon' }"></ng-container>
                                                 </span>
                                             </ng-container>
                                         </ng-template>
@@ -260,35 +260,35 @@ export class MultiSelectItem extends BaseComponent {
                         <ng-container *ngIf="!modelValue() || modelValue().length === 0">{{ placeholder() || 'empty' }}</ng-container>
                     </ng-container>
                 </ng-container>
-                <ng-container *ngIf="selectedItemsTemplate || _selectedItemsTemplate">
-                    <ng-container *ngTemplateOutlet="selectedItemsTemplate || _selectedItemsTemplate; context: { $implicit: selectedOptions, removeChip: removeOption.bind(this) }"></ng-container>
+                <ng-container *ngIf="selectedItemsTemplate() || _selectedItemsTemplate">
+                    <ng-container *ngTemplateOutlet="selectedItemsTemplate() || _selectedItemsTemplate; context: { $implicit: selectedOptions, removeChip: removeOption.bind(this) }"></ng-container>
                     <ng-container *ngIf="!modelValue() || modelValue().length === 0">{{ placeholder() || 'empty' }}</ng-container>
                 </ng-container>
             </div>
         </div>
         <ng-container *ngIf="isVisibleClearIcon">
-            <svg data-p-icon="times" *ngIf="!clearIconTemplate && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear($event)" [attr.aria-hidden]="true" />
-            <span *ngIf="clearIconTemplate || _clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear($event)" [attr.aria-hidden]="true">
-                <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
+            <svg data-p-icon="times" *ngIf="!clearIconTemplate() && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear($event)" [attr.aria-hidden]="true" />
+            <span *ngIf="clearIconTemplate() || _clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear($event)" [attr.aria-hidden]="true">
+                <ng-template *ngTemplateOutlet="clearIconTemplate() || _clearIconTemplate"></ng-template>
             </span>
         </ng-container>
         <div [pBind]="ptm('dropdown')" [class]="cx('dropdown')">
             <ng-container *ngIf="loading; else elseBlock">
-                <ng-container *ngIf="loadingIconTemplate || _loadingIconTemplate">
-                    <ng-container *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate"></ng-container>
+                <ng-container *ngIf="loadingIconTemplate() || _loadingIconTemplate">
+                    <ng-container *ngTemplateOutlet="loadingIconTemplate() || _loadingIconTemplate"></ng-container>
                 </ng-container>
-                <ng-container *ngIf="!loadingIconTemplate && !_loadingIconTemplate">
+                <ng-container *ngIf="!loadingIconTemplate() && !_loadingIconTemplate">
                     <span *ngIf="loadingIcon" [pBind]="ptm('loadingIcon')" [class]="cn(cx('loadingIcon'), 'pi-spin ' + loadingIcon)" [attr.aria-hidden]="true"></span>
                     <span *ngIf="!loadingIcon" [pBind]="ptm('loadingIcon')" [class]="cn(cx('loadingIcon'), 'pi pi-spinner pi-spin')" [attr.aria-hidden]="true"></span>
                 </ng-container>
             </ng-container>
             <ng-template #elseBlock>
-                <ng-container *ngIf="!dropdownIconTemplate && !_dropdownIconTemplate">
+                <ng-container *ngIf="!dropdownIconTemplate() && !_dropdownIconTemplate">
                     <span *ngIf="dropdownIcon" [pBind]="ptm('dropdownIcon')" [class]="cx('dropdownIcon')" [ngClass]="dropdownIcon" [attr.aria-hidden]="true" [attr.data-p]="dropdownIconDataP"></span>
                     <svg data-p-icon="chevron-down" *ngIf="!dropdownIcon" [pBind]="ptm('dropdownIcon')" [class]="cx('dropdownIcon')" [attr.aria-hidden]="true" [attr.data-p]="dropdownIconDataP" />
                 </ng-container>
-                <span *ngIf="dropdownIconTemplate || _dropdownIconTemplate" [pBind]="ptm('dropdownIcon')" [class]="cx('dropdownIcon')" [attr.aria-hidden]="true">
-                    <ng-template *ngTemplateOutlet="dropdownIconTemplate || _dropdownIconTemplate; context: { dataP: dropdownIconDataP }"></ng-template>
+                <span *ngIf="dropdownIconTemplate() || _dropdownIconTemplate" [pBind]="ptm('dropdownIcon')" [class]="cx('dropdownIcon')" [attr.aria-hidden]="true">
+                    <ng-template *ngTemplateOutlet="dropdownIconTemplate() || _dropdownIconTemplate; context: { dataP: dropdownIconDataP }"></ng-template>
                 </span>
             </ng-template>
         </div>
@@ -319,11 +319,11 @@ export class MultiSelectItem extends BaseComponent {
                         [pBind]="ptm('firstHiddenFocusableEl')"
                     >
                     </span>
-                    <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
                     <div [pBind]="ptm('header')" [class]="cx('header')" *ngIf="showHeader">
                         <ng-content select="p-header"></ng-content>
-                        <ng-container *ngIf="filterTemplate || _filterTemplate; else builtInFilterElement">
-                            <ng-container *ngTemplateOutlet="filterTemplate || _filterTemplate; context: { options: filterOptions }"></ng-container>
+                        <ng-container *ngIf="filterTemplate() || _filterTemplate; else builtInFilterElement">
+                            <ng-container *ngTemplateOutlet="filterTemplate() || _filterTemplate; context: { options: filterOptions }"></ng-container>
                         </ng-container>
                         <ng-template #builtInFilterElement>
                             <p-checkbox
@@ -340,10 +340,10 @@ export class MultiSelectItem extends BaseComponent {
                                 #headerCheckbox
                             >
                                 <ng-template #icon let-klass="class">
-                                    <svg data-p-icon="check" *ngIf="!headerCheckboxIconTemplate && !_headerCheckboxIconTemplate && allSelected()" [class]="klass" [pBind]="getHeaderCheckboxPTOptions('pcHeaderCheckbox.icon')" />
+                                    <svg data-p-icon="check" *ngIf="!headerCheckboxIconTemplate() && !_headerCheckboxIconTemplate && allSelected()" [class]="klass" [pBind]="getHeaderCheckboxPTOptions('pcHeaderCheckbox.icon')" />
                                     <ng-template
                                         *ngTemplateOutlet="
-                                            headerCheckboxIconTemplate || _headerCheckboxIconTemplate;
+                                            headerCheckboxIconTemplate() || _headerCheckboxIconTemplate;
                                             context: {
                                                 checked: allSelected(),
                                                 partialSelected: partialSelected(),
@@ -377,9 +377,9 @@ export class MultiSelectItem extends BaseComponent {
                                     [unstyled]="unstyled()"
                                 />
                                 <p-inputicon [pt]="ptm('pcFilterIconContainer')" [unstyled]="unstyled()">
-                                    <svg data-p-icon="search" *ngIf="!filterIconTemplate && !_filterIconTemplate" [pBind]="ptm('filterIcon')" />
-                                    <span *ngIf="filterIconTemplate || _filterIconTemplate" [pBind]="ptm('filterIcon')" class="p-multiselect-filter-icon">
-                                        <ng-template *ngTemplateOutlet="filterIconTemplate || _filterIconTemplate"></ng-template>
+                                    <svg data-p-icon="search" *ngIf="!filterIconTemplate() && !_filterIconTemplate" [pBind]="ptm('filterIcon')" />
+                                    <span *ngIf="filterIconTemplate() || _filterIconTemplate" [pBind]="ptm('filterIcon')" class="p-multiselect-filter-icon">
+                                        <ng-template *ngTemplateOutlet="filterIconTemplate() || _filterIconTemplate"></ng-template>
                                     </span>
                                 </p-inputicon>
                             </p-iconfield>
@@ -401,9 +401,9 @@ export class MultiSelectItem extends BaseComponent {
                             <ng-template #content let-items let-scrollerOptions="options">
                                 <ng-container *ngTemplateOutlet="buildInItems; context: { $implicit: items, options: scrollerOptions }"></ng-container>
                             </ng-template>
-                            <ng-container *ngIf="loaderTemplate || _loaderTemplate">
+                            <ng-container *ngIf="loaderTemplate() || _loaderTemplate">
                                 <ng-template #loader let-scrollerOptions="options">
-                                    <ng-container *ngTemplateOutlet="loaderTemplate || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
+                                    <ng-container *ngTemplateOutlet="loaderTemplate() || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
                                 </ng-template>
                             </ng-container>
                         </p-scroller>
@@ -416,8 +416,8 @@ export class MultiSelectItem extends BaseComponent {
                                 <ng-template ngFor let-option [ngForOf]="items" let-i="index">
                                     <ng-container *ngIf="isOptionGroup(option)">
                                         <li [pBind]="ptm('optionGroup')" [attr.id]="id + '_' + getOptionIndex(i, scrollerOptions)" [class]="cx('optionGroup')" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option">
-                                            <span *ngIf="!groupTemplate && option.optionGroup">{{ getOptionGroupLabel(option.optionGroup) }}</span>
-                                            <ng-container *ngIf="option.optionGroup && groupTemplate" [ngTemplateOutlet]="groupTemplate" [ngTemplateOutletContext]="{ $implicit: option.optionGroup }"></ng-container>
+                                            <span *ngIf="!groupTemplate() && option.optionGroup">{{ getOptionGroupLabel(option.optionGroup) }}</span>
+                                            <ng-container *ngIf="option.optionGroup && groupTemplate()" [ngTemplateOutlet]="groupTemplate()" [ngTemplateOutletContext]="{ $implicit: option.optionGroup }"></ng-container>
                                         </li>
                                     </ng-container>
                                     <ng-container *ngIf="!isOptionGroup(option)">
@@ -430,8 +430,8 @@ export class MultiSelectItem extends BaseComponent {
                                             [selected]="isSelected(option)"
                                             [label]="getOptionLabel(option)"
                                             [disabled]="isOptionDisabled(option)"
-                                            [template]="itemTemplate || _itemTemplate"
-                                            [itemCheckboxIconTemplate]="itemCheckboxIconTemplate || _itemCheckboxIconTemplate"
+                                            [template]="itemTemplate() || _itemTemplate"
+                                            [itemCheckboxIconTemplate]="itemCheckboxIconTemplate() || _itemCheckboxIconTemplate"
                                             [itemSize]="scrollerOptions.itemSize"
                                             [focused]="focusedOptionIndex() === getOptionIndex(i, scrollerOptions)"
                                             [ariaPosInset]="getAriaPosInset(getOptionIndex(i, scrollerOptions))"
@@ -447,25 +447,25 @@ export class MultiSelectItem extends BaseComponent {
                                 </ng-template>
 
                                 <li *ngIf="hasFilter() && isEmpty()" [pBind]="ptm('emptyMessage')" [class]="cx('emptyMessage')" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option">
-                                    @if (!emptyFilterTemplate && !_emptyFilterTemplate && !emptyTemplate && !_emptyTemplate) {
+                                    @if (!emptyFilterTemplate() && !_emptyFilterTemplate && !emptyTemplate() && !_emptyTemplate) {
                                         {{ emptyFilterMessageLabel }}
                                     } @else {
-                                        <ng-container *ngTemplateOutlet="emptyFilterTemplate || _emptyFilterTemplate || emptyTemplate || _emptyFilterTemplate"></ng-container>
+                                        <ng-container *ngTemplateOutlet="emptyFilterTemplate() || _emptyFilterTemplate || emptyTemplate() || _emptyFilterTemplate"></ng-container>
                                     }
                                 </li>
                                 <li *ngIf="!hasFilter() && isEmpty()" [pBind]="ptm('emptyMessage')" [class]="cx('emptyMessage')" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option">
-                                    @if (!emptyTemplate && !_emptyTemplate) {
+                                    @if (!emptyTemplate() && !_emptyTemplate) {
                                         {{ emptyMessageLabel }}
                                     } @else {
-                                        <ng-container *ngTemplateOutlet="emptyTemplate || _emptyTemplate"></ng-container>
+                                        <ng-container *ngTemplateOutlet="emptyTemplate() || _emptyTemplate"></ng-container>
                                     }
                                 </li>
                             </ul>
                         </ng-template>
                     </div>
-                    <div *ngIf="footerFacet || footerTemplate || _footerTemplate">
+                    <div *ngIf="footerFacet() || footerTemplate() || _footerTemplate">
                         <ng-content select="p-footer"></ng-content>
-                        <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
                     </div>
 
                     <span
@@ -930,25 +930,25 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
      */
     @Output() onSelectAllChange: EventEmitter<MultiSelectSelectAllChangeEvent> = new EventEmitter<MultiSelectSelectAllChangeEvent>();
 
-    @ViewChild('overlay') overlayViewChild: Nullable<Overlay>;
+    readonly overlayViewChild = viewChild<Nullable<Overlay>>('overlay');
 
-    @ViewChild('filterInput') filterInputChild: Nullable<ElementRef>;
+    readonly filterInputChild = viewChild<Nullable<ElementRef>>('filterInput');
 
-    @ViewChild('focusInput') focusInputViewChild: Nullable<ElementRef>;
+    readonly focusInputViewChild = viewChild<Nullable<ElementRef>>('focusInput');
 
-    @ViewChild('items') itemsViewChild: Nullable<ElementRef>;
+    readonly itemsViewChild = viewChild<Nullable<ElementRef>>('items');
 
-    @ViewChild('scroller') scroller: Nullable<Scroller>;
+    readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
-    @ViewChild('lastHiddenFocusableEl') lastHiddenFocusableElementOnOverlay: Nullable<ElementRef>;
+    readonly lastHiddenFocusableElementOnOverlay = viewChild<Nullable<ElementRef>>('lastHiddenFocusableEl');
 
-    @ViewChild('firstHiddenFocusableEl') firstHiddenFocusableElementOnOverlay: Nullable<ElementRef>;
+    readonly firstHiddenFocusableElementOnOverlay = viewChild<Nullable<ElementRef>>('firstHiddenFocusableEl');
 
-    @ViewChild('headerCheckbox') headerCheckboxViewChild: Nullable<Checkbox>;
+    readonly headerCheckboxViewChild = viewChild<Nullable<Checkbox>>('headerCheckbox');
 
-    @ContentChild(Footer) footerFacet: any;
+    readonly footerFacet = contentChild(Footer);
 
-    @ContentChild(Header) headerFacet: any;
+    readonly headerFacet = contentChild(Header);
 
     _componentStyle = inject(MultiSelectStyle);
 
@@ -976,105 +976,105 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
      * Custom item template.
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<MultiSelectItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<MultiSelectItemTemplateContext>>('item', { descendants: false });
 
     /**
      * Custom group template.
      * @group Templates
      */
-    @ContentChild('group', { descendants: false }) groupTemplate: TemplateRef<MultiSelectGroupTemplateContext> | undefined;
+    readonly groupTemplate = contentChild<TemplateRef<MultiSelectGroupTemplateContext>>('group', { descendants: false });
 
     /**
      * Custom loader template.
      * @group Templates
      */
-    @ContentChild('loader', { descendants: false }) loaderTemplate: TemplateRef<MultiSelectLoaderTemplateContext> | undefined;
+    readonly loaderTemplate = contentChild<TemplateRef<MultiSelectLoaderTemplateContext>>('loader', { descendants: false });
 
     /**
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
 
     /**
      * Custom filter template.
      * @group Templates
      */
-    @ContentChild('filter', { descendants: false }) filterTemplate: TemplateRef<MultiSelectFilterTemplateContext> | undefined;
+    readonly filterTemplate = contentChild<TemplateRef<MultiSelectFilterTemplateContext>>('filter', { descendants: false });
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: TemplateRef<void> | undefined;
+    readonly footerTemplate = contentChild<TemplateRef<void>>('footer', { descendants: false });
 
     /**
      * Custom empty filter template.
      * @group Templates
      */
-    @ContentChild('emptyfilter', { descendants: false }) emptyFilterTemplate: TemplateRef<void> | undefined;
+    readonly emptyFilterTemplate = contentChild<TemplateRef<void>>('emptyfilter', { descendants: false });
 
     /**
      * Custom empty template.
      * @group Templates
      */
-    @ContentChild('empty', { descendants: false }) emptyTemplate: TemplateRef<void> | undefined;
+    readonly emptyTemplate = contentChild<TemplateRef<void>>('empty', { descendants: false });
 
     /**
      * Custom selected items template.
      * @group Templates
      */
-    @ContentChild('selecteditems', { descendants: false }) selectedItemsTemplate: TemplateRef<MultiSelectSelectedItemsTemplateContext> | undefined;
+    readonly selectedItemsTemplate = contentChild<TemplateRef<MultiSelectSelectedItemsTemplateContext>>('selecteditems', { descendants: false });
 
     /**
      * Custom loading icon template.
      * @group Templates
      */
-    @ContentChild('loadingicon', { descendants: false }) loadingIconTemplate: TemplateRef<void> | undefined;
+    readonly loadingIconTemplate = contentChild<TemplateRef<void>>('loadingicon', { descendants: false });
 
     /**
      * Custom filter icon template.
      * @group Templates
      */
-    @ContentChild('filtericon', { descendants: false }) filterIconTemplate: TemplateRef<void> | undefined;
+    readonly filterIconTemplate = contentChild<TemplateRef<void>>('filtericon', { descendants: false });
 
     /**
      * Custom remove token icon template.
      * @group Templates
      */
-    @ContentChild('removetokenicon', { descendants: false }) removeTokenIconTemplate: TemplateRef<MultiSelectChipIconTemplateContext> | undefined;
+    readonly removeTokenIconTemplate = contentChild<TemplateRef<MultiSelectChipIconTemplateContext>>('removetokenicon', { descendants: false });
 
     /**
      * Custom chip icon template.
      * @group Templates
      */
-    @ContentChild('chipicon', { descendants: false }) chipIconTemplate: TemplateRef<MultiSelectChipIconTemplateContext> | undefined;
+    readonly chipIconTemplate = contentChild<TemplateRef<MultiSelectChipIconTemplateContext>>('chipicon', { descendants: false });
 
     /**
      * Custom clear icon template.
      * @group Templates
      */
-    @ContentChild('clearicon', { descendants: false }) clearIconTemplate: TemplateRef<void> | undefined;
+    readonly clearIconTemplate = contentChild<TemplateRef<void>>('clearicon', { descendants: false });
 
     /**
      * Custom dropdown icon template.
      * @group Templates
      */
-    @ContentChild('dropdownicon', { descendants: false }) dropdownIconTemplate: TemplateRef<MultiSelectDropdownIconTemplateContext> | undefined;
+    readonly dropdownIconTemplate = contentChild<TemplateRef<MultiSelectDropdownIconTemplateContext>>('dropdownicon', { descendants: false });
 
     /**
      * Custom item checkbox icon template.
      * @group Templates
      */
-    @ContentChild('itemcheckboxicon', { descendants: false }) itemCheckboxIconTemplate: TemplateRef<MultiSelectItemCheckboxIconTemplateContext> | undefined;
+    readonly itemCheckboxIconTemplate = contentChild<TemplateRef<MultiSelectItemCheckboxIconTemplateContext>>('itemcheckboxicon', { descendants: false });
 
     /**
      * Custom header checkbox icon template.
      * @group Templates
      */
-    @ContentChild('headercheckboxicon', { descendants: false }) headerCheckboxIconTemplate: TemplateRef<MultiSelectHeaderCheckboxIconTemplateContext> | undefined;
+    readonly headerCheckboxIconTemplate = contentChild<TemplateRef<MultiSelectHeaderCheckboxIconTemplateContext>>('headercheckboxicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _itemTemplate: TemplateRef<MultiSelectItemTemplateContext> | undefined;
 
@@ -1123,7 +1123,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -1361,7 +1361,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         if (this.filtered) {
             this.zone.runOutsideAngular(() => {
                 setTimeout(() => {
-                    this.overlayViewChild?.alignOverlay();
+                    this.overlayViewChild()?.alignOverlay();
                 }, 1);
             });
             this.filtered = false;
@@ -1422,7 +1422,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         this.updateModel(value, originalEvent);
         index !== -1 && this.focusedOptionIndex.set(index);
 
-        isFocus && focus(this.focusInputViewChild?.nativeElement);
+        isFocus && focus(this.focusInputViewChild()?.nativeElement);
 
         this.onChange.emit({
             originalEvent: event,
@@ -1832,7 +1832,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     onTabKey(event: KeyboardEvent, pressedInInputText = false) {
         if (!pressedInInputText) {
             if (this.overlayVisible && this.hasFocusableElements()) {
-                focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay?.nativeElement : this.firstHiddenFocusableElementOnOverlay?.nativeElement);
+                focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay()?.nativeElement : this.firstHiddenFocusableElementOnOverlay()?.nativeElement);
 
                 event.preventDefault();
             } else {
@@ -1846,11 +1846,13 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     onContainerClick(event: any) {
-        if (this.$disabled() || this.loading || this.readonly || event.target?.isSameNode?.(this.focusInputViewChild?.nativeElement)) {
+        const focusInputViewChild = this.focusInputViewChild();
+        if (this.$disabled() || this.loading || this.readonly || event.target?.isSameNode?.(focusInputViewChild?.nativeElement)) {
             return;
         }
 
-        if (!this.overlayViewChild || !this.overlayViewChild.el.nativeElement.contains(event.target)) {
+        const overlayViewChild = this.overlayViewChild();
+        if (!overlayViewChild || !overlayViewChild.el.nativeElement.contains(event.target)) {
             if (this.clickInProgress) {
                 return;
             }
@@ -1863,14 +1865,15 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
             this.overlayVisible ? this.hide(true) : this.show(true);
         }
-        this.focusInputViewChild?.nativeElement.focus({ preventScroll: true });
+        focusInputViewChild?.nativeElement.focus({ preventScroll: true });
         this.onClick.emit(event);
         this.cd.detectChanges();
     }
 
     onFirstHiddenFocus(event) {
+        const focusInputViewChild = this.focusInputViewChild();
         const focusableEl =
-            event.relatedTarget === this.focusInputViewChild?.nativeElement ? getFirstFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInputViewChild?.nativeElement;
+            event.relatedTarget === focusInputViewChild?.nativeElement ? getFirstFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
 
         focus(focusableEl);
     }
@@ -1899,15 +1902,16 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         this.focusedOptionIndex.set(-1);
         this.onFilter.emit({ originalEvent: event, filter: this._filterValue() });
 
-        !this.virtualScrollerDisabled && this.scroller?.scrollToIndex(0);
+        !this.virtualScrollerDisabled && this.scroller()?.scrollToIndex(0);
         setTimeout(() => {
-            this.overlayViewChild?.alignOverlay();
+            this.overlayViewChild()?.alignOverlay();
         });
     }
 
     onLastHiddenFocus(event) {
+        const focusInputViewChild = this.focusInputViewChild();
         const focusableEl =
-            event.relatedTarget === this.focusInputViewChild?.nativeElement ? getLastFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInputViewChild?.nativeElement;
+            event.relatedTarget === focusInputViewChild?.nativeElement ? getLastFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
 
         focus(focusableEl);
     }
@@ -1964,7 +1968,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         }
 
         this.onChange.emit({ originalEvent: event, value: this.value });
-        DomHandler.focus(this.headerCheckboxViewChild?.inputViewChild?.nativeElement);
+        DomHandler.focus(this.headerCheckboxViewChild()?.inputViewChild()?.nativeElement);
         this.headerCheckboxFocus = true;
 
         event.originalEvent.preventDefault();
@@ -1984,13 +1988,14 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     scrollInView(index = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
-        if (this.itemsViewChild && this.itemsViewChild.nativeElement) {
-            const element = findSingle(this.itemsViewChild.nativeElement, `li[id="${id}"]`);
+        const itemsViewChild = this.itemsViewChild();
+        if (itemsViewChild && itemsViewChild.nativeElement) {
+            const element = findSingle(itemsViewChild.nativeElement, `li[id="${id}"]`);
             if (element) {
                 element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
             } else if (!this.virtualScrollerDisabled) {
                 setTimeout(() => {
-                    this.virtualScroll && this.scroller?.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex());
+                    this.virtualScroll && this.scroller()?.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex());
                 }, 0);
             }
         }
@@ -2019,7 +2024,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         this.focusedOptionIndex.set(focusedOptionIndex);
 
         if (isFocus) {
-            focus(this.focusInputViewChild?.nativeElement);
+            focus(this.focusInputViewChild()?.nativeElement);
         }
 
         this.cd.markForCheck();
@@ -2040,19 +2045,19 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
             unblockBodyScroll();
         }
 
-        isFocus && focus(this.focusInputViewChild?.nativeElement);
+        isFocus && focus(this.focusInputViewChild()?.nativeElement);
         this.cd.markForCheck();
     }
 
     onOverlayBeforeEnter(event: any) {
-        this.itemsWrapper = <any>findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
-        this.virtualScroll && this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
+        this.itemsWrapper = <any>findSingle(this.overlayViewChild()?.overlayViewChild()?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
+        this.virtualScroll && this.scroller()?.setContentEl(this.itemsViewChild()?.nativeElement);
 
         if (this.options && this.options.length) {
             if (this.virtualScroll) {
                 const selectedIndex = this.modelValue() ? this.focusedOptionIndex() : -1;
                 if (selectedIndex !== -1) {
-                    this.scroller?.scrollToIndex(selectedIndex);
+                    this.scroller()?.scrollToIndex(selectedIndex);
                 }
             } else {
                 let selectedListItem = findSingle(this.itemsWrapper, '[data-pc-section="option"][data-p-selected="true"]');
@@ -2063,11 +2068,12 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
             }
         }
 
-        if (this.filterInputChild && this.filterInputChild.nativeElement) {
+        const filterInputChild = this.filterInputChild();
+        if (filterInputChild && filterInputChild.nativeElement) {
             this.preventModelTouched = true;
 
             if (this.autofocusFilter) {
-                this.filterInputChild.nativeElement.focus();
+                filterInputChild.nativeElement.focus();
             }
         }
 
@@ -2081,8 +2087,9 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     resetFilter() {
-        if (this.filterInputChild && this.filterInputChild.nativeElement) {
-            this.filterInputChild.nativeElement.value = '';
+        const filterInputChild = this.filterInputChild();
+        if (filterInputChild && filterInputChild.nativeElement) {
+            filterInputChild.nativeElement.value = '';
         }
 
         this._filterValue.set(null);
@@ -2210,7 +2217,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     hasFocusableElements() {
-        return getFocusableElements(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
+        return getFocusableElements(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
     }
 
     hasFilter() {

--- a/packages/optimus-ui/src/multiselect/multiselect.ts
+++ b/packages/optimus-ui/src/multiselect/multiselect.ts
@@ -27,7 +27,7 @@ import {
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionOptions } from '@openng/optimus-ui-motion';
 import { deepEquals, equals, findLastIndex, findSingle, focus, getFirstFocusableElement, getFocusableElements, getLastFocusableElement, isArray, isNotEmpty, isPrintableCharacter, resolveFieldData, uuid } from '@openng/optimus-ui-utils';
-import { FilterService, Footer, Header, OverlayOptions, OverlayService, PrimeTemplate, ScrollerOptions, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
+import { FilterService, Footer, OverlayOptions, OverlayService, PrimeTemplate, ScrollerOptions, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { AutoFocus } from '@openng/optimus-ui/autofocus';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { BaseEditableHolder } from '@openng/optimus-ui/baseeditableholder';
@@ -946,8 +946,6 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     readonly headerCheckboxViewChild = viewChild<Nullable<Checkbox>>('headerCheckbox');
 
     readonly footerFacet = contentChild(Footer);
-
-    readonly headerFacet = contentChild(Header);
 
     _componentStyle = inject(MultiSelectStyle);
 

--- a/packages/optimus-ui/src/orderlist/orderlist.test.ts
+++ b/packages/optimus-ui/src/orderlist/orderlist.test.ts
@@ -1765,16 +1765,16 @@ describe('OrderList', () => {
                 await contentChildFixture.whenStable();
 
                 const hasTemplates =
-                    contentChildOrderList.itemTemplate ||
-                    contentChildOrderList.headerTemplate ||
-                    contentChildOrderList.emptyMessageTemplate ||
-                    contentChildOrderList.emptyFilterMessageTemplate ||
-                    contentChildOrderList.filterTemplate ||
-                    contentChildOrderList.moveUpIconTemplate ||
-                    contentChildOrderList.moveTopIconTemplate ||
-                    contentChildOrderList.moveDownIconTemplate ||
-                    contentChildOrderList.moveBottomIconTemplate ||
-                    contentChildOrderList.filterIconTemplate;
+                    contentChildOrderList.itemTemplate() ||
+                    contentChildOrderList.headerTemplate() ||
+                    contentChildOrderList.emptyMessageTemplate() ||
+                    contentChildOrderList.emptyFilterMessageTemplate() ||
+                    contentChildOrderList.filterTemplate() ||
+                    contentChildOrderList.moveUpIconTemplate() ||
+                    contentChildOrderList.moveTopIconTemplate() ||
+                    contentChildOrderList.moveDownIconTemplate() ||
+                    contentChildOrderList.moveBottomIconTemplate() ||
+                    contentChildOrderList.filterIconTemplate();
 
                 expect(hasTemplates).toBeTruthy();
             });

--- a/packages/optimus-ui/src/orderlist/orderlist.test.ts
+++ b/packages/optimus-ui/src/orderlist/orderlist.test.ts
@@ -1906,3 +1906,37 @@ describe('OrderList', () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [OrderList, SharedModule],
+    template: `
+        <p-orderlist [value]="items">
+            <ng-template pTemplate="item">i</ng-template>
+        </p-orderlist>
+    `
+})
+class OrderListQueryApiHostComponent {
+    items = [{ name: 'a' }];
+}
+
+describe('OrderList Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [OrderListQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(OrderListQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(OrderList)).componentInstance;
+
+        expect(instance.listViewChild()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'item')).toBe(true);
+    });
+});

--- a/packages/optimus-ui/src/orderlist/orderlist.ts
+++ b/packages/optimus-ui/src/orderlist/orderlist.ts
@@ -698,7 +698,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
             this.movedUp = true;
             this.onReorder.emit(this.selection);
         }
-        this.listViewChild()?.cd?.markForCheck();
+        this.listViewChild().cd?.markForCheck();
     }
 
     moveTop() {
@@ -729,7 +729,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
                 this.listViewChild().scrollInView(0);
             });
         }
-        this.listViewChild()?.cd?.markForCheck();
+        this.listViewChild().cd?.markForCheck();
     }
 
     moveDown() {
@@ -758,7 +758,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
             this.onReorder.emit(this.selection);
         }
 
-        this.listViewChild()?.cd?.markForCheck();
+        this.listViewChild().cd?.markForCheck();
     }
 
     moveBottom() {
@@ -784,9 +784,9 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
             }
 
             this.onReorder.emit(this.selection);
-            this.listViewChild()?.scrollInView(this.value?.length ? this.value.length - 1 : 0);
+            this.listViewChild().scrollInView(this.value?.length ? this.value.length - 1 : 0);
         }
-        this.listViewChild()?.cd?.markForCheck();
+        this.listViewChild().cd?.markForCheck();
     }
 
     onDrop(event: CdkDragDrop<string[]>) {

--- a/packages/optimus-ui/src/orderlist/orderlist.ts
+++ b/packages/optimus-ui/src/orderlist/orderlist.ts
@@ -12,7 +12,6 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     TemplateRef,
     ViewEncapsulation,
     viewChild,
@@ -566,7 +565,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
     _filterIconTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -646,6 +645,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
      */
     public resetFilter() {
         this.filterValue = '';
+        const filterViewChild = this.filterViewChild();
         filterViewChild && ((<HTMLInputElement>filterViewChild.nativeElement).value = '');
     }
 

--- a/packages/optimus-ui/src/orderlist/orderlist.ts
+++ b/packages/optimus-ui/src/orderlist/orderlist.ts
@@ -4,8 +4,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -16,8 +14,10 @@ import {
     Output,
     QueryList,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { findIndexInList, setAttribute, uuid } from '@openng/optimus-ui-utils';
@@ -45,16 +45,16 @@ const ORDERLIST_INSTANCE = new InjectionToken<OrderList>('ORDERLIST_INSTANCE');
     template: `
         <div [pBind]="ptm('controls')" [class]="cx('controls')">
             <button [pt]="ptm('pcMoveUpButton')" type="button" [disabled]="moveDisabled()" pButton pRipple (click)="moveUp()" [attr.aria-label]="moveUpAriaLabel" [buttonProps]="getButtonProps('up')" hostName="orderlist" [unstyled]="unstyled()">
-                @if (!moveUpIconTemplate && !_moveUpIconTemplate) {
+                @if (!moveUpIconTemplate() && !_moveUpIconTemplate) {
                     <svg data-p-icon="angle-up" pButtonIcon [pt]="ptm('pcMoveUpButton')['icon']" />
                 }
-                <ng-template *ngTemplateOutlet="moveUpIconTemplate || _moveUpIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="moveUpIconTemplate() || _moveUpIconTemplate"></ng-template>
             </button>
             <button [pt]="ptm('pcMoveTopButton')" type="button" [disabled]="moveDisabled()" pButton pRipple (click)="moveTop()" [attr.aria-label]="moveTopAriaLabel" [buttonProps]="getButtonProps('top')" hostName="orderlist" [unstyled]="unstyled()">
-                @if (!moveTopIconTemplate && !_moveTopIconTemplate) {
+                @if (!moveTopIconTemplate() && !_moveTopIconTemplate) {
                     <svg data-p-icon="angle-double-up" pButtonIcon [pt]="ptm('pcMoveTopButton')['icon']" />
                 }
-                <ng-template *ngTemplateOutlet="moveTopIconTemplate || _moveTopIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="moveTopIconTemplate() || _moveTopIconTemplate"></ng-template>
             </button>
             <button
                 [pt]="ptm('pcMoveDownButton')"
@@ -68,10 +68,10 @@ const ORDERLIST_INSTANCE = new InjectionToken<OrderList>('ORDERLIST_INSTANCE');
                 hostName="orderlist"
                 [unstyled]="unstyled()"
             >
-                @if (!moveDownIconTemplate && !_moveDownIconTemplate) {
+                @if (!moveDownIconTemplate() && !_moveDownIconTemplate) {
                     <svg data-p-icon="angle-down" pButtonIcon [pt]="ptm('pcMoveDownButton')['icon']" />
                 }
-                <ng-template *ngTemplateOutlet="moveDownIconTemplate || _moveDownIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="moveDownIconTemplate() || _moveDownIconTemplate"></ng-template>
             </button>
             <button
                 [pt]="ptm('pcMoveBottomButton')"
@@ -85,10 +85,10 @@ const ORDERLIST_INSTANCE = new InjectionToken<OrderList>('ORDERLIST_INSTANCE');
                 hostName="orderlist"
                 [unstyled]="unstyled()"
             >
-                @if (!moveBottomIconTemplate && !_moveBottomIconTemplate) {
+                @if (!moveBottomIconTemplate() && !_moveBottomIconTemplate) {
                     <svg data-p-icon="angle-double-down" pButtonIcon [pt]="ptm('pcMoveBottomButton')['icon']" />
                 }
-                <ng-template *ngTemplateOutlet="moveBottomIconTemplate || _moveBottomIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="moveBottomIconTemplate() || _moveBottomIconTemplate"></ng-template>
             </button>
         </div>
         <p-listbox
@@ -120,34 +120,34 @@ const ORDERLIST_INSTANCE = new InjectionToken<OrderList>('ORDERLIST_INSTANCE');
             hostName="orderlist"
             [unstyled]="unstyled()"
         >
-            @if (headerTemplate || _headerTemplate) {
+            @if (headerTemplate() || _headerTemplate) {
                 <ng-template #header>
-                    <ng-template *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-template>
                 </ng-template>
             }
-            @if (itemTemplate || _itemTemplate) {
+            @if (itemTemplate() || _itemTemplate) {
                 <ng-template #item let-option let-selected="selected" let-index="index">
-                    <ng-template *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: option, selected: selected, index: index }"></ng-template>
+                    <ng-template *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: option, selected: selected, index: index }"></ng-template>
                 </ng-template>
             }
-            @if (emptyMessageTemplate || _emptyMessageTemplate) {
+            @if (emptyMessageTemplate() || _emptyMessageTemplate) {
                 <ng-template #empty>
-                    <ng-template *ngTemplateOutlet="emptyMessageTemplate || _emptyMessageTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="emptyMessageTemplate() || _emptyMessageTemplate"></ng-template>
                 </ng-template>
             }
-            @if (emptyFilterMessageTemplate || _emptyFilterMessageTemplate) {
+            @if (emptyFilterMessageTemplate() || _emptyFilterMessageTemplate) {
                 <ng-template #emptyfilter>
-                    <ng-template *ngTemplateOutlet="emptyFilterMessageTemplate || _emptyFilterMessageTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="emptyFilterMessageTemplate() || _emptyFilterMessageTemplate"></ng-template>
                 </ng-template>
             }
-            @if (filterIconTemplate || _filterIconTemplate) {
+            @if (filterIconTemplate() || _filterIconTemplate) {
                 <ng-template #filtericon>
-                    <ng-template *ngTemplateOutlet="filterIconTemplate || _filterIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="filterIconTemplate() || _filterIconTemplate"></ng-template>
                 </ng-template>
             }
-            @if (filterTemplate || _filterTemplate) {
+            @if (filterTemplate() || _filterTemplate) {
                 <ng-template #filter let-options="options">
-                    <ng-template *ngTemplateOutlet="filterTemplate || _filterTemplate; context: { options: options }"></ng-template>
+                    <ng-template *ngTemplateOutlet="filterTemplate() || _filterTemplate; context: { options: options }"></ng-template>
                 </ng-template>
             }
         </p-listbox>
@@ -402,9 +402,9 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
      */
     @Output() onBlur: EventEmitter<Event> = new EventEmitter<Event>();
 
-    @ViewChild('listelement') listViewChild!: Listbox;
+    readonly listViewChild = viewChild.required<Listbox>('listelement');
 
-    @ViewChild('filter') filterViewChild: Nullable<ElementRef>;
+    readonly filterViewChild = viewChild<Nullable<ElementRef>>('filter');
 
     /**
      * Custom item template.
@@ -412,19 +412,19 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
      * @see {@link OrderListItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<OrderListItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<OrderListItemTemplateContext>>('item', { descendants: false });
 
     /**
      * Custom empty template.
      * @group Templates
      */
-    @ContentChild('empty', { descendants: false }) emptyMessageTemplate: TemplateRef<void> | undefined;
+    readonly emptyMessageTemplate = contentChild<TemplateRef<void>>('empty', { descendants: false });
 
     /**
      * Custom empty filter template.
      * @group Templates
      */
-    @ContentChild('emptyfilter', { descendants: false }) emptyFilterMessageTemplate: TemplateRef<void> | undefined;
+    readonly emptyFilterMessageTemplate = contentChild<TemplateRef<void>>('emptyfilter', { descendants: false });
 
     /**
      * Custom filter template.
@@ -432,43 +432,43 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
      * @see {@link OrderListFilterTemplateContext}
      * @group Templates
      */
-    @ContentChild('filter', { descendants: false }) filterTemplate: TemplateRef<OrderListFilterTemplateContext> | undefined;
+    readonly filterTemplate = contentChild<TemplateRef<OrderListFilterTemplateContext>>('filter', { descendants: false });
 
     /**
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
 
     /**
      * Custom move up icon template.
      * @group Templates
      */
-    @ContentChild('moveupicon', { descendants: false }) moveUpIconTemplate: TemplateRef<void> | undefined;
+    readonly moveUpIconTemplate = contentChild<TemplateRef<void>>('moveupicon', { descendants: false });
 
     /**
      * Custom move top icon template.
      * @group Templates
      */
-    @ContentChild('movetopicon', { descendants: false }) moveTopIconTemplate: TemplateRef<void> | undefined;
+    readonly moveTopIconTemplate = contentChild<TemplateRef<void>>('movetopicon', { descendants: false });
 
     /**
      * Custom move down icon template.
      * @group Templates
      */
-    @ContentChild('movedownicon', { descendants: false }) moveDownIconTemplate: TemplateRef<void> | undefined;
+    readonly moveDownIconTemplate = contentChild<TemplateRef<void>>('movedownicon', { descendants: false });
 
     /**
      * Custom move bottom icon template.
      * @group Templates
      */
-    @ContentChild('movebottomicon', { descendants: false }) moveBottomIconTemplate: TemplateRef<void> | undefined;
+    readonly moveBottomIconTemplate = contentChild<TemplateRef<void>>('movebottomicon', { descendants: false });
 
     /**
      * Custom filter icon template.
      * @group Templates
      */
-    @ContentChild('filtericon', { descendants: false }) filterIconTemplate: TemplateRef<void> | undefined;
+    readonly filterIconTemplate = contentChild<TemplateRef<void>>('filtericon', { descendants: false });
 
     get moveUpAriaLabel() {
         return this.config.translation.aria ? this.config.translation.aria.moveUp : undefined;
@@ -543,7 +543,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
         }
     }
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _itemTemplate: TemplateRef<OrderListItemTemplateContext> | undefined;
 
@@ -566,7 +566,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
     _filterIconTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -646,7 +646,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
      */
     public resetFilter() {
         this.filterValue = '';
-        this.filterViewChild && ((<HTMLInputElement>this.filterViewChild.nativeElement).value = '');
+        filterViewChild && ((<HTMLInputElement>filterViewChild.nativeElement).value = '');
     }
 
     isItemVisible(item: any): boolean | undefined {
@@ -698,7 +698,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
             this.movedUp = true;
             this.onReorder.emit(this.selection);
         }
-        this.listViewChild?.cd?.markForCheck();
+        this.listViewChild()?.cd?.markForCheck();
     }
 
     moveTop() {
@@ -726,10 +726,10 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
 
             this.onReorder.emit(this.selection);
             setTimeout(() => {
-                this.listViewChild.scrollInView(0);
+                this.listViewChild().scrollInView(0);
             });
         }
-        this.listViewChild?.cd?.markForCheck();
+        this.listViewChild()?.cd?.markForCheck();
     }
 
     moveDown() {
@@ -758,7 +758,7 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
             this.onReorder.emit(this.selection);
         }
 
-        this.listViewChild?.cd?.markForCheck();
+        this.listViewChild()?.cd?.markForCheck();
     }
 
     moveBottom() {
@@ -784,9 +784,9 @@ export class OrderList extends BaseComponent<OrderListPassThrough> {
             }
 
             this.onReorder.emit(this.selection);
-            this.listViewChild?.scrollInView(this.value?.length ? this.value.length - 1 : 0);
+            this.listViewChild()?.scrollInView(this.value?.length ? this.value.length - 1 : 0);
         }
-        this.listViewChild?.cd?.markForCheck();
+        this.listViewChild()?.cd?.markForCheck();
     }
 
     onDrop(event: CdkDragDrop<string[]>) {

--- a/packages/optimus-ui/src/organizationchart/organizationchart.test.ts
+++ b/packages/optimus-ui/src/organizationchart/organizationchart.test.ts
@@ -6,6 +6,8 @@ import { TreeNode } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { OrganizationChart, OrganizationChartNode } from './organizationchart';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 // Test component for basic use cases
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1104,5 +1106,43 @@ describe('OrganizationChart', () => {
                 expect(selectedNode).toBeTruthy();
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [OrganizationChart, PrimeTemplate],
+    template: `
+        <p-organizationchart [value]="chartValue">
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-organizationchart>
+    `
+})
+class OrganizationChartQueryApiHostComponent {
+    chartValue = [{ label: 'root' }];
+}
+
+describe('OrganizationChart Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [OrganizationChartQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(OrganizationChartQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(OrganizationChart)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/organizationchart/organizationchart.ts
+++ b/packages/optimus-ui/src/organizationchart/organizationchart.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -15,7 +13,9 @@ import {
     Output,
     QueryList,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChildren,
+    contentChild
 } from '@angular/core';
 import { hasClass, isAttributeEquals } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule, TreeNode } from '@openng/optimus-ui/api';
@@ -50,7 +50,7 @@ const ORGANIZATIONCHART_INSTANCE = new InjectionToken<OrganizationChart>('ORGANI
                             @if (collapsible) {
                                 @if (!leaf) {
                                     <a tabindex="0" [class]="cx('nodeToggleButton')" (click)="toggleNode($event, node)" (keydown.enter)="toggleNode($event, node)" (keydown.space)="toggleNode($event, node)" [pBind]="getPTOptions('nodeToggleButton')">
-                                        @if (!chart.togglerIconTemplate && !chart._togglerIconTemplate) {
+                                        @if (!chart.togglerIconTemplate() && !chart._togglerIconTemplate) {
                                             @if (node.expanded) {
                                                 <svg data-p-icon="chevron-down" [class]="cx('nodeToggleButtonIcon')" [pBind]="getPTOptions('nodeToggleButtonIcon')" />
                                             }
@@ -58,9 +58,9 @@ const ORGANIZATIONCHART_INSTANCE = new InjectionToken<OrganizationChart>('ORGANI
                                                 <svg data-p-icon="chevron-up" [class]="cx('nodeToggleButtonIcon')" [pBind]="getPTOptions('nodeToggleButtonIcon')" />
                                             }
                                         }
-                                        @if (chart.togglerIconTemplate || chart._togglerIconTemplate) {
+                                        @if (chart.togglerIconTemplate() || chart._togglerIconTemplate) {
                                             <span [class]="cx('nodeToggleButtonIcon')" [pBind]="getPTOptions('nodeToggleButtonIcon')">
-                                                <ng-template *ngTemplateOutlet="chart.togglerIconTemplate || chart._togglerIconTemplate; context: { $implicit: node.expanded }"></ng-template>
+                                                <ng-template *ngTemplateOutlet="chart.togglerIconTemplate() || chart._togglerIconTemplate; context: { $implicit: node.expanded }"></ng-template>
                                             </span>
                                         }
                                     </a>
@@ -284,9 +284,9 @@ export class OrganizationChart extends BaseComponent<OrganizationChartPassThroug
      */
     @Output() onNodeCollapse: EventEmitter<OrganizationChartNodeCollapseEvent> = new EventEmitter<OrganizationChartNodeCollapseEvent>();
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
-    @ContentChild('togglericon', { descendants: false }) togglerIconTemplate: TemplateRef<any> | undefined;
+    readonly togglerIconTemplate = contentChild<TemplateRef<any>>('togglericon', { descendants: false });
 
     public templateMap: any;
 
@@ -315,11 +315,11 @@ export class OrganizationChart extends BaseComponent<OrganizationChartPassThroug
     }
 
     onAfterContentInit() {
-        if ((this.templates as QueryList<PrimeTemplate>).length) {
+        if ((this.templates() as QueryList<PrimeTemplate>).length) {
             this.templateMap = {};
         }
 
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             if (item.getType() === 'togglericon') {
                 this._togglerIconTemplate = item.template;
             } else {

--- a/packages/optimus-ui/src/organizationchart/organizationchart.ts
+++ b/packages/optimus-ui/src/organizationchart/organizationchart.ts
@@ -1,21 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-    booleanAttribute,
-    ChangeDetectionStrategy,
-    ChangeDetectorRef,
-    Component,
-    ElementRef,
-    EventEmitter,
-    inject,
-    InjectionToken,
-    Input,
-    NgModule,
-    Output,
-    TemplateRef,
-    ViewEncapsulation,
-    contentChildren,
-    contentChild
-} from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, inject, InjectionToken, Input, NgModule, Output, TemplateRef, ViewEncapsulation, contentChildren, contentChild } from '@angular/core';
 import { hasClass, isAttributeEquals } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule, TreeNode } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';

--- a/packages/optimus-ui/src/organizationchart/organizationchart.ts
+++ b/packages/optimus-ui/src/organizationchart/organizationchart.ts
@@ -11,7 +11,6 @@ import {
     Input,
     NgModule,
     Output,
-    QueryList,
     TemplateRef,
     ViewEncapsulation,
     contentChildren,
@@ -315,11 +314,11 @@ export class OrganizationChart extends BaseComponent<OrganizationChartPassThroug
     }
 
     onAfterContentInit() {
-        if ((this.templates() as QueryList<PrimeTemplate>).length) {
+        if (this.templates().length) {
             this.templateMap = {};
         }
 
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             if (item.getType() === 'togglericon') {
                 this._togglerIconTemplate = item.template;
             } else {

--- a/packages/optimus-ui/src/overlay/overlay.test.ts
+++ b/packages/optimus-ui/src/overlay/overlay.test.ts
@@ -4,6 +4,8 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Overlay } from './overlay';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 describe('Overlay', () => {
     describe('PassThrough API', () => {
         @Component({
@@ -388,5 +390,40 @@ describe('Overlay', () => {
                 expect(hookCalled).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Overlay, SharedModule],
+    template: `
+        <p-overlay>
+            <ng-template #content>C</ng-template>
+            <ng-template pTemplate="content">c2</ng-template>
+        </p-overlay>
+    `
+})
+class OverlayQueryApiHostComponent {}
+
+describe('Overlay Signal Query API', () => {
+    it('should resolve content queries and leave view queries unresolved while hidden', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [OverlayQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(OverlayQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Overlay)).componentInstance;
+        expect(instance.contentTemplate()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'content')).toBe(true);
+        expect(instance.overlayViewChild()).toBeUndefined();
+        expect(instance.contentViewChild()).toBeUndefined();
     });
 });

--- a/packages/optimus-ui/src/overlay/overlay.ts
+++ b/packages/optimus-ui/src/overlay/overlay.ts
@@ -1,25 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import {
-    ChangeDetectionStrategy,
-    Component,
-    computed,
-    ContentChild,
-    ContentChildren,
-    ElementRef,
-    EventEmitter,
-    inject,
-    InjectionToken,
-    input,
-    Input,
-    NgModule,
-    NgZone,
-    Output,
-    QueryList,
-    signal,
-    TemplateRef,
-    ViewChild,
-    ViewEncapsulation
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, ElementRef, EventEmitter, inject, InjectionToken, input, Input, NgModule, NgZone, Output, signal, TemplateRef, ViewEncapsulation, viewChild, contentChild, contentChildren } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { absolutePosition, addClass, appendChild, focus, getOuterWidth, getTargetElement, isTouchDevice, relativePosition, removeClass } from '@openng/optimus-ui-utils';
 import { OverlayModeType, OverlayOnBeforeHideEvent, OverlayOnBeforeShowEvent, OverlayOnHideEvent, OverlayOnShowEvent, OverlayOptions, OverlayService, PrimeTemplate, ResponsiveOverlayOptions, SharedModule } from '@openng/optimus-ui/api';
@@ -47,7 +27,7 @@ const OVERLAY_INSTANCE = new InjectionToken<Overlay>('OVERLAY_INSTANCE');
     template: `
         @if (inline()) {
             <ng-content></ng-content>
-            <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: { mode: null } }"></ng-container>
+            <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { $implicit: { mode: null } }"></ng-container>
         } @else {
             @if (modalVisible) {
                 <div #overlay [class]="cn(cx('root'), styleClass)" [style]="sx('root')" [pBind]="ptm('root')" (click)="onOverlayClick()">
@@ -65,7 +45,7 @@ const OVERLAY_INSTANCE = new InjectionToken<Overlay>('OVERLAY_INSTANCE');
                     >
                         <div #content [class]="cn(cx('content'), contentStyleClass)" [pBind]="ptm('content')" (click)="onOverlayContentClick($event)">
                             <ng-content></ng-content>
-                            <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: { mode: overlayMode } }"></ng-container>
+                            <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { $implicit: { mode: overlayMode } }"></ng-container>
                         </div>
                     </p-motion>
                 </div>
@@ -356,18 +336,18 @@ export class Overlay extends BaseComponent {
      */
     @Output() onAfterLeave: EventEmitter<MotionEvent> = new EventEmitter<MotionEvent>();
 
-    @ViewChild('overlay') overlayViewChild: ElementRef | undefined;
+    readonly overlayViewChild = viewChild<ElementRef>('overlay');
 
-    @ViewChild('content') contentViewChild: ElementRef | undefined;
+    readonly contentViewChild = viewChild<ElementRef>('content');
     /**
      * Content template of the component.
      * @param {OverlayContentTemplateContext} context - content context.
      * @see {@link OverlayContentTemplateContext}
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<OverlayContentTemplateContext> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<OverlayContentTemplateContext>>('content', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     hostAttrSelector = input<string>();
 
@@ -465,11 +445,11 @@ export class Overlay extends BaseComponent {
     }
 
     get overlayEl() {
-        return this.overlayViewChild?.nativeElement;
+        return this.overlayViewChild()?.nativeElement;
     }
 
     get contentEl() {
-        return this.contentViewChild?.nativeElement;
+        return this.contentViewChild()?.nativeElement;
     }
 
     get targetEl() {
@@ -477,7 +457,7 @@ export class Overlay extends BaseComponent {
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/paginator/paginator.test.ts
+++ b/packages/optimus-ui/src/paginator/paginator.test.ts
@@ -1,5 +1,5 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { FormControl, FormGroup, FormsModule, NgModel, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
@@ -612,11 +612,11 @@ describe('Paginator', () => {
                 await contentChildFixture.whenStable();
 
                 const hasTemplates =
-                    contentChildPaginator.dropdownIconTemplate ||
-                    contentChildPaginator.firstPageLinkIconTemplate ||
-                    contentChildPaginator.previousPageLinkIconTemplate ||
-                    contentChildPaginator.nextPageLinkIconTemplate ||
-                    contentChildPaginator.lastPageLinkIconTemplate;
+                    contentChildPaginator.dropdownIconTemplate() ||
+                    contentChildPaginator.firstPageLinkIconTemplate() ||
+                    contentChildPaginator.previousPageLinkIconTemplate() ||
+                    contentChildPaginator.nextPageLinkIconTemplate() ||
+                    contentChildPaginator.lastPageLinkIconTemplate();
 
                 expect(hasTemplates).toBeTruthy();
             });
@@ -1169,7 +1169,7 @@ describe('Paginator', () => {
             dynamicFixture = TestBed.createComponent(TestDynamicPaginatorComponent);
             dynamicComponent = dynamicFixture.componentInstance;
             dynamicFixture.detectChanges();
-            dynamicPaginator = dynamicComponent.paginator;
+            dynamicPaginator = dynamicComponent.paginator();
         });
 
         it('should handle dynamic totalRecords changes', async () => {
@@ -1349,7 +1349,7 @@ describe('Paginator', () => {
     `
 })
 class TestDynamicPaginatorComponent {
-    @ViewChild('paginator') paginator!: Paginator;
+    readonly paginator = viewChild.required<Paginator>('paginator');
 
     totalRecords = 100;
     rows = 10;

--- a/packages/optimus-ui/src/paginator/paginator.test.ts
+++ b/packages/optimus-ui/src/paginator/paginator.test.ts
@@ -10,6 +10,8 @@ import { Ripple } from '@openng/optimus-ui/ripple';
 import { SharedModule } from '@openng/optimus-ui/api';
 import { PaginatorState } from '@openng/optimus-ui/types/paginator';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 // Test component for basic paginator functionality
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1440,3 +1442,39 @@ describe('Paginator inside a parent form', () => {
 class TestFormIsolationPaginatorComponent {
     form = new FormGroup({ value: new FormControl(1) });
 }
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Paginator, PrimeTemplate],
+    template: `
+        <p-paginator [rows]="10" [totalRecords]="100">
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-paginator>
+    `
+})
+class PaginatorQueryApiHostComponent {}
+
+describe('Paginator Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [PaginatorQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(PaginatorQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Paginator)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
+    });
+});

--- a/packages/optimus-ui/src/paginator/paginator.ts
+++ b/packages/optimus-ui/src/paginator/paginator.ts
@@ -5,8 +5,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     HostBinding,
@@ -22,7 +20,9 @@ import {
     QueryList,
     SimpleChanges,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Aria, PrimeTemplate, SelectItem, SharedModule } from '@openng/optimus-ui/api';
@@ -57,23 +57,23 @@ const PAGINATOR_INSTANCE = new InjectionToken<Paginator>('PAGINATOR_INSTANCE');
         }
         @if (showFirstLastIcon) {
             <button [pBind]="ptm('first')" type="button" (click)="changePageToFirst($event)" pRipple [class]="cx('first')" [attr.aria-label]="getAriaLabel('firstPageLabel')">
-                @if (!firstPageLinkIconTemplate && !_firstPageLinkIconTemplate) {
+                @if (!firstPageLinkIconTemplate() && !_firstPageLinkIconTemplate) {
                     <svg [pBind]="ptm('firstIcon')" data-p-icon="angle-double-left" [class]="cx('firstIcon')" />
                 }
-                @if (firstPageLinkIconTemplate || _firstPageLinkIconTemplate) {
+                @if (firstPageLinkIconTemplate() || _firstPageLinkIconTemplate) {
                     <span [class]="cx('firstIcon')">
-                        <ng-template *ngTemplateOutlet="firstPageLinkIconTemplate || _firstPageLinkIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="firstPageLinkIconTemplate() || _firstPageLinkIconTemplate"></ng-template>
                     </span>
                 }
             </button>
         }
         <button [pBind]="ptm('prev')" type="button" [disabled]="isFirstPage() || empty()" (click)="changePageToPrev($event)" pRipple [class]="cx('prev')" [attr.aria-label]="getAriaLabel('prevPageLabel')">
-            @if (!previousPageLinkIconTemplate && !_previousPageLinkIconTemplate) {
+            @if (!previousPageLinkIconTemplate() && !_previousPageLinkIconTemplate) {
                 <svg [pBind]="ptm('prevIcon')" data-p-icon="angle-left" [class]="cx('prevIcon')" />
             }
-            @if (previousPageLinkIconTemplate || _previousPageLinkIconTemplate) {
+            @if (previousPageLinkIconTemplate() || _previousPageLinkIconTemplate) {
                 <span [class]="cx('prevIcon')">
-                    <ng-template *ngTemplateOutlet="previousPageLinkIconTemplate || _previousPageLinkIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="previousPageLinkIconTemplate() || _previousPageLinkIconTemplate"></ng-template>
                 </span>
             }
         </button>
@@ -114,31 +114,31 @@ const PAGINATOR_INSTANCE = new InjectionToken<Paginator>('PAGINATOR_INSTANCE');
                         <ng-container *ngTemplateOutlet="jumpToPageItemTemplate; context: { $implicit: item }"></ng-container>
                     </ng-template>
                 }
-                @if (dropdownIconTemplate || _dropdownIconTemplate) {
+                @if (dropdownIconTemplate() || _dropdownIconTemplate) {
                     <ng-template pTemplate="dropdownicon">
-                        <ng-container *ngTemplateOutlet="dropdownIconTemplate || _dropdownIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="dropdownIconTemplate() || _dropdownIconTemplate"></ng-container>
                     </ng-template>
                 }
             </p-select>
         }
         <button [pBind]="ptm('next')" type="button" [disabled]="isLastPage() || empty()" (click)="changePageToNext($event)" pRipple [class]="cx('next')" [attr.aria-label]="getAriaLabel('nextPageLabel')">
-            @if (!nextPageLinkIconTemplate && !_nextPageLinkIconTemplate) {
+            @if (!nextPageLinkIconTemplate() && !_nextPageLinkIconTemplate) {
                 <svg [pBind]="ptm('nextIcon')" data-p-icon="angle-right" [class]="cx('nextIcon')" />
             }
-            @if (nextPageLinkIconTemplate || _nextPageLinkIconTemplate) {
+            @if (nextPageLinkIconTemplate() || _nextPageLinkIconTemplate) {
                 <span [class]="cx('nextIcon')">
-                    <ng-template *ngTemplateOutlet="nextPageLinkIconTemplate || _nextPageLinkIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="nextPageLinkIconTemplate() || _nextPageLinkIconTemplate"></ng-template>
                 </span>
             }
         </button>
         @if (showFirstLastIcon) {
             <button [pBind]="ptm('last')" type="button" [disabled]="isLastPage() || empty()" (click)="changePageToLast($event)" pRipple [class]="cx('last')" [attr.aria-label]="getAriaLabel('lastPageLabel')">
-                @if (!lastPageLinkIconTemplate && !_lastPageLinkIconTemplate) {
+                @if (!lastPageLinkIconTemplate() && !_lastPageLinkIconTemplate) {
                     <svg [pBind]="ptm('lastIcon')" data-p-icon="angle-double-right" [class]="cx('lastIcon')" />
                 }
-                @if (lastPageLinkIconTemplate || _lastPageLinkIconTemplate) {
+                @if (lastPageLinkIconTemplate() || _lastPageLinkIconTemplate) {
                     <span [class]="cx('lastIcon')">
-                        <ng-template *ngTemplateOutlet="lastPageLinkIconTemplate || _lastPageLinkIconTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="lastPageLinkIconTemplate() || _lastPageLinkIconTemplate"></ng-template>
                     </span>
                 }
             </button>
@@ -173,9 +173,9 @@ const PAGINATOR_INSTANCE = new InjectionToken<Paginator>('PAGINATOR_INSTANCE');
                         <ng-container *ngTemplateOutlet="dropdownItemTemplate; context: { $implicit: item }"></ng-container>
                     </ng-template>
                 }
-                @if (dropdownIconTemplate || _dropdownIconTemplate) {
+                @if (dropdownIconTemplate() || _dropdownIconTemplate) {
                     <ng-template pTemplate="dropdownicon">
-                        <ng-container *ngTemplateOutlet="dropdownIconTemplate || _dropdownIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="dropdownIconTemplate() || _dropdownIconTemplate"></ng-container>
                     </ng-template>
                 }
             </p-select>
@@ -338,33 +338,33 @@ export class Paginator extends BaseComponent<PaginatorPassThrough> {
      * Template for the dropdown icon.
      * @group Templates
      */
-    @ContentChild('dropdownicon', { descendants: false }) dropdownIconTemplate: Nullable<TemplateRef<void>>;
+    readonly dropdownIconTemplate = contentChild<Nullable<TemplateRef<void>>>('dropdownicon', { descendants: false });
 
     /**
      * Template for the first page link icon.
      * @group Templates
      */
-    @ContentChild('firstpagelinkicon', { descendants: false }) firstPageLinkIconTemplate: Nullable<TemplateRef<void>>;
+    readonly firstPageLinkIconTemplate = contentChild<Nullable<TemplateRef<void>>>('firstpagelinkicon', { descendants: false });
 
     /**
      * Template for the previous page link icon.
      * @group Templates
      */
-    @ContentChild('previouspagelinkicon', { descendants: false }) previousPageLinkIconTemplate: Nullable<TemplateRef<void>>;
+    readonly previousPageLinkIconTemplate = contentChild<Nullable<TemplateRef<void>>>('previouspagelinkicon', { descendants: false });
 
     /**
      * Template for the last page link icon.
      * @group Templates
      */
-    @ContentChild('lastpagelinkicon', { descendants: false }) lastPageLinkIconTemplate: Nullable<TemplateRef<void>>;
+    readonly lastPageLinkIconTemplate = contentChild<Nullable<TemplateRef<void>>>('lastpagelinkicon', { descendants: false });
 
     /**
      * Template for the next page link icon.
      * @group Templates
      */
-    @ContentChild('nextpagelinkicon', { descendants: false }) nextPageLinkIconTemplate: Nullable<TemplateRef<void>>;
+    readonly nextPageLinkIconTemplate = contentChild<Nullable<TemplateRef<void>>>('nextpagelinkicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _dropdownIconTemplate: TemplateRef<void> | undefined;
 
@@ -401,7 +401,7 @@ export class Paginator extends BaseComponent<PaginatorPassThrough> {
     }
 
     onAfterContentInit(): void {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'dropdownicon':
                     this._dropdownIconTemplate = item.template;

--- a/packages/optimus-ui/src/paginator/paginator.ts
+++ b/packages/optimus-ui/src/paginator/paginator.ts
@@ -17,7 +17,6 @@ import {
     OnChanges,
     OnInit,
     Output,
-    QueryList,
     SimpleChanges,
     TemplateRef,
     ViewEncapsulation,
@@ -401,7 +400,7 @@ export class Paginator extends BaseComponent<PaginatorPassThrough> {
     }
 
     onAfterContentInit(): void {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'dropdownicon':
                     this._dropdownIconTemplate = item.template;

--- a/packages/optimus-ui/src/panel/panel.test.ts
+++ b/packages/optimus-ui/src/panel/panel.test.ts
@@ -7,6 +7,7 @@ import { MinusIcon, PlusIcon } from '@openng/optimus-ui/icons';
 import { PanelAfterToggleEvent, PanelBeforeToggleEvent } from '@openng/optimus-ui/types/panel';
 import { Panel } from './panel';
 
+import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1375,5 +1376,43 @@ describe('Panel', () => {
                 expect(footerEl).toBeFalsy();
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Panel, SharedModule],
+    template: `
+        <p-panel>
+            <p-footer>F</p-footer>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-panel>
+    `
+})
+class PanelQueryApiHostComponent {}
+
+describe('Panel Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [PanelQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(PanelQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Panel)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
+        expect(instance.footerFacet()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/panel/panel.test.ts
+++ b/packages/optimus-ui/src/panel/panel.test.ts
@@ -708,7 +708,7 @@ describe('Panel', () => {
         });
 
         it('should handle missing contentWrapper in updateTabIndex', () => {
-            panelInstance.contentWrapperViewChild = undefined as any;
+            (panelInstance as any).contentWrapperViewChild = () => undefined as any;
 
             expect(() => panelInstance.updateTabIndex()).not.toThrow();
         });
@@ -793,7 +793,7 @@ describe('Panel', () => {
             const panel = fixture.debugElement.query(By.directive(Panel)).componentInstance;
 
             // Get the focusable div inside the panel content wrapper
-            const contentWrapper = panel.contentWrapperViewChild.nativeElement;
+            const contentWrapper = panel.contentWrapperViewChild().nativeElement;
             const focusableDiv = contentWrapper.querySelector('div[tabindex]');
 
             // Initially should have tabindex="0"

--- a/packages/optimus-ui/src/panel/panel.test.ts
+++ b/packages/optimus-ui/src/panel/panel.test.ts
@@ -707,12 +707,6 @@ describe('Panel', () => {
             expect(customFooter).toBeTruthy();
         });
 
-        it('should handle missing contentWrapper in updateTabIndex', () => {
-            (panelInstance as any).contentWrapperViewChild = () => undefined as any;
-
-            expect(() => panelInstance.updateTabIndex()).not.toThrow();
-        });
-
         it('should update tab indices for focusable elements when collapsed', () => {
             const fixture = TestBed.createComponent(TestKeyboardNavigationComponent);
             fixture.detectChanges();

--- a/packages/optimus-ui/src/panel/panel.ts
+++ b/packages/optimus-ui/src/panel/panel.ts
@@ -12,7 +12,6 @@ import {
     Input,
     NgModule,
     Output,
-    QueryList,
     TemplateRef,
     ViewEncapsulation,
     contentChild,
@@ -370,7 +369,7 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
     readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;

--- a/packages/optimus-ui/src/panel/panel.ts
+++ b/packages/optimus-ui/src/panel/panel.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -16,8 +14,10 @@ import {
     Output,
     QueryList,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    viewChild,
+    contentChildren
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { uuid } from '@openng/optimus-ui-utils';
@@ -48,9 +48,9 @@ const PANEL_INSTANCE = new InjectionToken<Panel>('PANEL_INSTANCE');
                     <span [pBind]="ptm('title')" [class]="cx('title')" [attr.id]="id + '_header'">{{ _header }}</span>
                 }
                 <ng-content select="p-header"></ng-content>
-                <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
                 <div [pBind]="ptm('headerActions')" [class]="cx('headerActions')">
-                    <ng-template *ngTemplateOutlet="iconsTemplate || _iconsTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="iconsTemplate() || _iconsTemplate"></ng-template>
                     @if (toggleable) {
                         <p-button
                             [attr.id]="id + '_header'"
@@ -70,7 +70,7 @@ const PANEL_INSTANCE = new InjectionToken<Panel>('PANEL_INSTANCE');
                             [unstyled]="unstyled()"
                         >
                             <ng-template #icon>
-                                @if (!headerIconsTemplate && !_headerIconsTemplate && !toggleButtonProps?.icon) {
+                                @if (!headerIconsTemplate() && !_headerIconsTemplate && !toggleButtonProps?.icon) {
                                     @if (!collapsed) {
                                         <svg data-p-icon="minus" [pBind]="ptm('pcToggleButton.icon')" />
                                     }
@@ -78,7 +78,7 @@ const PANEL_INSTANCE = new InjectionToken<Panel>('PANEL_INSTANCE');
                                         <svg data-p-icon="plus" [pBind]="ptm('pcToggleButton.icon')" />
                                     }
                                 }
-                                <ng-template *ngTemplateOutlet="headerIconsTemplate || _headerIconsTemplate; context: { $implicit: collapsed }"></ng-template>
+                                <ng-template *ngTemplateOutlet="headerIconsTemplate() || _headerIconsTemplate; context: { $implicit: collapsed }"></ng-template>
                             </ng-template>
                         </p-button>
                     }
@@ -101,13 +101,13 @@ const PANEL_INSTANCE = new InjectionToken<Panel>('PANEL_INSTANCE');
             <div [pBind]="ptm('contentWrapper')" [class]="cx('contentWrapper')">
                 <div [pBind]="ptm('content')" [class]="cx('content')" #contentWrapper>
                     <ng-content></ng-content>
-                    <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate"></ng-container>
                 </div>
 
-                @if (footerFacet || footerTemplate || _footerTemplate) {
+                @if (footerFacet() || footerTemplate() || _footerTemplate) {
                     <div [pBind]="ptm('footer')" [class]="cx('footer')">
                         <ng-content select="p-footer"></ng-content>
-                        <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
                     </div>
                 }
             </div>
@@ -241,12 +241,12 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
      */
     @Output() onAfterToggle: EventEmitter<PanelAfterToggleEvent> = new EventEmitter<PanelAfterToggleEvent>();
 
-    @ContentChild(Footer) footerFacet: Nullable<TemplateRef<void>>;
+    readonly footerFacet = contentChild(Footer);
     /**
      * Defines template option for header.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
     /**
      * Defines template option for icons.
      * @example
@@ -255,7 +255,7 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
      * ```
      * @group Templates
      */
-    @ContentChild('icons', { descendants: false }) iconsTemplate: TemplateRef<void> | undefined;
+    readonly iconsTemplate = contentChild<TemplateRef<void>>('icons', { descendants: false });
 
     /**
      * Defines template option for content.
@@ -265,7 +265,7 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
      * ```
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<void> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<void>>('content', { descendants: false });
 
     /**
      * Defines template option for footer.
@@ -275,7 +275,7 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
      * ```
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: TemplateRef<void> | undefined;
+    readonly footerTemplate = contentChild<TemplateRef<void>>('footer', { descendants: false });
 
     /**
      * Defines template option for headerIcon.
@@ -287,7 +287,7 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
      * @see {@link PanelHeaderIconsTemplateContext}
      * @group Templates
      */
-    @ContentChild('headericons', { descendants: false }) headerIconsTemplate: TemplateRef<PanelHeaderIconsTemplateContext> | undefined;
+    readonly headerIconsTemplate = contentChild<TemplateRef<PanelHeaderIconsTemplateContext>>('headericons', { descendants: false });
 
     _headerTemplate: TemplateRef<void> | undefined;
 
@@ -299,7 +299,7 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
 
     _headerIconsTemplate: TemplateRef<PanelHeaderIconsTemplateContext> | undefined;
 
-    @ViewChild('contentWrapper') contentWrapperViewChild: ElementRef;
+    readonly contentWrapperViewChild = viewChild.required<ElementRef>('contentWrapper');
 
     get buttonAriaLabel() {
         return this._header;
@@ -343,8 +343,9 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
     }
 
     updateTabIndex() {
-        if (this.contentWrapperViewChild) {
-            const focusableElements = this.contentWrapperViewChild.nativeElement.querySelectorAll('input, button, select, a, textarea, [tabindex]');
+        const contentWrapperViewChild = this.contentWrapperViewChild();
+        if (contentWrapperViewChild) {
+            const focusableElements = contentWrapperViewChild.nativeElement.querySelectorAll('input, button, select, a, textarea, [tabindex]');
             focusableElements.forEach((element: HTMLElement) => {
                 if (this.collapsed) {
                     element.setAttribute('tabindex', '-1');
@@ -366,10 +367,10 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
         this.onAfterToggle.emit({ originalEvent: event as any, collapsed: this.collapsed });
     }
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;

--- a/packages/optimus-ui/src/panel/panel.ts
+++ b/packages/optimus-ui/src/panel/panel.ts
@@ -342,17 +342,14 @@ export class Panel extends BaseComponent<PanelPassThrough> implements BlockableU
     }
 
     updateTabIndex() {
-        const contentWrapperViewChild = this.contentWrapperViewChild();
-        if (contentWrapperViewChild) {
-            const focusableElements = contentWrapperViewChild.nativeElement.querySelectorAll('input, button, select, a, textarea, [tabindex]');
-            focusableElements.forEach((element: HTMLElement) => {
-                if (this.collapsed) {
-                    element.setAttribute('tabindex', '-1');
-                } else {
-                    element.removeAttribute('tabindex');
-                }
-            });
-        }
+        const focusableElements = this.contentWrapperViewChild().nativeElement.querySelectorAll('input, button, select, a, textarea, [tabindex]');
+        focusableElements.forEach((element: HTMLElement) => {
+            if (this.collapsed) {
+                element.setAttribute('tabindex', '-1');
+            } else {
+                element.removeAttribute('tabindex');
+            }
+        });
     }
 
     onKeyDown(event: KeyboardEvent) {

--- a/packages/optimus-ui/src/panelmenu/panelmenu.test.ts
+++ b/packages/optimus-ui/src/panelmenu/panelmenu.test.ts
@@ -6,6 +6,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MenuItem, SharedModule } from '@openng/optimus-ui/api';
 import { PanelMenu } from './panelmenu';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PanelMenuList } from './panelmenu';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1411,5 +1413,35 @@ describe('PanelMenu', () => {
                 expect(hostElement.classList.contains('HOOK_TEST_CLASS')).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [PanelMenu],
+    template: ` <p-panelmenu [model]="model"></p-panelmenu> `
+})
+class PanelMenuQueryApiHostComponent {
+    model = [{ label: 'Root', expanded: true, items: [{ label: 'Child' }] }];
+}
+
+describe('PanelMenu Signal Query API', () => {
+    it('should resolve the submenu viewChild of the rendered panel list', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [PanelMenuQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(PanelMenuQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const list = fixture.debugElement.query(By.directive(PanelMenuList));
+        expect(list, 'expanded panel should render its PanelMenuList').toBeTruthy();
+        expect(list.componentInstance.subMenuViewChild()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/panelmenu/panelmenu.test.ts
+++ b/packages/optimus-ui/src/panelmenu/panelmenu.test.ts
@@ -777,7 +777,7 @@ describe('PanelMenu', () => {
         it('should handle Arrow Down key navigation', () => {
             const keyboardFixture = TestBed.createComponent(TestKeyboardPanelMenuComponent);
             const keyboardPanelMenu = keyboardFixture.debugElement.query(By.directive(PanelMenu)).componentInstance;
-            keyboardPanelMenu.containerViewChild = { nativeElement: { firstElementChild: null } };
+            keyboardPanelMenu.containerViewChild = () => ({ nativeElement: { firstElementChild: null } });
             keyboardFixture.detectChanges();
 
             const panelHeader = keyboardFixture.debugElement.query(By.css('[data-pc-section="header"]'));
@@ -801,7 +801,7 @@ describe('PanelMenu', () => {
         it('should handle Arrow Up key navigation', () => {
             const keyboardFixture = TestBed.createComponent(TestKeyboardPanelMenuComponent);
             const keyboardPanelMenu = keyboardFixture.debugElement.query(By.directive(PanelMenu)).componentInstance;
-            keyboardPanelMenu.containerViewChild = { nativeElement: { lastElementChild: null } };
+            keyboardPanelMenu.containerViewChild = () => ({ nativeElement: { lastElementChild: null } });
             keyboardFixture.detectChanges();
 
             const panelHeaders = keyboardFixture.debugElement.queryAll(By.css('[data-pc-section="header"]'));
@@ -829,7 +829,7 @@ describe('PanelMenu', () => {
         it('should handle Home key navigation', () => {
             const keyboardFixture = TestBed.createComponent(TestKeyboardPanelMenuComponent);
             const keyboardPanelMenu = keyboardFixture.debugElement.query(By.directive(PanelMenu)).componentInstance;
-            keyboardPanelMenu.containerViewChild = { nativeElement: { firstElementChild: null } };
+            keyboardPanelMenu.containerViewChild = () => ({ nativeElement: { firstElementChild: null } });
             keyboardFixture.detectChanges();
 
             const panelHeader = keyboardFixture.debugElement.query(By.css('[data-pc-section="header"]'));
@@ -852,7 +852,7 @@ describe('PanelMenu', () => {
         it('should handle End key navigation', () => {
             const keyboardFixture = TestBed.createComponent(TestKeyboardPanelMenuComponent);
             const keyboardPanelMenu = keyboardFixture.debugElement.query(By.directive(PanelMenu)).componentInstance;
-            keyboardPanelMenu.containerViewChild = { nativeElement: { lastElementChild: null } };
+            keyboardPanelMenu.containerViewChild = () => ({ nativeElement: { lastElementChild: null } });
             keyboardFixture.detectChanges();
 
             const panelHeader = keyboardFixture.debugElement.query(By.css('[data-pc-section="header"]'));

--- a/packages/optimus-ui/src/panelmenu/panelmenu.ts
+++ b/packages/optimus-ui/src/panelmenu/panelmenu.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -16,12 +14,13 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MotionOptions } from '@openng/optimus-ui-motion';
@@ -80,7 +79,7 @@ const PANELMENUSUB_INSTANCE = new InjectionToken<PanelMenuSub>('PANELMENUSUB_INS
                                     [pBind]="getPTOptions(processedItem, index, 'itemLink')"
                                 >
                                     @if (isItemGroup(processedItem)) {
-                                        @if (!panelMenu.submenuIconTemplate && !panelMenu._submenuIconTemplate) {
+                                        @if (!panelMenu.submenuIconTemplate() && !panelMenu._submenuIconTemplate) {
                                             @if (isItemActive(processedItem)) {
                                                 <svg
                                                     data-p-icon="chevron-down"
@@ -98,7 +97,7 @@ const PANELMENUSUB_INSTANCE = new InjectionToken<PanelMenuSub>('PANELMENUSUB_INS
                                                 />
                                             }
                                         }
-                                        <ng-template *ngTemplateOutlet="panelMenu.submenuIconTemplate || panelMenu._submenuIconTemplate"></ng-template>
+                                        <ng-template *ngTemplateOutlet="panelMenu.submenuIconTemplate() || panelMenu._submenuIconTemplate"></ng-template>
                                     }
                                     @if (processedItem.icon) {
                                         <span
@@ -142,7 +141,7 @@ const PANELMENUSUB_INSTANCE = new InjectionToken<PanelMenuSub>('PANELMENUSUB_INS
                                     [pBind]="getPTOptions(processedItem, index, 'itemLink')"
                                 >
                                     @if (isItemGroup(processedItem)) {
-                                        @if (!panelMenu.submenuIconTemplate && !panelMenu._submenuIconTemplate) {
+                                        @if (!panelMenu.submenuIconTemplate() && !panelMenu._submenuIconTemplate) {
                                             @if (isItemActive(processedItem)) {
                                                 <svg
                                                     data-p-icon="chevron-down"
@@ -160,7 +159,7 @@ const PANELMENUSUB_INSTANCE = new InjectionToken<PanelMenuSub>('PANELMENUSUB_INS
                                                 />
                                             }
                                         }
-                                        <ng-template *ngTemplateOutlet="panelMenu.submenuIconTemplate && panelMenu._submenuIconTemplate"></ng-template>
+                                        <ng-template *ngTemplateOutlet="panelMenu.submenuIconTemplate() && panelMenu._submenuIconTemplate"></ng-template>
                                     }
                                     @if (processedItem.icon) {
                                         <span
@@ -412,7 +411,7 @@ export class PanelMenuList extends BaseComponent {
 
     @Output() headerFocus: EventEmitter<any> = new EventEmitter<any>();
 
-    @ViewChild('submenu') subMenuViewChild: PanelMenuSub;
+    readonly subMenuViewChild = viewChild.required<PanelMenuSub>('submenu');
 
     searchTimeout: any;
 
@@ -560,7 +559,7 @@ export class PanelMenuList extends BaseComponent {
     }
 
     scrollInView() {
-        const element = findSingle(this.subMenuViewChild.listViewChild.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+        const element = findSingle(this.subMenuViewChild().listViewChild.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -726,7 +725,7 @@ export class PanelMenuList extends BaseComponent {
 
     onEnterKey(event) {
         if (isNotEmpty(this.focusedItem())) {
-            const element = <any>findSingle(this.subMenuViewChild.listViewChild.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+            const element = <any>findSingle(this.subMenuViewChild().listViewChild.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
             const anchorElement = element && (<HTMLElement>findSingle(element, 'a') || <HTMLElement>findSingle(element, 'button'));
 
             anchorElement ? anchorElement.click() : element && element.click();
@@ -841,7 +840,7 @@ export class PanelMenuList extends BaseComponent {
                         (keydown)="onHeaderKeyDown($event, item, i)"
                     >
                         <div [class]="cx('headerContent')" [pBind]="getPTOptions('headerContent', item, i)">
-                            @if (!itemTemplate && !_itemTemplate) {
+                            @if (!itemTemplate() && !_itemTemplate) {
                                 @if (!getItemProp(item, 'routerLink')) {
                                     <a
                                         [attr.href]="getItemProp(item, 'url')"
@@ -854,7 +853,7 @@ export class PanelMenuList extends BaseComponent {
                                         [pBind]="getPTOptions('headerLink', item, i)"
                                     >
                                         @if (isItemGroup(item)) {
-                                            @if (!headerIconTemplate && !_headerIconTemplate) {
+                                            @if (!headerIconTemplate() && !_headerIconTemplate) {
                                                 @if (isItemActive(item)) {
                                                     <svg data-p-icon="chevron-down" [class]="cx('submenuIcon')" [pBind]="getPTOptions('submenuIcon', item, i)" />
                                                 }
@@ -862,7 +861,7 @@ export class PanelMenuList extends BaseComponent {
                                                     <svg data-p-icon="chevron-right" [class]="cx('submenuIcon')" [pBind]="getPTOptions('submenuIcon', item, i)" />
                                                 }
                                             }
-                                            <ng-template *ngTemplateOutlet="headerIconTemplate || _headerIconTemplate"></ng-template>
+                                            <ng-template *ngTemplateOutlet="headerIconTemplate() || _headerIconTemplate"></ng-template>
                                         }
                                         @if (item.icon) {
                                             <span [class]="cn(cx('headerIcon'), item.icon, getItemProp(item, 'iconClass'))" [ngStyle]="getItemProp(item, 'iconStyle')" [pBind]="getPTOptions('headerIcon', item, i)"></span>
@@ -883,7 +882,7 @@ export class PanelMenuList extends BaseComponent {
                                     </a>
                                 }
                             }
-                            <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
+                            <ng-container *ngTemplateOutlet="itemTemplate(); context: { $implicit: item }"></ng-container>
                             @if (getItemProp(item, 'routerLink')) {
                                 <a
                                     [routerLink]="getItemProp(item, 'routerLink')"
@@ -905,7 +904,7 @@ export class PanelMenuList extends BaseComponent {
                                     [pBind]="getPTOptions('headerLink', item, i)"
                                 >
                                     @if (isItemGroup(item)) {
-                                        @if (!headerIconTemplate && !_headerIconTemplate) {
+                                        @if (!headerIconTemplate() && !_headerIconTemplate) {
                                             @if (isItemActive(item)) {
                                                 <svg data-p-icon="chevron-down" [class]="cx('submenuIcon')" [pBind]="getPTOptions('submenuIcon', item, i)" />
                                             }
@@ -913,7 +912,7 @@ export class PanelMenuList extends BaseComponent {
                                                 <svg data-p-icon="chevron-right" [class]="cx('submenuIcon')" [pBind]="getPTOptions('submenuIcon', item, i)" />
                                             }
                                         }
-                                        <ng-template *ngTemplateOutlet="headerIconTemplate || _headerIconTemplate"></ng-template>
+                                        <ng-template *ngTemplateOutlet="headerIconTemplate() || _headerIconTemplate"></ng-template>
                                     }
                                     @if (item.icon) {
                                         <span [class]="cn(cx('headerIcon'), item.icon, getItemProp(item, 'iconClass'))" [ngStyle]="getItemProp(item, 'iconStyle')" [pBind]="getPTOptions('headerIcon', item, i)"></span>
@@ -946,7 +945,7 @@ export class PanelMenuList extends BaseComponent {
                                     pPanelMenuList
                                     [panelId]="getPanelId(i, item)"
                                     [items]="getItemProp(item, 'items')"
-                                    [itemTemplate]="itemTemplate || _itemTemplate"
+                                    [itemTemplate]="itemTemplate() || _itemTemplate"
                                     [transitionOptions]="transitionOptions"
                                     [root]="true"
                                     [activeItem]="activeItem()"
@@ -1020,26 +1019,26 @@ export class PanelMenu extends BaseComponent<PanelMenuPassThrough> {
      */
     @Input({ transform: numberAttribute }) tabindex: number | undefined = 0;
 
-    @ViewChild('container') containerViewChild: ElementRef | undefined;
+    readonly containerViewChild = viewChild<ElementRef>('container');
     /**
      * Template option of submenu icon.
      * @group Templates
      */
-    @ContentChild('submenuicon', { descendants: false }) submenuIconTemplate: TemplateRef<void> | undefined;
+    readonly submenuIconTemplate = contentChild<TemplateRef<void>>('submenuicon', { descendants: false });
     /**
      * Template option of header icon.
      * @group Templates
      */
-    @ContentChild('headericon', { descendants: false }) headerIconTemplate: TemplateRef<void> | undefined;
+    readonly headerIconTemplate = contentChild<TemplateRef<void>>('headericon', { descendants: false });
     /**
      * Template option of item.
      * @param {PanelMenuItemTemplateContext} context - item context.
      * @see {@link PanelMenuItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<PanelMenuItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<PanelMenuItemTemplateContext>>('item', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _submenuIconTemplate: TemplateRef<void> | undefined;
 
@@ -1074,7 +1073,7 @@ export class PanelMenu extends BaseComponent<PanelMenuPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'submenuicon':
                     this._submenuIconTemplate = item.template;
@@ -1179,11 +1178,13 @@ export class PanelMenu extends BaseComponent<PanelMenuPassThrough> {
     }
 
     findFirstHeader() {
-        return this.containerViewChild?.nativeElement ? this.findNextHeader(this.containerViewChild.nativeElement.firstElementChild, true) : null;
+        const containerViewChild = this.containerViewChild();
+        return containerViewChild?.nativeElement ? this.findNextHeader(containerViewChild.nativeElement.firstElementChild, true) : null;
     }
 
     findLastHeader() {
-        return this.containerViewChild?.nativeElement ? this.findPrevHeader(this.containerViewChild.nativeElement.lastElementChild, true) : null;
+        const containerViewChild = this.containerViewChild();
+        return containerViewChild?.nativeElement ? this.findPrevHeader(containerViewChild.nativeElement.lastElementChild, true) : null;
     }
 
     onHeaderClick(event, item, index) {

--- a/packages/optimus-ui/src/password/password.test.ts
+++ b/packages/optimus-ui/src/password/password.test.ts
@@ -9,6 +9,7 @@ import { SharedModule } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { MapperPipe, Password, PasswordDirective, PasswordModule } from './password';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 // Test Components
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -2391,5 +2392,32 @@ describe('Password PassThrough Tests', () => {
             expect(inputEl.nativeElement.classList.contains('PC_INPUT_CLASS')).toBe(true);
             expect(inputEl.nativeElement.getAttribute('data-input')).toBe('test-value');
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Password, SharedModule],
+    template: ` <p-password> </p-password> `
+})
+class PasswordQueryApiHostComponent {}
+
+describe('Password Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [PasswordQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(PasswordQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Password)).componentInstance;
+
+        expect(instance.input()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/password/password.test.ts
+++ b/packages/optimus-ui/src/password/password.test.ts
@@ -943,7 +943,7 @@ describe('Password', () => {
 
                 // Templates should be available for context binding
                 if (passwordComponent.templates) {
-                    passwordComponent.templates.forEach((template: any) => {
+                    passwordComponent.templates().forEach((template: any) => {
                         expect(template).toBeTruthy();
                     });
                 }

--- a/packages/optimus-ui/src/password/password.ts
+++ b/packages/optimus-ui/src/password/password.ts
@@ -691,8 +691,6 @@ export class Password extends BaseInput<PasswordPassThrough> {
      */
     @Output() onClear: EventEmitter<any> = new EventEmitter<any>();
 
-    readonly overlayViewChild = viewChild.required<Overlay>('overlay');
-
     readonly input = viewChild.required<ElementRef>('input');
 
     /**

--- a/packages/optimus-ui/src/password/password.ts
+++ b/packages/optimus-ui/src/password/password.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     Directive,
     effect,
     ElementRef,
@@ -22,11 +20,12 @@ import {
     Output,
     Pipe,
     PipeTransform,
-    QueryList,
     signal,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionOptions } from '@openng/optimus-ui-motion';
@@ -468,32 +467,32 @@ export const Password_VALUE_ACCESSOR: any = {
             [unstyled]="unstyled()"
         />
         @if (showClear && value != null) {
-            @if (!clearIconTemplate && !_clearIconTemplate) {
+            @if (!clearIconTemplate() && !_clearIconTemplate) {
                 <svg data-p-icon="times" [class]="cx('clearIcon')" (click)="clear()" [pBind]="ptm('clearIcon')" />
             }
             <span (click)="clear()" [class]="cx('clearIcon')" [pBind]="ptm('clearIcon')">
-                <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="clearIconTemplate() || _clearIconTemplate"></ng-template>
             </span>
         }
 
         @if (toggleMask) {
             @if (unmasked) {
-                @if (!hideIconTemplate && !_hideIconTemplate) {
+                @if (!hideIconTemplate() && !_hideIconTemplate) {
                     <svg data-p-icon="eyeslash" [class]="cx('maskIcon')" [pBind]="ptm('maskIcon')" (click)="onMaskToggle()" />
                 }
-                @if (hideIconTemplate || _hideIconTemplate) {
+                @if (hideIconTemplate() || _hideIconTemplate) {
                     <span (click)="onMaskToggle()" [pBind]="ptm('maskIcon')">
-                        <ng-template *ngTemplateOutlet="hideIconTemplate || _hideIconTemplate; context: { class: cx('maskIcon') }"></ng-template>
+                        <ng-template *ngTemplateOutlet="hideIconTemplate() || _hideIconTemplate; context: { class: cx('maskIcon') }"></ng-template>
                     </span>
                 }
             }
             @if (!unmasked) {
-                @if (!showIconTemplate && !_showIconTemplate) {
+                @if (!showIconTemplate() && !_showIconTemplate) {
                     <svg data-p-icon="eye" [class]="cx('unmaskIcon')" [pBind]="ptm('unmaskIcon')" (click)="onMaskToggle()" />
                 }
-                @if (showIconTemplate || _showIconTemplate) {
+                @if (showIconTemplate() || _showIconTemplate) {
                     <span (click)="onMaskToggle()" [pBind]="ptm('unmaskIcon')">
-                        <ng-template *ngTemplateOutlet="showIconTemplate || _showIconTemplate; context: { class: cx('unmaskIcon') }"></ng-template>
+                        <ng-template *ngTemplateOutlet="showIconTemplate() || _showIconTemplate; context: { class: cx('unmaskIcon') }"></ng-template>
                     </span>
                 }
             }
@@ -502,9 +501,9 @@ export const Password_VALUE_ACCESSOR: any = {
         <p-overlay #overlay [hostAttrSelector]="$attrSelector" [(visible)]="overlayVisible" [options]="overlayOptions" [target]="'@parent'" [appendTo]="$appendTo()" [unstyled]="unstyled()" [pt]="ptm('pcOverlay')" [motionOptions]="motionOptions()">
             <ng-template #content>
                 <div [class]="cx('overlay')" [style]="sx('overlay')" (click)="onOverlayClick($event)" [pBind]="ptm('overlay')" [attr.data-p]="overlayDataP">
-                    <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
-                    @if (contentTemplate || _contentTemplate) {
-                        <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
+                    @if (contentTemplate() || _contentTemplate) {
+                        <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate"></ng-container>
                     } @else {
                         <div [class]="cx('content')" [pBind]="ptm('content')">
                             <div [class]="cx('meter')" [pBind]="ptm('meter')">
@@ -513,7 +512,7 @@ export const Password_VALUE_ACCESSOR: any = {
                             <div [class]="cx('meterText')" [pBind]="ptm('meterText')">{{ infoText }}</div>
                         </div>
                     }
-                    <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
                 </div>
             </ng-template>
         </p-overlay>
@@ -692,33 +691,33 @@ export class Password extends BaseInput<PasswordPassThrough> {
      */
     @Output() onClear: EventEmitter<any> = new EventEmitter<any>();
 
-    @ViewChild('overlay') overlayViewChild!: Overlay;
+    readonly overlayViewChild = viewChild.required<Overlay>('overlay');
 
-    @ViewChild('input') input!: ElementRef;
+    readonly input = viewChild.required<ElementRef>('input');
 
     /**
      * Custom template of content.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: Nullable<TemplateRef<void>>;
+    readonly contentTemplate = contentChild<Nullable<TemplateRef<void>>>('content', { descendants: false });
 
     /**
      * Custom template of footer.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: Nullable<TemplateRef<void>>;
+    readonly footerTemplate = contentChild<Nullable<TemplateRef<void>>>('footer', { descendants: false });
 
     /**
      * Custom template of header.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: Nullable<TemplateRef<void>>;
+    readonly headerTemplate = contentChild<Nullable<TemplateRef<void>>>('header', { descendants: false });
 
     /**
      * Custom template of clear icon.
      * @group Templates
      */
-    @ContentChild('clearicon', { descendants: false }) clearIconTemplate: Nullable<TemplateRef<void>>;
+    readonly clearIconTemplate = contentChild<Nullable<TemplateRef<void>>>('clearicon', { descendants: false });
 
     /**
      * Custom template of hide icon.
@@ -726,7 +725,7 @@ export class Password extends BaseInput<PasswordPassThrough> {
      * @see {@link PasswordIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('hideicon', { descendants: false }) hideIconTemplate: Nullable<TemplateRef<PasswordIconTemplateContext>>;
+    readonly hideIconTemplate = contentChild<Nullable<TemplateRef<PasswordIconTemplateContext>>>('hideicon', { descendants: false });
 
     /**
      * Custom template of show icon.
@@ -734,9 +733,9 @@ export class Password extends BaseInput<PasswordPassThrough> {
      * @see {@link PasswordIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('showicon', { descendants: false }) showIconTemplate: Nullable<TemplateRef<PasswordIconTemplateContext>>;
+    readonly showIconTemplate = contentChild<Nullable<TemplateRef<PasswordIconTemplateContext>>>('showicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
 
@@ -788,7 +787,7 @@ export class Password extends BaseInput<PasswordPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/picklist/picklist.test.ts
+++ b/packages/optimus-ui/src/picklist/picklist.test.ts
@@ -19,6 +19,7 @@ import { PickList } from './picklist';
 
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { SharedModule } from '@openng/optimus-ui/api';
+import { Listbox } from '@openng/optimus-ui/listbox';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1908,15 +1909,118 @@ describe('PickList Signal Query API', () => {
         await fixture.whenStable();
         const instance = fixture.debugElement.query(By.directive(PickList)).componentInstance;
 
-        for (const hook of ['sourceFilterTemplate','targetFilterTemplate','emptyMessageSourceTemplate','emptyFilterMessageSourceTemplate','emptyMessageTargetTemplate','emptyFilterMessageTargetTemplate','moveUpIconTemplate','moveTopIconTemplate','moveDownIconTemplate','moveBottomIconTemplate','moveToTargetIconTemplate','moveAllToTargetIconTemplate','moveToSourceIconTemplate','moveAllToSourceIconTemplate','targetFilterIconTemplate','sourceFilterIconTemplate']) {
+        for (const hook of [
+            'sourceFilterTemplate',
+            'targetFilterTemplate',
+            'emptyMessageSourceTemplate',
+            'emptyFilterMessageSourceTemplate',
+            'emptyMessageTargetTemplate',
+            'emptyFilterMessageTargetTemplate',
+            'moveUpIconTemplate',
+            'moveTopIconTemplate',
+            'moveDownIconTemplate',
+            'moveBottomIconTemplate',
+            'moveToTargetIconTemplate',
+            'moveAllToTargetIconTemplate',
+            'moveToSourceIconTemplate',
+            'moveAllToSourceIconTemplate',
+            'targetFilterIconTemplate',
+            'sourceFilterIconTemplate'
+        ]) {
             expect((instance as any)[hook](), `${hook} should resolve`).toBeDefined();
         }
         expect(instance.listViewSourceChild()).toBeDefined();
         expect(instance.listViewTargetChild()).toBeDefined();
-        // #sourceFilter / #targetFilter elements no longer exist in the PickList template
-        // (filtering is delegated to the inner listboxes), so these queries never resolve
-        expect(instance.sourceFilterViewChild()).toBeUndefined();
-        expect(instance.targetFilterViewChild()).toBeUndefined();
         expect(instance.templates().some((t: any) => t.getType() === 'item')).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Filter reset behavior (resetSourceFilter/resetTargetFilter delegate to the
+// embedded listboxes, clearing both their filter state and the visible input)
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [PickList, SharedModule],
+    template: ` <p-picklist [source]="src" [target]="tgt" filterBy="name"></p-picklist> `
+})
+class PickListFilterResetHostComponent {
+    src = [{ name: 'apple' }, { name: 'banana' }];
+    tgt = [{ name: 'cherry' }, { name: 'date' }];
+}
+
+describe('PickList filter reset', () => {
+    async function setup() {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [PickListFilterResetHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(PickListFilterResetHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const pickList = fixture.debugElement.query(By.directive(PickList)).componentInstance;
+        const [sourceListbox, targetListbox] = fixture.debugElement.queryAll(By.directive(Listbox)).map((de) => de.componentInstance);
+        return { fixture, pickList, sourceListbox, targetListbox };
+    }
+
+    async function typeIntoFilter(fixture: any, listbox: any, text: string) {
+        const input = listbox.filterViewChild()!.nativeElement as HTMLInputElement;
+        input.value = text;
+        input.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        await fixture.whenStable();
+        return input;
+    }
+
+    it('should clear the source listbox filter input and state on resetSourceFilter', async () => {
+        const { fixture, pickList, sourceListbox } = await setup();
+
+        const input = await typeIntoFilter(fixture, sourceListbox, 'apple');
+        expect(sourceListbox._filterValue()).toBe('apple');
+        expect(sourceListbox.visibleOptions().length).toBe(1);
+
+        pickList.resetSourceFilter();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input.value).toBe('');
+        expect(sourceListbox._filterValue()).toBeNull();
+        expect(sourceListbox.visibleOptions().length).toBe(2);
+        expect(pickList.filterValueSource).toBeNull();
+    });
+
+    it('should clear the target listbox filter input and state on resetTargetFilter', async () => {
+        const { fixture, pickList, targetListbox } = await setup();
+
+        const input = await typeIntoFilter(fixture, targetListbox, 'cherry');
+        expect(targetListbox._filterValue()).toBe('cherry');
+        expect(targetListbox.visibleOptions().length).toBe(1);
+
+        pickList.resetTargetFilter();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(input.value).toBe('');
+        expect(targetListbox._filterValue()).toBeNull();
+        expect(targetListbox.visibleOptions().length).toBe(2);
+        expect(pickList.filterValueTarget).toBeNull();
+    });
+
+    it('should clear both filters on resetFilter', async () => {
+        const { fixture, pickList, sourceListbox, targetListbox } = await setup();
+
+        const sourceInput = await typeIntoFilter(fixture, sourceListbox, 'apple');
+        const targetInput = await typeIntoFilter(fixture, targetListbox, 'date');
+
+        pickList.resetFilter();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(sourceInput.value).toBe('');
+        expect(targetInput.value).toBe('');
+        expect(sourceListbox.visibleOptions().length).toBe(2);
+        expect(targetListbox.visibleOptions().length).toBe(2);
     });
 });

--- a/packages/optimus-ui/src/picklist/picklist.test.ts
+++ b/packages/optimus-ui/src/picklist/picklist.test.ts
@@ -17,6 +17,8 @@ import {
 } from '@openng/optimus-ui/types/picklist';
 import { PickList } from './picklist';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1857,5 +1859,64 @@ describe('PickList', () => {
                 });
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [PickList, SharedModule],
+    template: `
+        <p-picklist [source]="src" [target]="tgt" filterBy="name">
+            <ng-template #sourceFilter>sf</ng-template>
+            <ng-template #targetFilter>tf</ng-template>
+            <ng-template #emptymessagesource>ems</ng-template>
+            <ng-template #emptyfiltermessagesource>efms</ng-template>
+            <ng-template #emptymessagetarget>emt</ng-template>
+            <ng-template #emptyfiltermessagetarget>efmt</ng-template>
+            <ng-template #moveupicon>u</ng-template>
+            <ng-template #movetopicon>t</ng-template>
+            <ng-template #movedownicon>d</ng-template>
+            <ng-template #movebottomicon>b</ng-template>
+            <ng-template #movetotargeticon>mt</ng-template>
+            <ng-template #movealltotargeticon>mat</ng-template>
+            <ng-template #movetosourceicon>ms</ng-template>
+            <ng-template #movealltosourceicon>mas</ng-template>
+            <ng-template #targetfiltericon>tfi</ng-template>
+            <ng-template #sourcefiltericon>sfi</ng-template>
+            <ng-template pTemplate="item">i</ng-template>
+        </p-picklist>
+    `
+})
+class PickListQueryApiHostComponent {
+    src = [{ name: 'a' }];
+    tgt = [{ name: 'b' }];
+}
+
+describe('PickList Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [PickListQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(PickListQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(PickList)).componentInstance;
+
+        for (const hook of ['sourceFilterTemplate','targetFilterTemplate','emptyMessageSourceTemplate','emptyFilterMessageSourceTemplate','emptyMessageTargetTemplate','emptyFilterMessageTargetTemplate','moveUpIconTemplate','moveTopIconTemplate','moveDownIconTemplate','moveBottomIconTemplate','moveToTargetIconTemplate','moveAllToTargetIconTemplate','moveToSourceIconTemplate','moveAllToSourceIconTemplate','targetFilterIconTemplate','sourceFilterIconTemplate']) {
+            expect((instance as any)[hook](), `${hook} should resolve`).toBeDefined();
+        }
+        expect(instance.listViewSourceChild()).toBeDefined();
+        expect(instance.listViewTargetChild()).toBeDefined();
+        // #sourceFilter / #targetFilter elements no longer exist in the PickList template
+        // (filtering is delegated to the inner listboxes), so these queries never resolve
+        expect(instance.sourceFilterViewChild()).toBeUndefined();
+        expect(instance.targetFilterViewChild()).toBeUndefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'item')).toBe(true);
     });
 });

--- a/packages/optimus-ui/src/picklist/picklist.ts
+++ b/packages/optimus-ui/src/picklist/picklist.ts
@@ -800,10 +800,6 @@ export class PickList extends BaseComponent {
 
     readonly listViewTargetChild = viewChild.required<Listbox>('targetlist');
 
-    readonly sourceFilterViewChild = viewChild<Nullable<ElementRef>>('sourceFilter');
-
-    readonly targetFilterViewChild = viewChild<Nullable<ElementRef>>('targetFilter');
-
     getButtonProps(direction: string) {
         switch (direction) {
             case 'moveup':
@@ -1717,15 +1713,13 @@ export class PickList extends BaseComponent {
     resetSourceFilter() {
         this.visibleOptionsSource = null;
         this.filterValueSource = null;
-        const sourceFilterViewChild = this.sourceFilterViewChild();
-        sourceFilterViewChild && ((<HTMLInputElement>sourceFilterViewChild.nativeElement).value = '');
+        this.listViewSourceChild().resetFilter();
     }
 
     resetTargetFilter() {
         this.visibleOptionsTarget = null;
         this.filterValueTarget = null;
-        const targetFilterViewChild = this.targetFilterViewChild();
-        targetFilterViewChild && ((<HTMLInputElement>targetFilterViewChild.nativeElement).value = '');
+        this.listViewTargetChild().resetFilter();
     }
 
     resetFilter() {

--- a/packages/optimus-ui/src/picklist/picklist.ts
+++ b/packages/optimus-ui/src/picklist/picklist.ts
@@ -13,7 +13,6 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     TemplateRef,
     ViewEncapsulation,
     viewChild,
@@ -949,19 +948,19 @@ export class PickList extends BaseComponent {
      * @see {@link PickListItemTemplateContext}
      * @group Templates
      */
-    readonly itemTemplate = contentChild.required<TemplateRef<PickListItemTemplateContext>>('item', { descendants: false });
+    readonly itemTemplate = contentChild<TemplateRef<PickListItemTemplateContext>>('item', { descendants: false });
 
     /**
      * Custom source header template.
      * @group Templates
      */
-    readonly sourceHeaderTemplate = contentChild.required<TemplateRef<void>>('sourceHeader', { descendants: false });
+    readonly sourceHeaderTemplate = contentChild<TemplateRef<void>>('sourceHeader', { descendants: false });
 
     /**
      * Custom target header template.
      * @group Templates
      */
-    readonly targetHeaderTemplate = contentChild.required<TemplateRef<void>>('targetHeader', { descendants: false });
+    readonly targetHeaderTemplate = contentChild<TemplateRef<void>>('targetHeader', { descendants: false });
 
     /**
      * Custom source filter template.
@@ -969,7 +968,7 @@ export class PickList extends BaseComponent {
      * @see {@link PickListFilterTemplateContext}
      * @group Templates
      */
-    readonly sourceFilterTemplate = contentChild.required<TemplateRef<PickListFilterTemplateContext>>('sourceFilter', { descendants: false });
+    readonly sourceFilterTemplate = contentChild<TemplateRef<PickListFilterTemplateContext>>('sourceFilter', { descendants: false });
 
     /**
      * Custom target filter template.
@@ -977,55 +976,55 @@ export class PickList extends BaseComponent {
      * @see {@link PickListFilterTemplateContext}
      * @group Templates
      */
-    readonly targetFilterTemplate = contentChild.required<TemplateRef<PickListFilterTemplateContext>>('targetFilter', { descendants: false });
+    readonly targetFilterTemplate = contentChild<TemplateRef<PickListFilterTemplateContext>>('targetFilter', { descendants: false });
 
     /**
      * Custom empty message when source is empty template.
      * @group Templates
      */
-    readonly emptyMessageSourceTemplate = contentChild.required<TemplateRef<void>>('emptymessagesource', { descendants: false });
+    readonly emptyMessageSourceTemplate = contentChild<TemplateRef<void>>('emptymessagesource', { descendants: false });
 
     /**
      * Custom empty filter message when source is empty template.
      * @group Templates
      */
-    readonly emptyFilterMessageSourceTemplate = contentChild.required<TemplateRef<void>>('emptyfiltermessagesource', { descendants: false });
+    readonly emptyFilterMessageSourceTemplate = contentChild<TemplateRef<void>>('emptyfiltermessagesource', { descendants: false });
 
     /**
      * Custom empty message when target is empty template.
      * @group Templates
      */
-    readonly emptyMessageTargetTemplate = contentChild.required<TemplateRef<void>>('emptymessagetarget', { descendants: false });
+    readonly emptyMessageTargetTemplate = contentChild<TemplateRef<void>>('emptymessagetarget', { descendants: false });
 
     /**
      * Custom empty filter message when target is empty template.
      * @group Templates
      */
-    readonly emptyFilterMessageTargetTemplate = contentChild.required<TemplateRef<void>>('emptyfiltermessagetarget', { descendants: false });
+    readonly emptyFilterMessageTargetTemplate = contentChild<TemplateRef<void>>('emptyfiltermessagetarget', { descendants: false });
 
     /**
      * Custom move up icon template.
      * @group Templates
      */
-    readonly moveUpIconTemplate = contentChild.required<TemplateRef<void>>('moveupicon', { descendants: false });
+    readonly moveUpIconTemplate = contentChild<TemplateRef<void>>('moveupicon', { descendants: false });
 
     /**
      * Custom move top icon template.
      * @group Templates
      */
-    readonly moveTopIconTemplate = contentChild.required<TemplateRef<void>>('movetopicon', { descendants: false });
+    readonly moveTopIconTemplate = contentChild<TemplateRef<void>>('movetopicon', { descendants: false });
 
     /**
      * Custom move down icon template.
      * @group Templates
      */
-    readonly moveDownIconTemplate = contentChild.required<TemplateRef<void>>('movedownicon', { descendants: false });
+    readonly moveDownIconTemplate = contentChild<TemplateRef<void>>('movedownicon', { descendants: false });
 
     /**
      * Custom move bottom icon template.
      * @group Templates
      */
-    readonly moveBottomIconTemplate = contentChild.required<TemplateRef<void>>('movebottomicon', { descendants: false });
+    readonly moveBottomIconTemplate = contentChild<TemplateRef<void>>('movebottomicon', { descendants: false });
 
     /**
      * Custom move to target icon template.
@@ -1033,7 +1032,7 @@ export class PickList extends BaseComponent {
      * @see {@link PickListTransferIconTemplateContext}
      * @group Templates
      */
-    readonly moveToTargetIconTemplate = contentChild.required<TemplateRef<PickListTransferIconTemplateContext>>('movetotargeticon', { descendants: false });
+    readonly moveToTargetIconTemplate = contentChild<TemplateRef<PickListTransferIconTemplateContext>>('movetotargeticon', { descendants: false });
 
     /**
      * Custom move all to target icon template.
@@ -1041,7 +1040,7 @@ export class PickList extends BaseComponent {
      * @see {@link PickListTransferIconTemplateContext}
      * @group Templates
      */
-    readonly moveAllToTargetIconTemplate = contentChild.required<TemplateRef<PickListTransferIconTemplateContext>>('movealltotargeticon', { descendants: false });
+    readonly moveAllToTargetIconTemplate = contentChild<TemplateRef<PickListTransferIconTemplateContext>>('movealltotargeticon', { descendants: false });
 
     /**
      * Custom move to source icon template.
@@ -1049,7 +1048,7 @@ export class PickList extends BaseComponent {
      * @see {@link PickListTransferIconTemplateContext}
      * @group Templates
      */
-    readonly moveToSourceIconTemplate = contentChild.required<TemplateRef<PickListTransferIconTemplateContext>>('movetosourceicon', { descendants: false });
+    readonly moveToSourceIconTemplate = contentChild<TemplateRef<PickListTransferIconTemplateContext>>('movetosourceicon', { descendants: false });
 
     /**
      * Custom move all to source icon template.
@@ -1057,19 +1056,19 @@ export class PickList extends BaseComponent {
      * @see {@link PickListTransferIconTemplateContext}
      * @group Templates
      */
-    readonly moveAllToSourceIconTemplate = contentChild.required<TemplateRef<PickListTransferIconTemplateContext>>('movealltosourceicon', { descendants: false });
+    readonly moveAllToSourceIconTemplate = contentChild<TemplateRef<PickListTransferIconTemplateContext>>('movealltosourceicon', { descendants: false });
 
     /**
      * Custom target filter icon template.
      * @group Templates
      */
-    readonly targetFilterIconTemplate = contentChild.required<TemplateRef<void>>('targetfiltericon', { descendants: false });
+    readonly targetFilterIconTemplate = contentChild<TemplateRef<void>>('targetfiltericon', { descendants: false });
 
     /**
      * Custom source filter icon template.
      * @group Templates
      */
-    readonly sourceFilterIconTemplate = contentChild.required<TemplateRef<void>>('sourcefiltericon', { descendants: false });
+    readonly sourceFilterIconTemplate = contentChild<TemplateRef<void>>('sourcefiltericon', { descendants: false });
 
     readonly templates = contentChildren(PrimeTemplate);
 
@@ -1112,7 +1111,7 @@ export class PickList extends BaseComponent {
     _sourceFilterIconTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -1718,12 +1717,14 @@ export class PickList extends BaseComponent {
     resetSourceFilter() {
         this.visibleOptionsSource = null;
         this.filterValueSource = null;
+        const sourceFilterViewChild = this.sourceFilterViewChild();
         sourceFilterViewChild && ((<HTMLInputElement>sourceFilterViewChild.nativeElement).value = '');
     }
 
     resetTargetFilter() {
         this.visibleOptionsTarget = null;
         this.filterValueTarget = null;
+        const targetFilterViewChild = this.targetFilterViewChild();
         targetFilterViewChild && ((<HTMLInputElement>targetFilterViewChild.nativeElement).value = '');
     }
 

--- a/packages/optimus-ui/src/picklist/picklist.ts
+++ b/packages/optimus-ui/src/picklist/picklist.ts
@@ -4,8 +4,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -17,8 +15,10 @@ import {
     Output,
     QueryList,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { find, findIndexInList, isEmpty, setAttribute, uuid } from '@openng/optimus-ui-utils';
@@ -90,8 +90,8 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     [pt]="ptm('pcSourceMoveUpButton')"
                     [unstyled]="unstyled()"
                 >
-                    <svg data-p-icon="angle-up" *ngIf="!moveUpIconTemplate && !_moveUpIconTemplate" [pt]="ptm('pcSourceMoveUpButton')['icon']" pButtonIcon />
-                    <ng-template *ngTemplateOutlet="moveUpIconTemplate || _moveUpIconTemplate"></ng-template>
+                    <svg data-p-icon="angle-up" *ngIf="!moveUpIconTemplate() && !_moveUpIconTemplate" [pt]="ptm('pcSourceMoveUpButton')['icon']" pButtonIcon />
+                    <ng-template *ngTemplateOutlet="moveUpIconTemplate() || _moveUpIconTemplate"></ng-template>
                 </button>
                 <button
                     type="button"
@@ -105,8 +105,8 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     [pt]="ptm('pcSourceMoveTopButton')"
                     [unstyled]="unstyled()"
                 >
-                    <svg data-p-icon="angle-double-up" *ngIf="!moveTopIconTemplate && !_moveTopIconTemplate" pButtonIcon [pt]="ptm('pcSourceMoveTopButton')['icon']" />
-                    <ng-template *ngTemplateOutlet="moveTopIconTemplate || _moveTopIconTemplate"></ng-template>
+                    <svg data-p-icon="angle-double-up" *ngIf="!moveTopIconTemplate() && !_moveTopIconTemplate" pButtonIcon [pt]="ptm('pcSourceMoveTopButton')['icon']" />
+                    <ng-template *ngTemplateOutlet="moveTopIconTemplate() || _moveTopIconTemplate"></ng-template>
                 </button>
                 <button
                     type="button"
@@ -121,8 +121,8 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     [unstyled]="unstyled()"
                     hostName="picklist"
                 >
-                    <svg data-p-icon="angle-down" *ngIf="!moveDownIconTemplate && !_moveDownIconTemplate" pButtonIcon [pt]="ptm('pcSourceMoveDownButton')['icon']" />
-                    <ng-template *ngTemplateOutlet="moveDownIconTemplate || _moveDownIconTemplate"></ng-template>
+                    <svg data-p-icon="angle-down" *ngIf="!moveDownIconTemplate() && !_moveDownIconTemplate" pButtonIcon [pt]="ptm('pcSourceMoveDownButton')['icon']" />
+                    <ng-template *ngTemplateOutlet="moveDownIconTemplate() || _moveDownIconTemplate"></ng-template>
                 </button>
                 <button
                     type="button"
@@ -137,8 +137,8 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     [unstyled]="unstyled()"
                     hostName="picklist"
                 >
-                    <svg data-p-icon="angle-double-down" *ngIf="!moveBottomIconTemplate || _moveBottomIconTemplate" pButtonIcon [pt]="ptm('pcSourceMoveBottomButton')['icon']" />
-                    <ng-template *ngTemplateOutlet="moveBottomIconTemplate || _moveBottomIconTemplate"></ng-template>
+                    <svg data-p-icon="angle-double-down" *ngIf="!moveBottomIconTemplate() || _moveBottomIconTemplate" pButtonIcon [pt]="ptm('pcSourceMoveBottomButton')['icon']" />
+                    <ng-template *ngTemplateOutlet="moveBottomIconTemplate() || _moveBottomIconTemplate"></ng-template>
                 </button>
             </div>
             <div [class]="cx('sourceListContainer')" [attr.data-pc-group-section]="'listcontainer'" [pBind]="ptm('sourceListContainer')">
@@ -177,33 +177,33 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     [attr.data-pc-group-section]="'list'"
                     [unstyled]="unstyled()"
                 >
-                    <ng-container *ngIf="sourceHeaderTemplate || _sourceHeaderTemplate || sourceHeader">
+                    <ng-container *ngIf="sourceHeaderTemplate() || _sourceHeaderTemplate || sourceHeader">
                         <ng-template #header>
-                            <div *ngIf="!sourceHeaderTemplate && !_sourceHeaderTemplate">{{ sourceHeader }}</div>
-                            <ng-template *ngTemplateOutlet="sourceHeaderTemplate || _sourceHeaderTemplate"></ng-template>
+                            <div *ngIf="!sourceHeaderTemplate() && !_sourceHeaderTemplate">{{ sourceHeader }}</div>
+                            <ng-template *ngTemplateOutlet="sourceHeaderTemplate() || _sourceHeaderTemplate"></ng-template>
                         </ng-template>
                     </ng-container>
-                    <ng-container *ngIf="sourceFilterTemplate || _sourceFilterTemplate">
+                    <ng-container *ngIf="sourceFilterTemplate() || _sourceFilterTemplate">
                         <ng-template #filter>
-                            <ng-template *ngTemplateOutlet="sourceFilterTemplate || _sourceFilterTemplate; context: { options: sourceFilterOptions }"></ng-template>
+                            <ng-template *ngTemplateOutlet="sourceFilterTemplate() || _sourceFilterTemplate; context: { options: sourceFilterOptions }"></ng-template>
                         </ng-template>
                     </ng-container>
-                    <ng-container *ngIf="sourceFilterIconTemplate || _sourceFilterIconTemplate">
-                        <ng-container *ngTemplateOutlet="sourceFilterIconTemplate || _sourceFilterIconTemplate"></ng-container>
+                    <ng-container *ngIf="sourceFilterIconTemplate() || _sourceFilterIconTemplate">
+                        <ng-container *ngTemplateOutlet="sourceFilterIconTemplate() || _sourceFilterIconTemplate"></ng-container>
                     </ng-container>
-                    <ng-container *ngIf="itemTemplate || _itemTemplate">
+                    <ng-container *ngIf="itemTemplate() || _itemTemplate">
                         <ng-template #item let-item let-index="index" let-selected="selected" let-disabled="disabled">
-                            <ng-container *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: item, index: index, selected: selected, disabled: disabled }"></ng-container>
+                            <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: item, index: index, selected: selected, disabled: disabled }"></ng-container>
                         </ng-template>
                     </ng-container>
-                    <ng-container *ngIf="emptyMessageSourceTemplate || _emptyMessageSourceTemplate">
+                    <ng-container *ngIf="emptyMessageSourceTemplate() || _emptyMessageSourceTemplate">
                         <ng-template #empty>
-                            <ng-container *ngTemplateOutlet="emptyMessageSourceTemplate || _emptyMessageSourceTemplate"></ng-container>
+                            <ng-container *ngTemplateOutlet="emptyMessageSourceTemplate() || _emptyMessageSourceTemplate"></ng-container>
                         </ng-template>
                     </ng-container>
-                    <ng-container *ngIf="emptyFilterMessageSourceTemplate || _emptyFilterMessageSourceTemplate">
+                    <ng-container *ngIf="emptyFilterMessageSourceTemplate() || _emptyFilterMessageSourceTemplate">
                         <ng-template #emptyfilter>
-                            <ng-container *ngTemplateOutlet="emptyFilterMessageSourceTemplate || _emptyFilterMessageSourceTemplate"></ng-container>
+                            <ng-container *ngTemplateOutlet="emptyFilterMessageSourceTemplate() || _emptyFilterMessageSourceTemplate"></ng-container>
                         </ng-template>
                     </ng-container>
                 </p-listbox>
@@ -222,11 +222,11 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     hostName="picklist"
                     [unstyled]="unstyled()"
                 >
-                    <ng-container *ngIf="!moveToTargetIconTemplate && !_moveToTargetIconTemplate">
+                    <ng-container *ngIf="!moveToTargetIconTemplate() && !_moveToTargetIconTemplate">
                         <svg data-p-icon="angle-right" *ngIf="!viewChanged" pButtonIcon [pt]="ptm('pcMoveToTargetButton')['icon']" />
                         <svg data-p-icon="angle-down" *ngIf="viewChanged" pButtonIcon [pt]="ptm('pcMoveToTargetButton')['icon']" />
                     </ng-container>
-                    <ng-template *ngTemplateOutlet="moveToTargetIconTemplate || _moveToTargetIconTemplate; context: { $implicit: viewChanged }"></ng-template>
+                    <ng-template *ngTemplateOutlet="moveToTargetIconTemplate() || _moveToTargetIconTemplate; context: { $implicit: viewChanged }"></ng-template>
                 </button>
                 <button
                     type="button"
@@ -240,11 +240,11 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     [pt]="ptm('pcMoveAllToTargetButton')"
                     [unstyled]="unstyled()"
                 >
-                    <ng-container *ngIf="!moveAllToTargetIconTemplate && !_moveAllToTargetIconTemplate">
+                    <ng-container *ngIf="!moveAllToTargetIconTemplate() && !_moveAllToTargetIconTemplate">
                         <svg data-p-icon="angle-double-right" *ngIf="!viewChanged" pButtonIcon [pt]="ptm('pcMoveAllToTargetButton')['icon']" />
                         <svg data-p-icon="angle-double-down" *ngIf="viewChanged" pButtonIcon [pt]="ptm('pcMoveAllToTargetButton')['icon']" />
                     </ng-container>
-                    <ng-template *ngTemplateOutlet="moveAllToTargetIconTemplate || _moveAllToTargetIconTemplate; context: { $implicit: viewChanged }"></ng-template>
+                    <ng-template *ngTemplateOutlet="moveAllToTargetIconTemplate() || _moveAllToTargetIconTemplate; context: { $implicit: viewChanged }"></ng-template>
                 </button>
                 <button
                     type="button"
@@ -259,11 +259,11 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     hostName="picklist"
                     [unstyled]="unstyled()"
                 >
-                    <ng-container *ngIf="!moveToSourceIconTemplate && !_moveToSourceIconTemplate">
+                    <ng-container *ngIf="!moveToSourceIconTemplate() && !_moveToSourceIconTemplate">
                         <svg data-p-icon="angle-left" *ngIf="!viewChanged" pButtonIcon [pt]="ptm('pcMoveToSourceButton')['icon']" />
                         <svg data-p-icon="angle-up" *ngIf="viewChanged" pButtonIcon [pt]="ptm('pcMoveToSourceButton')['icon']" />
                     </ng-container>
-                    <ng-template *ngTemplateOutlet="moveToSourceIconTemplate || _moveToSourceIconTemplate; context: { $implicit: viewChanged }"></ng-template>
+                    <ng-template *ngTemplateOutlet="moveToSourceIconTemplate() || _moveToSourceIconTemplate; context: { $implicit: viewChanged }"></ng-template>
                 </button>
                 <button
                     type="button"
@@ -278,11 +278,11 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     hostName="picklist"
                     [unstyled]="unstyled()"
                 >
-                    <ng-container *ngIf="!moveAllToSourceIconTemplate && !_moveAllToSourceIconTemplate">
+                    <ng-container *ngIf="!moveAllToSourceIconTemplate() && !_moveAllToSourceIconTemplate">
                         <svg data-p-icon="angle-double-left" *ngIf="!viewChanged" pButtonIcon [pt]="ptm('pcMoveAllToSourceButton')['icon']" />
                         <svg data-p-icon="angle-double-up" *ngIf="viewChanged" pButtonIcon [pt]="ptm('pcMoveAllToSourceButton')['icon']" />
                     </ng-container>
-                    <ng-template *ngTemplateOutlet="moveAllToSourceIconTemplate || _moveAllToSourceIconTemplate; context: { $implicit: viewChanged }"></ng-template>
+                    <ng-template *ngTemplateOutlet="moveAllToSourceIconTemplate() || _moveAllToSourceIconTemplate; context: { $implicit: viewChanged }"></ng-template>
                 </button>
             </div>
             <div [class]="cx('targetListContainer')" [attr.data-pc-group-section]="'listcontainer'" [pBind]="ptm('targetListContainer')">
@@ -321,33 +321,33 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     hostName="picklist"
                     [unstyled]="unstyled()"
                 >
-                    <ng-container *ngIf="targetHeaderTemplate || _targetHeaderTemplate || targetHeader">
+                    <ng-container *ngIf="targetHeaderTemplate() || _targetHeaderTemplate || targetHeader">
                         <ng-template #header>
-                            <div *ngIf="!targetHeaderTemplate && !_targetHeaderTemplate">{{ targetHeader }}</div>
-                            <ng-template *ngTemplateOutlet="targetHeaderTemplate || _targetHeaderTemplate"></ng-template>
+                            <div *ngIf="!targetHeaderTemplate() && !_targetHeaderTemplate">{{ targetHeader }}</div>
+                            <ng-template *ngTemplateOutlet="targetHeaderTemplate() || _targetHeaderTemplate"></ng-template>
                         </ng-template>
                     </ng-container>
-                    <ng-container *ngIf="targetFilterTemplate || _targetFilterTemplate">
+                    <ng-container *ngIf="targetFilterTemplate() || _targetFilterTemplate">
                         <ng-template #filter>
-                            <ng-template *ngTemplateOutlet="targetFilterTemplate || _targetFilterTemplate; context: { options: targetFilterOptions }"></ng-template>
+                            <ng-template *ngTemplateOutlet="targetFilterTemplate() || _targetFilterTemplate; context: { options: targetFilterOptions }"></ng-template>
                         </ng-template>
                     </ng-container>
-                    <ng-container *ngIf="targetFilterIconTemplate || _targetFilterIconTemplate">
-                        <ng-container *ngTemplateOutlet="targetFilterIconTemplate || _targetFilterIconTemplate"></ng-container>
+                    <ng-container *ngIf="targetFilterIconTemplate() || _targetFilterIconTemplate">
+                        <ng-container *ngTemplateOutlet="targetFilterIconTemplate() || _targetFilterIconTemplate"></ng-container>
                     </ng-container>
-                    <ng-container *ngIf="itemTemplate || _itemTemplate">
+                    <ng-container *ngIf="itemTemplate() || _itemTemplate">
                         <ng-template #item let-item let-index="index" let-selected="selected" let-disabled="disabled">
-                            <ng-container *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: item, index: index, selected: selected, disabled: disabled }"></ng-container>
+                            <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: item, index: index, selected: selected, disabled: disabled }"></ng-container>
                         </ng-template>
                     </ng-container>
-                    <ng-container *ngIf="emptyMessageTargetTemplate || _emptyMessageTargetTemplate">
+                    <ng-container *ngIf="emptyMessageTargetTemplate() || _emptyMessageTargetTemplate">
                         <ng-template #empty>
-                            <ng-container *ngTemplateOutlet="emptyMessageTargetTemplate || _emptyMessageTargetTemplate"></ng-container>
+                            <ng-container *ngTemplateOutlet="emptyMessageTargetTemplate() || _emptyMessageTargetTemplate"></ng-container>
                         </ng-template>
                     </ng-container>
-                    <ng-container *ngIf="emptyFilterMessageTargetTemplate || _emptyFilterMessageTargetTemplate">
+                    <ng-container *ngIf="emptyFilterMessageTargetTemplate() || _emptyFilterMessageTargetTemplate">
                         <ng-template #emptyfilter>
-                            <ng-container *ngTemplateOutlet="emptyFilterMessageTargetTemplate || _emptyFilterMessageTargetTemplate"></ng-container>
+                            <ng-container *ngTemplateOutlet="emptyFilterMessageTargetTemplate() || _emptyFilterMessageTargetTemplate"></ng-container>
                         </ng-template>
                     </ng-container>
                 </p-listbox>
@@ -366,8 +366,8 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     hostName="picklist"
                     [unstyled]="unstyled()"
                 >
-                    <svg data-p-icon="angle-up" *ngIf="!moveUpIconTemplate && !_moveUpIconTemplate" pButtonIcon [pt]="ptm('pcTargetMoveUpButton')['icon']" />
-                    <ng-template *ngTemplateOutlet="moveUpIconTemplate || _moveUpIconTemplate"></ng-template>
+                    <svg data-p-icon="angle-up" *ngIf="!moveUpIconTemplate() && !_moveUpIconTemplate" pButtonIcon [pt]="ptm('pcTargetMoveUpButton')['icon']" />
+                    <ng-template *ngTemplateOutlet="moveUpIconTemplate() || _moveUpIconTemplate"></ng-template>
                 </button>
                 <button
                     type="button"
@@ -382,8 +382,8 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     hostName="picklist"
                     [unstyled]="unstyled()"
                 >
-                    <svg data-p-icon="angle-double-up" *ngIf="!moveTopIconTemplate && !_moveTopIconTemplate" pButtonIcon [pt]="ptm('pcTargetMoveTopButton')['icon']" />
-                    <ng-template *ngTemplateOutlet="moveTopIconTemplate || moveTopIconTemplate"></ng-template>
+                    <svg data-p-icon="angle-double-up" *ngIf="!moveTopIconTemplate() && !_moveTopIconTemplate" pButtonIcon [pt]="ptm('pcTargetMoveTopButton')['icon']" />
+                    <ng-template *ngTemplateOutlet="moveTopIconTemplate() || moveTopIconTemplate()"></ng-template>
                 </button>
                 <button
                     type="button"
@@ -398,8 +398,8 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     hostName="picklist"
                     [unstyled]="unstyled()"
                 >
-                    <svg data-p-icon="angle-down" *ngIf="!moveDownIconTemplate && !_moveDownIconTemplate" pButtonIcon [pt]="ptm('pcTargetMoveDownButton')['icon']" />
-                    <ng-template *ngTemplateOutlet="moveDownIconTemplate || _moveDownIconTemplate"></ng-template>
+                    <svg data-p-icon="angle-down" *ngIf="!moveDownIconTemplate() && !_moveDownIconTemplate" pButtonIcon [pt]="ptm('pcTargetMoveDownButton')['icon']" />
+                    <ng-template *ngTemplateOutlet="moveDownIconTemplate() || _moveDownIconTemplate"></ng-template>
                 </button>
                 <button
                     type="button"
@@ -414,8 +414,8 @@ const PICKLIST_INSTANCE = new InjectionToken<PickList>('PICKLIST_INSTANCE');
                     hostName="picklist"
                     [unstyled]="unstyled()"
                 >
-                    <svg data-p-icon="angle-double-down" *ngIf="!moveBottomIconTemplate && !_moveBottomIconTemplate" pButtonIcon [pt]="ptm('pcTargetMoveBottomButton')['icon']" />
-                    <ng-template *ngTemplateOutlet="moveBottomIconTemplate || _moveBottomIconTemplate"></ng-template>
+                    <svg data-p-icon="angle-double-down" *ngIf="!moveBottomIconTemplate() && !_moveBottomIconTemplate" pButtonIcon [pt]="ptm('pcTargetMoveBottomButton')['icon']" />
+                    <ng-template *ngTemplateOutlet="moveBottomIconTemplate() || _moveBottomIconTemplate"></ng-template>
                 </button>
             </div>
         </div>
@@ -797,13 +797,13 @@ export class PickList extends BaseComponent {
      */
     @Output() onBlur: EventEmitter<Event> = new EventEmitter<Event>();
 
-    @ViewChild('sourcelist') listViewSourceChild: Listbox;
+    readonly listViewSourceChild = viewChild.required<Listbox>('sourcelist');
 
-    @ViewChild('targetlist') listViewTargetChild: Listbox;
+    readonly listViewTargetChild = viewChild.required<Listbox>('targetlist');
 
-    @ViewChild('sourceFilter') sourceFilterViewChild: Nullable<ElementRef>;
+    readonly sourceFilterViewChild = viewChild<Nullable<ElementRef>>('sourceFilter');
 
-    @ViewChild('targetFilter') targetFilterViewChild: Nullable<ElementRef>;
+    readonly targetFilterViewChild = viewChild<Nullable<ElementRef>>('targetFilter');
 
     getButtonProps(direction: string) {
         switch (direction) {
@@ -949,19 +949,19 @@ export class PickList extends BaseComponent {
      * @see {@link PickListItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<PickListItemTemplateContext>;
+    readonly itemTemplate = contentChild.required<TemplateRef<PickListItemTemplateContext>>('item', { descendants: false });
 
     /**
      * Custom source header template.
      * @group Templates
      */
-    @ContentChild('sourceHeader', { descendants: false }) sourceHeaderTemplate: TemplateRef<void>;
+    readonly sourceHeaderTemplate = contentChild.required<TemplateRef<void>>('sourceHeader', { descendants: false });
 
     /**
      * Custom target header template.
      * @group Templates
      */
-    @ContentChild('targetHeader', { descendants: false }) targetHeaderTemplate: TemplateRef<void>;
+    readonly targetHeaderTemplate = contentChild.required<TemplateRef<void>>('targetHeader', { descendants: false });
 
     /**
      * Custom source filter template.
@@ -969,7 +969,7 @@ export class PickList extends BaseComponent {
      * @see {@link PickListFilterTemplateContext}
      * @group Templates
      */
-    @ContentChild('sourceFilter', { descendants: false }) sourceFilterTemplate: TemplateRef<PickListFilterTemplateContext>;
+    readonly sourceFilterTemplate = contentChild.required<TemplateRef<PickListFilterTemplateContext>>('sourceFilter', { descendants: false });
 
     /**
      * Custom target filter template.
@@ -977,55 +977,55 @@ export class PickList extends BaseComponent {
      * @see {@link PickListFilterTemplateContext}
      * @group Templates
      */
-    @ContentChild('targetFilter', { descendants: false }) targetFilterTemplate: TemplateRef<PickListFilterTemplateContext>;
+    readonly targetFilterTemplate = contentChild.required<TemplateRef<PickListFilterTemplateContext>>('targetFilter', { descendants: false });
 
     /**
      * Custom empty message when source is empty template.
      * @group Templates
      */
-    @ContentChild('emptymessagesource', { descendants: false }) emptyMessageSourceTemplate: TemplateRef<void>;
+    readonly emptyMessageSourceTemplate = contentChild.required<TemplateRef<void>>('emptymessagesource', { descendants: false });
 
     /**
      * Custom empty filter message when source is empty template.
      * @group Templates
      */
-    @ContentChild('emptyfiltermessagesource', { descendants: false }) emptyFilterMessageSourceTemplate: TemplateRef<void>;
+    readonly emptyFilterMessageSourceTemplate = contentChild.required<TemplateRef<void>>('emptyfiltermessagesource', { descendants: false });
 
     /**
      * Custom empty message when target is empty template.
      * @group Templates
      */
-    @ContentChild('emptymessagetarget', { descendants: false }) emptyMessageTargetTemplate: TemplateRef<void>;
+    readonly emptyMessageTargetTemplate = contentChild.required<TemplateRef<void>>('emptymessagetarget', { descendants: false });
 
     /**
      * Custom empty filter message when target is empty template.
      * @group Templates
      */
-    @ContentChild('emptyfiltermessagetarget', { descendants: false }) emptyFilterMessageTargetTemplate: TemplateRef<void>;
+    readonly emptyFilterMessageTargetTemplate = contentChild.required<TemplateRef<void>>('emptyfiltermessagetarget', { descendants: false });
 
     /**
      * Custom move up icon template.
      * @group Templates
      */
-    @ContentChild('moveupicon', { descendants: false }) moveUpIconTemplate: TemplateRef<void>;
+    readonly moveUpIconTemplate = contentChild.required<TemplateRef<void>>('moveupicon', { descendants: false });
 
     /**
      * Custom move top icon template.
      * @group Templates
      */
-    @ContentChild('movetopicon', { descendants: false }) moveTopIconTemplate: TemplateRef<void>;
+    readonly moveTopIconTemplate = contentChild.required<TemplateRef<void>>('movetopicon', { descendants: false });
 
     /**
      * Custom move down icon template.
      * @group Templates
      */
-    @ContentChild('movedownicon', { descendants: false }) moveDownIconTemplate: TemplateRef<void>;
+    readonly moveDownIconTemplate = contentChild.required<TemplateRef<void>>('movedownicon', { descendants: false });
 
     /**
      * Custom move bottom icon template.
      * @group Templates
      */
-    @ContentChild('movebottomicon', { descendants: false }) moveBottomIconTemplate: TemplateRef<void>;
+    readonly moveBottomIconTemplate = contentChild.required<TemplateRef<void>>('movebottomicon', { descendants: false });
 
     /**
      * Custom move to target icon template.
@@ -1033,7 +1033,7 @@ export class PickList extends BaseComponent {
      * @see {@link PickListTransferIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('movetotargeticon', { descendants: false }) moveToTargetIconTemplate: TemplateRef<PickListTransferIconTemplateContext>;
+    readonly moveToTargetIconTemplate = contentChild.required<TemplateRef<PickListTransferIconTemplateContext>>('movetotargeticon', { descendants: false });
 
     /**
      * Custom move all to target icon template.
@@ -1041,7 +1041,7 @@ export class PickList extends BaseComponent {
      * @see {@link PickListTransferIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('movealltotargeticon', { descendants: false }) moveAllToTargetIconTemplate: TemplateRef<PickListTransferIconTemplateContext>;
+    readonly moveAllToTargetIconTemplate = contentChild.required<TemplateRef<PickListTransferIconTemplateContext>>('movealltotargeticon', { descendants: false });
 
     /**
      * Custom move to source icon template.
@@ -1049,7 +1049,7 @@ export class PickList extends BaseComponent {
      * @see {@link PickListTransferIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('movetosourceicon', { descendants: false }) moveToSourceIconTemplate: TemplateRef<PickListTransferIconTemplateContext>;
+    readonly moveToSourceIconTemplate = contentChild.required<TemplateRef<PickListTransferIconTemplateContext>>('movetosourceicon', { descendants: false });
 
     /**
      * Custom move all to source icon template.
@@ -1057,21 +1057,21 @@ export class PickList extends BaseComponent {
      * @see {@link PickListTransferIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('movealltosourceicon', { descendants: false }) moveAllToSourceIconTemplate: TemplateRef<PickListTransferIconTemplateContext>;
+    readonly moveAllToSourceIconTemplate = contentChild.required<TemplateRef<PickListTransferIconTemplateContext>>('movealltosourceicon', { descendants: false });
 
     /**
      * Custom target filter icon template.
      * @group Templates
      */
-    @ContentChild('targetfiltericon', { descendants: false }) targetFilterIconTemplate: TemplateRef<void>;
+    readonly targetFilterIconTemplate = contentChild.required<TemplateRef<void>>('targetfiltericon', { descendants: false });
 
     /**
      * Custom source filter icon template.
      * @group Templates
      */
-    @ContentChild('sourcefiltericon', { descendants: false }) sourceFilterIconTemplate: TemplateRef<void>;
+    readonly sourceFilterIconTemplate = contentChild.required<TemplateRef<void>>('sourcefiltericon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _itemTemplate: TemplateRef<PickListItemTemplateContext> | undefined;
 
@@ -1112,7 +1112,7 @@ export class PickList extends BaseComponent {
     _sourceFilterIconTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -1291,8 +1291,8 @@ export class PickList extends BaseComponent {
     }
 
     triggerChangeDetection() {
-        this.listViewTargetChild.cd.markForCheck();
-        this.listViewSourceChild.cd.markForCheck();
+        this.listViewTargetChild().cd.markForCheck();
+        this.listViewSourceChild().cd.markForCheck();
     }
 
     moveUp(listElement: any, list: any[], selectedItems: any[], callback: EventEmitter<any>, listType: number) {
@@ -1661,7 +1661,7 @@ export class PickList extends BaseComponent {
     }
 
     getListElement(listType: number) {
-        return listType === this.SOURCE_LIST ? this.listViewSourceChild?.el.nativeElement : this.listViewTargetChild?.el.nativeElement;
+        return listType === this.SOURCE_LIST ? this.listViewSourceChild()?.el.nativeElement : this.listViewTargetChild()?.el.nativeElement;
     }
 
     getListItems(listType: number) {
@@ -1718,13 +1718,13 @@ export class PickList extends BaseComponent {
     resetSourceFilter() {
         this.visibleOptionsSource = null;
         this.filterValueSource = null;
-        this.sourceFilterViewChild && ((<HTMLInputElement>this.sourceFilterViewChild.nativeElement).value = '');
+        sourceFilterViewChild && ((<HTMLInputElement>sourceFilterViewChild.nativeElement).value = '');
     }
 
     resetTargetFilter() {
         this.visibleOptionsTarget = null;
         this.filterValueTarget = null;
-        this.targetFilterViewChild && ((<HTMLInputElement>this.targetFilterViewChild.nativeElement).value = '');
+        targetFilterViewChild && ((<HTMLInputElement>targetFilterViewChild.nativeElement).value = '');
     }
 
     resetFilter() {

--- a/packages/optimus-ui/src/picklist/picklist.ts
+++ b/packages/optimus-ui/src/picklist/picklist.ts
@@ -1660,7 +1660,7 @@ export class PickList extends BaseComponent {
     }
 
     getListElement(listType: number) {
-        return listType === this.SOURCE_LIST ? this.listViewSourceChild()?.el.nativeElement : this.listViewTargetChild()?.el.nativeElement;
+        return listType === this.SOURCE_LIST ? this.listViewSourceChild().el.nativeElement : this.listViewTargetChild().el.nativeElement;
     }
 
     getListItems(listType: number) {

--- a/packages/optimus-ui/src/popover/popover.test.ts
+++ b/packages/optimus-ui/src/popover/popover.test.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ElementRef, provideZonelessChangeDetection, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import type { Mock } from 'vitest';
@@ -46,8 +46,8 @@ import { Popover } from './popover';
     `
 })
 class TestBasicPopoverComponent {
-    @ViewChild('popover') popover!: Popover;
-    @ViewChild('targetButton', { read: ElementRef }) targetButton!: ElementRef;
+    readonly popover = viewChild.required<Popover>('popover');
+    readonly targetButton = viewChild.required('targetButton', { read: ElementRef });
 
     dismissable = true;
     style: { [klass: string]: any } | null = null as any;
@@ -90,8 +90,8 @@ class TestBasicPopoverComponent {
     `
 })
 class TestTemplatePopoverComponent {
-    @ViewChild('popover') popover!: Popover;
-    @ViewChild('targetButton', { read: ElementRef }) targetButton!: ElementRef;
+    readonly popover = viewChild.required<Popover>('popover');
+    readonly targetButton = viewChild.required('targetButton', { read: ElementRef });
 }
 
 @Component({
@@ -110,8 +110,8 @@ class TestTemplatePopoverComponent {
     `
 })
 class TestPTemplatePopoverComponent {
-    @ViewChild('popover') popover!: Popover;
-    @ViewChild('targetButton', { read: ElementRef }) targetButton!: ElementRef;
+    readonly popover = viewChild.required<Popover>('popover');
+    readonly targetButton = viewChild.required('targetButton', { read: ElementRef });
 }
 
 @Component({
@@ -127,8 +127,8 @@ class TestPTemplatePopoverComponent {
     `
 })
 class TestKeyboardNavigationComponent {
-    @ViewChild('popover') popover!: Popover;
-    @ViewChild('targetButton', { read: ElementRef }) targetButton!: ElementRef;
+    readonly popover = viewChild.required<Popover>('popover');
+    readonly targetButton = viewChild.required('targetButton', { read: ElementRef });
 }
 
 describe('Popover', () => {
@@ -158,7 +158,7 @@ describe('Popover', () => {
             fixture = TestBed.createComponent(TestBasicPopoverComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            popoverInstance = component.popover;
+            popoverInstance = component.popover();
         });
 
         it('should create the component', () => {
@@ -206,12 +206,12 @@ describe('Popover', () => {
             fixture = TestBed.createComponent(TestBasicPopoverComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            popoverInstance = component.popover;
+            popoverInstance = component.popover();
         });
 
         it('should show popover programmatically', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -224,7 +224,7 @@ describe('Popover', () => {
 
         it('should hide popover programmatically', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -237,7 +237,7 @@ describe('Popover', () => {
 
         it('should toggle popover visibility', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             expect(popoverInstance.overlayVisible).toBe(false);
 
@@ -254,7 +254,7 @@ describe('Popover', () => {
 
         it('should prevent toggle when animation is in progress', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             // First toggle to start animation
             popoverInstance.toggle(mockEvent, target);
@@ -269,7 +269,7 @@ describe('Popover', () => {
 
         it('should handle target change in toggle', async () => {
             const mockEvent = new MouseEvent('click');
-            const target1 = component.targetButton.nativeElement;
+            const target1 = component.targetButton().nativeElement;
             const target2 = document.createElement('button');
 
             popoverInstance.show(mockEvent, target1);
@@ -292,13 +292,13 @@ describe('Popover', () => {
             fixture = TestBed.createComponent(TestBasicPopoverComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            popoverInstance = component.popover;
+            popoverInstance = component.popover();
         });
 
         it('should emit onShow event', async () => {
             vi.spyOn(component, 'onShow').mockImplementation(() => {});
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -314,7 +314,7 @@ describe('Popover', () => {
         it('should emit onHide event', async () => {
             vi.spyOn(component, 'onHide').mockImplementation(() => {});
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -340,23 +340,23 @@ describe('Popover', () => {
                 fixture = TestBed.createComponent(TestTemplatePopoverComponent);
                 component = fixture.componentInstance;
                 fixture.detectChanges();
-                popoverInstance = component.popover;
+                popoverInstance = component.popover();
             });
 
             it('should project content template correctly', async () => {
                 const mockEvent = new MouseEvent('click');
-                const target = component.targetButton.nativeElement;
+                const target = component.targetButton().nativeElement;
 
                 popoverInstance.show(mockEvent, target);
                 await new Promise((resolve) => setTimeout(resolve, 100));
                 await fixture.whenStable();
 
-                expect(popoverInstance.contentTemplate).toBeTruthy();
+                expect(popoverInstance.contentTemplate()).toBeTruthy();
             });
 
             it('should provide closeCallback context to template', async () => {
                 const mockEvent = new MouseEvent('click');
-                const target = component.targetButton.nativeElement;
+                const target = component.targetButton().nativeElement;
 
                 popoverInstance.show(mockEvent, target);
                 await new Promise((resolve) => setTimeout(resolve, 100));
@@ -391,7 +391,7 @@ describe('Popover', () => {
                 fixture = TestBed.createComponent(TestPTemplatePopoverComponent);
                 component = fixture.componentInstance;
                 fixture.detectChanges();
-                popoverInstance = component.popover;
+                popoverInstance = component.popover();
             });
 
             it('should process pTemplate content in ngAfterContentInit', () => {
@@ -401,7 +401,7 @@ describe('Popover', () => {
 
             it('should render pTemplate content correctly', async () => {
                 const mockEvent = new MouseEvent('click');
-                const target = component.targetButton.nativeElement;
+                const target = component.targetButton().nativeElement;
 
                 popoverInstance.show(mockEvent, target);
                 await new Promise((resolve) => setTimeout(resolve, 100));
@@ -427,12 +427,12 @@ describe('Popover', () => {
             fixture = TestBed.createComponent(TestKeyboardNavigationComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            popoverInstance = component.popover;
+            popoverInstance = component.popover();
         });
 
         it('should have correct ARIA attributes', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.ariaLabel = 'Test popover';
             popoverInstance.ariaLabelledBy = 'test-label';
@@ -459,7 +459,7 @@ describe('Popover', () => {
 
         it('should focus autofocus element when focusOnShow is true', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -482,7 +482,7 @@ describe('Popover', () => {
 
         it('should hide popover on Escape key', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -504,7 +504,7 @@ describe('Popover', () => {
             fixture = TestBed.createComponent(TestBasicPopoverComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            popoverInstance = component.popover;
+            popoverInstance = component.popover();
         });
 
         it('should apply styleClass correctly', async () => {
@@ -513,7 +513,7 @@ describe('Popover', () => {
             await fixture.whenStable();
 
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -536,7 +536,7 @@ describe('Popover', () => {
             expect(popoverInstance.style).toEqual({ border: '2px solid red', padding: '10px' });
 
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -573,12 +573,12 @@ describe('Popover', () => {
             fixture = TestBed.createComponent(TestBasicPopoverComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            popoverInstance = component.popover;
+            popoverInstance = component.popover();
         });
 
         it('should handle rapid toggle clicks during animation', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             // First click
             popoverInstance.toggle(mockEvent, target);
@@ -607,7 +607,7 @@ describe('Popover', () => {
 
         it('should handle animation states correctly', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -649,12 +649,12 @@ describe('Popover', () => {
             fixture = TestBed.createComponent(TestBasicPopoverComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            popoverInstance = component.popover;
+            popoverInstance = component.popover();
         });
 
         it('should bind document click listener when shown', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             // Since animation event is commented out, bindDocumentClickListener won't be called
             // Test that show method at least sets the overlay visible
@@ -680,7 +680,7 @@ describe('Popover', () => {
 
         it('should hide on window resize for non-touch devices', async () => {
             const mockEvent = new MouseEvent('click');
-            const target = component.targetButton.nativeElement;
+            const target = component.targetButton().nativeElement;
 
             popoverInstance.show(mockEvent, target);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -744,7 +744,7 @@ describe('Popover', () => {
             fixture = TestBed.createComponent(TestBasicPopoverComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            popoverInstance = component.popover;
+            popoverInstance = component.popover();
         });
 
         it('should cleanup resources on destroy', () => {

--- a/packages/optimus-ui/src/popover/popover.test.ts
+++ b/packages/optimus-ui/src/popover/popover.test.ts
@@ -7,6 +7,7 @@ import type { Mock } from 'vitest';
 import { OverlayService, PrimeTemplate } from '@openng/optimus-ui/api';
 import { Popover } from './popover';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 // function createMockAnimationEvent(toState: string, fromState: string = 'void'): AnimationEvent {
 //     return {
 //         element: document.createElement('div'),
@@ -775,5 +776,41 @@ describe('Popover', () => {
             expect(popoverInstance.onContainerDestroy).toHaveBeenCalled();
             expect(mockSubscription.unsubscribe).toHaveBeenCalled();
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Popover, PrimeTemplate],
+    template: `
+        <p-popover>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-popover>
+    `
+})
+class PopoverQueryApiHostComponent {}
+
+describe('Popover Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [PopoverQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(PopoverQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Popover)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/popover/popover.ts
+++ b/packages/optimus-ui/src/popover/popover.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     HostListener,
@@ -17,10 +15,11 @@ import {
     NgZone,
     numberAttribute,
     Output,
-    QueryList,
     TemplateRef,
     ViewEncapsulation,
-    ViewRef
+    ViewRef,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { $dt } from '@openng/optimus-ui-styled';
@@ -69,7 +68,7 @@ const POPOVER_INSTANCE = new InjectionToken<Popover>('POPOVER_INSTANCE');
             >
                 <div [pBind]="ptm('content')" [class]="cx('content')" (click)="onContentClick($event)" (mousedown)="onContentClick($event)">
                     <ng-content></ng-content>
-                    <ng-template *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { closeCallback: onCloseClick.bind(this) }"></ng-template>
+                    <ng-template *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { closeCallback: onCloseClick.bind(this) }"></ng-template>
                 </div>
             </div>
         }
@@ -200,9 +199,9 @@ export class Popover extends BaseComponent<PopoverPassThrough> {
      * @see {@link PopoverContentTemplateContext}
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: Nullable<TemplateRef<PopoverContentTemplateContext>>;
+    readonly contentTemplate = contentChild<Nullable<TemplateRef<PopoverContentTemplateContext>>>('content', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _contentTemplate: TemplateRef<PopoverContentTemplateContext> | undefined;
 
@@ -219,7 +218,7 @@ export class Popover extends BaseComponent<PopoverPassThrough> {
     overlayService = inject(OverlayService);
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/progressbar/progressbar.ts
+++ b/packages/optimus-ui/src/progressbar/progressbar.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ContentChild, ContentChildren, inject, InjectionToken, Input, NgModule, numberAttribute, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, numberAttribute, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
@@ -20,10 +20,10 @@ const PROGRESSBAR_INSTANCE = new InjectionToken<ProgressBar>('PROGRESSBAR_INSTAN
         @if (mode === 'determinate') {
             <div [class]="cn(cx('value'), valueStyleClass)" [pBind]="ptm('value')" [style.width]="value + '%'" [style.display]="'flex'" [style.background]="color" [attr.data-p]="dataP">
                 <div [class]="cx('label')" [pBind]="ptm('label')" [attr.data-p]="dataP">
-                    @if (showValue && !contentTemplate && !_contentTemplate) {
+                    @if (showValue && !contentTemplate() && !_contentTemplate) {
                         <div [style.display]="value != null && value !== 0 ? 'flex' : 'none'">{{ value }}{{ unit }}</div>
                     }
-                    <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: value }"></ng-container>
+                    <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { $implicit: value }"></ng-container>
                 </div>
             </div>
         }
@@ -95,7 +95,7 @@ export class ProgressBar extends BaseComponent<ProgressBarPassThrough> {
      * @see {@link ProgressBarContentTemplateContext}
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<ProgressBarContentTemplateContext> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<ProgressBarContentTemplateContext>>('content', { descendants: false });
 
     onAfterViewChecked(): void {
         this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
@@ -103,12 +103,12 @@ export class ProgressBar extends BaseComponent<ProgressBarPassThrough> {
 
     _componentStyle = inject(ProgressBarStyle);
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _contentTemplate: TemplateRef<ProgressBarContentTemplateContext> | undefined;
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/radiobutton/radiobutton.test.ts
+++ b/packages/optimus-ui/src/radiobutton/radiobutton.test.ts
@@ -236,11 +236,11 @@ describe('RadioButton', () => {
         });
 
         it('should programmatically focus', () => {
-            vi.spyOn(radioInstance.inputViewChild.nativeElement, 'focus').mockImplementation(() => {});
+            vi.spyOn(radioInstance.inputViewChild().nativeElement, 'focus').mockImplementation(() => {});
 
             radioInstance.focus();
 
-            expect(radioInstance.inputViewChild.nativeElement.focus).toHaveBeenCalled();
+            expect(radioInstance.inputViewChild().nativeElement.focus).toHaveBeenCalled();
         });
 
         it('should update checked state when model value changes', async () => {

--- a/packages/optimus-ui/src/radiobutton/radiobutton.ts
+++ b/packages/optimus-ui/src/radiobutton/radiobutton.ts
@@ -17,7 +17,7 @@ import {
     OnDestroy,
     OnInit,
     Output,
-    ViewChild
+    viewChild
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, NgControl } from '@angular/forms';
 import { SharedModule } from '@openng/optimus-ui/api';
@@ -197,7 +197,7 @@ export class RadioButton extends BaseEditableHolder<RadioButtonPassThrough> {
      */
     @Output() onBlur: EventEmitter<Event> = new EventEmitter<Event>();
 
-    @ViewChild('input') inputViewChild!: ElementRef;
+    readonly inputViewChild = viewChild.required<ElementRef>('input');
 
     $variant = computed(() => this.variant() || this.config.inputStyle() || this.config.inputVariant());
 
@@ -250,7 +250,7 @@ export class RadioButton extends BaseEditableHolder<RadioButtonPassThrough> {
      * @group Method
      */
     public focus() {
-        this.inputViewChild.nativeElement.focus();
+        this.inputViewChild().nativeElement.focus();
     }
 
     /**

--- a/packages/optimus-ui/src/rating/rating.test.ts
+++ b/packages/optimus-ui/src/rating/rating.test.ts
@@ -8,6 +8,8 @@ import { Rating } from './rating';
 
 import { provideOptimus } from '@openng/optimus-ui/config';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 // Basic Rating test component
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1485,5 +1487,41 @@ describe('Rating', () => {
                 expect(inputEls.length).toBeGreaterThan(0);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Rating, PrimeTemplate],
+    template: `
+        <p-rating>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-rating>
+    `
+})
+class RatingQueryApiHostComponent {}
+
+describe('Rating Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [RatingQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(RatingQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Rating)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/rating/rating.test.ts
+++ b/packages/optimus-ui/src/rating/rating.test.ts
@@ -884,12 +884,12 @@ describe('Rating', () => {
 
         it('should have onicon pTemplate', () => {
             expect(ratingInstance).toBeTruthy();
-            expect(() => ratingInstance.onIconTemplate).not.toThrow();
+            expect(() => ratingInstance.onIconTemplate()).not.toThrow();
         });
 
         it('should have officon pTemplate', () => {
             expect(ratingInstance).toBeTruthy();
-            expect(() => ratingInstance.offIconTemplate).not.toThrow();
+            expect(() => ratingInstance.offIconTemplate()).not.toThrow();
         });
 
         it('should pass context parameters to onicon template', async () => {
@@ -989,12 +989,12 @@ describe('Rating', () => {
 
         it('should have onicon #template', () => {
             expect(ratingInstance).toBeTruthy();
-            expect(() => ratingInstance.onIconTemplate).not.toThrow();
+            expect(() => ratingInstance.onIconTemplate()).not.toThrow();
         });
 
         it('should have officon #template', () => {
             expect(ratingInstance).toBeTruthy();
-            expect(() => ratingInstance.offIconTemplate).not.toThrow();
+            expect(() => ratingInstance.offIconTemplate()).not.toThrow();
         });
 
         it('should pass context parameters to onicon template', async () => {

--- a/packages/optimus-ui/src/rating/rating.ts
+++ b/packages/optimus-ui/src/rating/rating.ts
@@ -1,23 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-    booleanAttribute,
-    ChangeDetectionStrategy,
-    Component,
-    ContentChild,
-    ContentChildren,
-    EventEmitter,
-    forwardRef,
-    inject,
-    InjectionToken,
-    Input,
-    NgModule,
-    numberAttribute,
-    Output,
-    QueryList,
-    signal,
-    TemplateRef,
-    ViewEncapsulation
-} from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, EventEmitter, forwardRef, inject, InjectionToken, Input, NgModule, numberAttribute, Output, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { focus, getFirstFocusableElement, uuid } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
@@ -69,8 +51,8 @@ export const RATING_VALUE_ACCESSOR: any = {
                     />
                 </span>
                 @if (star + 1 <= value) {
-                    @if (onIconTemplate || _onIconTemplate) {
-                        <ng-container *ngTemplateOutlet="onIconTemplate || _onIconTemplate; context: { $implicit: star + 1, class: cx('onIcon') }"></ng-container>
+                    @if (onIconTemplate() || _onIconTemplate) {
+                        <ng-container *ngTemplateOutlet="onIconTemplate() || _onIconTemplate; context: { $implicit: star + 1, class: cx('onIcon') }"></ng-container>
                     } @else {
                         @if (iconOnClass) {
                             <span [class]="cx('onIcon')" [ngStyle]="iconOnStyle" [ngClass]="iconOnClass" [pBind]="ptm('onIcon')"></span>
@@ -80,8 +62,8 @@ export const RATING_VALUE_ACCESSOR: any = {
                         }
                     }
                 } @else {
-                    @if (offIconTemplate || _offIconTemplate) {
-                        <ng-container *ngTemplateOutlet="offIconTemplate || _offIconTemplate; context: { $implicit: star + 1, class: cx('offIcon') }"></ng-container>
+                    @if (offIconTemplate() || _offIconTemplate) {
+                        <ng-container *ngTemplateOutlet="offIconTemplate() || _offIconTemplate; context: { $implicit: star + 1, class: cx('offIcon') }"></ng-container>
                     } @else {
                         @if (iconOffClass) {
                             <span [class]="cx('offIcon')" [ngStyle]="iconOffStyle" [ngClass]="iconOffClass" [pBind]="ptm('offIcon')"></span>
@@ -173,16 +155,16 @@ export class Rating extends BaseEditableHolder<RatingPassThrough> {
      * @see {@link RatingIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('onicon', { descendants: false }) onIconTemplate: Nullable<TemplateRef<RatingIconTemplateContext>>;
+    readonly onIconTemplate = contentChild<Nullable<TemplateRef<RatingIconTemplateContext>>>('onicon', { descendants: false });
     /**
      * Custom off icon template.
      * @param {RatingIconTemplateContext} context - icon context.
      * @see {@link RatingIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('officon', { descendants: false }) offIconTemplate: Nullable<TemplateRef<RatingIconTemplateContext>>;
+    readonly offIconTemplate = contentChild<Nullable<TemplateRef<RatingIconTemplateContext>>>('officon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     value: Nullable<number>;
 
@@ -209,7 +191,7 @@ export class Rating extends BaseEditableHolder<RatingPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'onicon':
                     this._onIconTemplate = item.template;
@@ -279,7 +261,7 @@ export class Rating extends BaseEditableHolder<RatingPassThrough> {
     }
 
     getIconTemplate(i: number): Nullable<TemplateRef<RatingIconTemplateContext>> {
-        return !this.value || i >= this.value ? this.offIconTemplate || this._offIconTemplate : this.onIconTemplate || this.offIconTemplate;
+        return !this.value || i >= this.value ? this.offIconTemplate() || this._offIconTemplate : this.onIconTemplate() || this.offIconTemplate();
     }
 
     /**
@@ -294,7 +276,7 @@ export class Rating extends BaseEditableHolder<RatingPassThrough> {
     }
 
     get isCustomIcon(): boolean {
-        return !!(this.onIconTemplate || this._onIconTemplate || this.offIconTemplate || this._offIconTemplate);
+        return !!(this.onIconTemplate() || this._onIconTemplate || this.offIconTemplate() || this._offIconTemplate);
     }
 
     get dataP() {

--- a/packages/optimus-ui/src/scroller/scroller.test.ts
+++ b/packages/optimus-ui/src/scroller/scroller.test.ts
@@ -775,7 +775,7 @@ describe('Scroller', () => {
         it('should get element reference', async () => {
             const elementRef = scroller.getElementRef();
             expect(elementRef).toBeDefined();
-            expect(elementRef).toBe(scroller.elementViewChild);
+            expect(elementRef).toBe(scroller.elementViewChild());
         });
 
         it('should calculate page by first index', async () => {
@@ -802,7 +802,7 @@ describe('Scroller', () => {
         });
 
         it('should scroll to specified options', async () => {
-            const scrollToSpy = vi.spyOn(scroller.elementViewChild?.nativeElement, 'scrollTo').mockImplementation(() => {});
+            const scrollToSpy = vi.spyOn(scroller.elementViewChild()?.nativeElement, 'scrollTo').mockImplementation(() => {});
             const scrollOptions: ScrollToOptions = { left: 100, top: 200, behavior: 'smooth' };
 
             scroller.scrollTo(scrollOptions);
@@ -1415,11 +1415,12 @@ describe('Scroller', () => {
             });
 
             // Mock element dimensions
-            Object.defineProperty(scroller.elementViewChild?.nativeElement, 'offsetHeight', {
+            const elementViewChild = scroller.elementViewChild();
+            Object.defineProperty(elementViewChild?.nativeElement, 'offsetHeight', {
                 value: 200,
                 writable: true
             });
-            Object.defineProperty(scroller.elementViewChild?.nativeElement, 'offsetWidth', {
+            Object.defineProperty(elementViewChild?.nativeElement, 'offsetWidth', {
                 value: 300,
                 writable: true
             });

--- a/packages/optimus-ui/src/scroller/scroller.test.ts
+++ b/packages/optimus-ui/src/scroller/scroller.test.ts
@@ -1761,7 +1761,7 @@ describe('Scroller', () => {
         });
 
         it('should handle resize without element', async () => {
-            scroller.elementViewChild = null as any;
+            (scroller as any).elementViewChild = () => null as any;
             expect(() => scroller.onWindowResize()).not.toThrow();
         });
 

--- a/packages/optimus-ui/src/scroller/scroller.ts
+++ b/packages/optimus-ui/src/scroller/scroller.ts
@@ -11,7 +11,6 @@ import {
     NgModule,
     NgZone,
     Output,
-    QueryList,
     SimpleChanges,
     TemplateRef,
     ViewEncapsulation,
@@ -629,7 +628,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
     }
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/scroller/scroller.ts
+++ b/packages/optimus-ui/src/scroller/scroller.ts
@@ -2,8 +2,6 @@ import { CommonModule, isPlatformBrowser } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     HostBinding,
@@ -16,8 +14,10 @@ import {
     QueryList,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { findSingle, getHeight, getWidth, isTouchDevice, isVisible } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, ScrollerOptions, SharedModule } from '@openng/optimus-ui/api';
@@ -51,12 +51,12 @@ const SCROLLER_INSTANCE = new InjectionToken<Scroller>('SCROLLER_INSTANCE');
     template: `
         @if (!_disabled) {
             <div #element [attr.id]="_id" [attr.tabindex]="tabindex" [ngStyle]="_style" [class]="cn(cx('root'), styleClass)" (scroll)="onContainerScroll($event)" [pBind]="ptm('root')">
-                @if (contentTemplate || _contentTemplate) {
-                    <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: loadedItems, options: getContentOptions() }"></ng-container>
+                @if (contentTemplate() || _contentTemplate) {
+                    <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { $implicit: loadedItems, options: getContentOptions() }"></ng-container>
                 } @else {
                     <div #content [class]="cn(cx('content'), contentStyleClass)" [style]="contentStyle" [pBind]="ptm('content')">
                         @for (item of loadedItems; track _trackBy ? _trackBy($index, item) : item; let index = $index) {
-                            <ng-container *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: item, options: getOptions(index) }"></ng-container>
+                            <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: item, options: getOptions(index) }"></ng-container>
                         }
                     </div>
                 }
@@ -65,11 +65,11 @@ const SCROLLER_INSTANCE = new InjectionToken<Scroller>('SCROLLER_INSTANCE');
                 }
                 @if (!loaderDisabled && _showLoader && d_loading) {
                     <div [class]="cx('loader')" [pBind]="ptm('loader')">
-                        @if (loaderTemplate || _loaderTemplate) {
+                        @if (loaderTemplate() || _loaderTemplate) {
                             @for (item of loaderArr; track item; let index = $index) {
                                 <ng-container
                                     *ngTemplateOutlet="
-                                        loaderTemplate || _loaderTemplate;
+                                        loaderTemplate() || _loaderTemplate;
                                         context: {
                                             options: getLoaderOptions(index, both && { numCols: numItemsInViewport.cols })
                                         }
@@ -77,8 +77,8 @@ const SCROLLER_INSTANCE = new InjectionToken<Scroller>('SCROLLER_INSTANCE');
                                 ></ng-container>
                             }
                         } @else {
-                            @if (loaderIconTemplate || _loaderIconTemplate) {
-                                <ng-container *ngTemplateOutlet="loaderIconTemplate || _loaderIconTemplate; context: { options: { styleClass: 'p-virtualscroller-loading-icon' } }"></ng-container>
+                            @if (loaderIconTemplate() || _loaderIconTemplate) {
+                                <ng-container *ngTemplateOutlet="loaderIconTemplate() || _loaderIconTemplate; context: { options: { styleClass: 'p-virtualscroller-loading-icon' } }"></ng-container>
                             } @else {
                                 <svg data-p-icon="spinner" [class]="cx('loadingIcon')" [spin]="true" [pBind]="ptm('loadingIcon')" />
                             }
@@ -88,8 +88,8 @@ const SCROLLER_INSTANCE = new InjectionToken<Scroller>('SCROLLER_INSTANCE');
             </div>
         } @else {
             <ng-content></ng-content>
-            @if (contentTemplate || _contentTemplate) {
-                <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: items, options: { rows: _items, columns: loadedColumns } }"></ng-container>
+            @if (contentTemplate() || _contentTemplate) {
+                <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { $implicit: items, options: { rows: _items, columns: loadedColumns } }"></ng-container>
             }
         }
     `,
@@ -382,9 +382,9 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
      */
     @Output() onScrollIndexChange: EventEmitter<ScrollerScrollIndexChangeEvent> = new EventEmitter<ScrollerScrollIndexChangeEvent>();
 
-    @ViewChild('element') elementViewChild: Nullable<ElementRef>;
+    readonly elementViewChild = viewChild<Nullable<ElementRef>>('element');
 
-    @ViewChild('content') contentViewChild: Nullable<ElementRef>;
+    readonly contentViewChild = viewChild<Nullable<ElementRef>>('content');
 
     @HostBinding('style.height') height: string;
 
@@ -449,7 +449,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
      * @see {@link ScrollerContentTemplateContext}
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: Nullable<TemplateRef<ScrollerContentTemplateContext>>;
+    readonly contentTemplate = contentChild<Nullable<TemplateRef<ScrollerContentTemplateContext>>>('content', { descendants: false });
 
     /**
      * Item template of the component.
@@ -457,7 +457,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
      * @see {@link ScrollerItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: Nullable<TemplateRef<ScrollerItemTemplateContext>>;
+    readonly itemTemplate = contentChild<Nullable<TemplateRef<ScrollerItemTemplateContext>>>('item', { descendants: false });
 
     /**
      * Loader template of the component.
@@ -465,7 +465,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
      * @see {@link ScrollerLoaderTemplateContext}
      * @group Templates
      */
-    @ContentChild('loader', { descendants: false }) loaderTemplate: Nullable<TemplateRef<ScrollerLoaderTemplateContext>>;
+    readonly loaderTemplate = contentChild<Nullable<TemplateRef<ScrollerLoaderTemplateContext>>>('loader', { descendants: false });
 
     /**
      * Loader icon template of the component.
@@ -473,9 +473,9 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
      * @see {@link ScrollerLoaderIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('loadericon', { descendants: false }) loaderIconTemplate: Nullable<TemplateRef<ScrollerLoaderIconTemplateContext>>;
+    readonly loaderIconTemplate = contentChild<Nullable<TemplateRef<ScrollerLoaderIconTemplateContext>>>('loadericon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _contentTemplate: TemplateRef<ScrollerContentTemplateContext> | undefined;
 
@@ -629,7 +629,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
     }
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;
@@ -676,13 +676,14 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
 
     viewInit() {
         if (isPlatformBrowser(this.platformId) && !this.initialized) {
-            if (isVisible(this.elementViewChild?.nativeElement)) {
+            const elementViewChild = this.elementViewChild();
+            if (isVisible(elementViewChild?.nativeElement)) {
                 this.setInitialState();
                 this.setContentEl(this.contentEl);
                 this.init();
 
-                this.defaultWidth = getWidth(this.elementViewChild?.nativeElement);
-                this.defaultHeight = getHeight(this.elementViewChild?.nativeElement);
+                this.defaultWidth = getWidth(elementViewChild?.nativeElement);
+                this.defaultHeight = getHeight(elementViewChild?.nativeElement);
                 this.defaultContentWidth = getWidth(this.contentEl);
                 this.defaultContentHeight = getHeight(this.contentEl);
                 this.initialized = true;
@@ -706,7 +707,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
     }
 
     setContentEl(el?: HTMLElement) {
-        this.contentEl = el || this.contentViewChild?.nativeElement || findSingle(this.elementViewChild?.nativeElement, '.p-virtualscroller-content');
+        this.contentEl = el || this.contentViewChild()?.nativeElement || findSingle(this.elementViewChild()?.nativeElement, '.p-virtualscroller-content');
     }
     setInitialState() {
         this.first = this.both ? { rows: 0, cols: 0 } : 0;
@@ -721,7 +722,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
     }
 
     getElementRef() {
-        return this.elementViewChild;
+        return this.elementViewChild();
     }
 
     getPageByFirst(first?: any) {
@@ -734,7 +735,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
 
     scrollTo(options: ScrollToOptions) {
         // this.lastScrollPos = this.both ? { top: 0, left: 0 } : 0;
-        this.elementViewChild?.nativeElement?.scrollTo(options);
+        this.elementViewChild()?.nativeElement?.scrollTo(options);
     }
 
     scrollToIndex(index: number | number[], behavior: ScrollBehavior = 'auto') {
@@ -742,7 +743,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
 
         if (valid) {
             const first = this.first;
-            const { scrollTop = 0, scrollLeft = 0 } = this.elementViewChild?.nativeElement;
+            const { scrollTop = 0, scrollLeft = 0 } = this.elementViewChild()?.nativeElement;
             const { numToleratedItems } = this.calculateNumItems();
             const contentPos = this.getContentPosition();
             const itemSize = this.itemSize;
@@ -818,8 +819,9 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
         let firstInViewport = this.first;
         let lastInViewport: any = 0;
 
-        if (this.elementViewChild?.nativeElement) {
-            const { scrollTop, scrollLeft } = this.elementViewChild.nativeElement;
+        const elementViewChild = this.elementViewChild();
+        if (elementViewChild?.nativeElement) {
+            const { scrollTop, scrollLeft } = elementViewChild.nativeElement;
 
             if (this.both) {
                 firstInViewport = {
@@ -849,8 +851,10 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
 
     calculateNumItems() {
         const contentPos = this.getContentPosition();
-        const contentWidth = (this.elementViewChild?.nativeElement ? this.elementViewChild.nativeElement.offsetWidth - contentPos.left : 0) || 0;
-        const contentHeight = (this.elementViewChild?.nativeElement ? this.elementViewChild.nativeElement.offsetHeight - contentPos.top : 0) || 0;
+        const elementViewChild = this.elementViewChild();
+        const contentWidth = (elementViewChild?.nativeElement ? elementViewChild.nativeElement.offsetWidth - contentPos.left : 0) || 0;
+        const elementViewChildValue = this.elementViewChild();
+        const contentHeight = (elementViewChildValue?.nativeElement ? elementViewChildValue.nativeElement.offsetHeight - contentPos.top : 0) || 0;
         const calculateNumItemsInViewport = (_contentSize: number, _itemSize: number) => (_itemSize || _contentSize ? Math.ceil(_contentSize / (_itemSize || _contentSize)) : 0);
         const calculateNumToleratedItems = (_numItems: number) => Math.ceil(_numItems / 2);
         const numItemsInViewport: any = this.both
@@ -902,19 +906,19 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
                 if (this.contentEl) {
                     this.contentEl.style.minHeight = this.contentEl.style.minWidth = 'auto';
                     this.contentEl.style.position = 'relative';
-                    (<ElementRef>this.elementViewChild).nativeElement.style.contain = 'none';
+                    (<ElementRef>this.elementViewChild()).nativeElement.style.contain = 'none';
 
                     const [contentWidth, contentHeight] = [getWidth(this.contentEl), getHeight(this.contentEl)];
-                    contentWidth !== this.defaultContentWidth && ((<ElementRef>this.elementViewChild).nativeElement.style.width = '');
-                    contentHeight !== this.defaultContentHeight && ((<ElementRef>this.elementViewChild).nativeElement.style.height = '');
+                    contentWidth !== this.defaultContentWidth && ((<ElementRef>this.elementViewChild()).nativeElement.style.width = '');
+                    contentHeight !== this.defaultContentHeight && ((<ElementRef>this.elementViewChild()).nativeElement.style.height = '');
 
-                    const [width, height] = [getWidth((<ElementRef>this.elementViewChild).nativeElement), getHeight((<ElementRef>this.elementViewChild).nativeElement)];
-                    (this.both || this.horizontal) && ((<ElementRef>this.elementViewChild).nativeElement.style.width = width < <number>this.defaultWidth ? width + 'px' : this._scrollWidth || this.defaultWidth + 'px');
-                    (this.both || this.vertical) && ((<ElementRef>this.elementViewChild).nativeElement.style.height = height < <number>this.defaultHeight ? height + 'px' : this._scrollHeight || this.defaultHeight + 'px');
+                    const [width, height] = [getWidth((<ElementRef>this.elementViewChild()).nativeElement), getHeight((<ElementRef>this.elementViewChild()).nativeElement)];
+                    (this.both || this.horizontal) && ((<ElementRef>this.elementViewChild()).nativeElement.style.width = width < <number>this.defaultWidth ? width + 'px' : this._scrollWidth || this.defaultWidth + 'px');
+                    (this.both || this.vertical) && ((<ElementRef>this.elementViewChild()).nativeElement.style.height = height < <number>this.defaultHeight ? height + 'px' : this._scrollHeight || this.defaultHeight + 'px');
 
                     this.contentEl.style.minHeight = this.contentEl.style.minWidth = '';
                     this.contentEl.style.position = '';
-                    (<ElementRef>this.elementViewChild).nativeElement.style.contain = '';
+                    (<ElementRef>this.elementViewChild()).nativeElement.style.contain = '';
                 }
             });
         }
@@ -939,8 +943,9 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
     }
 
     setSize() {
-        if (this.elementViewChild?.nativeElement) {
-            const nativeElement = this.elementViewChild.nativeElement;
+        const elementViewChild = this.elementViewChild();
+        if (elementViewChild?.nativeElement) {
+            const nativeElement = elementViewChild.nativeElement;
             const parentElement = nativeElement.parentElement?.parentElement;
 
             const elementWidth = nativeElement.offsetWidth;
@@ -1169,8 +1174,9 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
         }
 
         this.resizeTimeout = setTimeout(() => {
-            if (isVisible(this.elementViewChild?.nativeElement)) {
-                const [width, height] = [getWidth(this.elementViewChild?.nativeElement), getHeight(this.elementViewChild?.nativeElement)];
+            const elementViewChild = this.elementViewChild();
+            if (isVisible(elementViewChild?.nativeElement)) {
+                const [width, height] = [getWidth(elementViewChild?.nativeElement), getHeight(elementViewChild?.nativeElement)];
                 const [isDiffWidth, isDiffHeight] = [width !== this.defaultWidth, height !== this.defaultHeight];
                 const reinit = this.both ? isDiffWidth || isDiffHeight : this.horizontal ? isDiffWidth : this.vertical ? isDiffHeight : false;
 
@@ -1211,7 +1217,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
             scrollTo: this.scrollTo.bind(this),
             scrollToIndex: this.scrollToIndex.bind(this),
             orientation: this._orientation,
-            scrollableElement: this.elementViewChild?.nativeElement
+            scrollableElement: this.elementViewChild()?.nativeElement
         };
     }
 

--- a/packages/optimus-ui/src/scrollpanel/scrollpanel.test.ts
+++ b/packages/optimus-ui/src/scrollpanel/scrollpanel.test.ts
@@ -294,9 +294,10 @@ describe('ScrollPanel', () => {
 
         it('should programmatically scroll to top position', async () => {
             // Mock scrollTop behavior since test environment doesn't scroll
-            if (scrollPanel.contentViewChild) {
-                Object.defineProperty(scrollPanel.contentViewChild.nativeElement, 'scrollHeight', { value: 600, writable: true });
-                Object.defineProperty(scrollPanel.contentViewChild.nativeElement, 'clientHeight', { value: 200, writable: true });
+            const contentViewChild = scrollPanel.contentViewChild();
+            if (contentViewChild) {
+                Object.defineProperty(contentViewChild.nativeElement, 'scrollHeight', { value: 600, writable: true });
+                Object.defineProperty(contentViewChild.nativeElement, 'clientHeight', { value: 200, writable: true });
             }
 
             scrollPanel.scrollTop(100);
@@ -304,7 +305,7 @@ describe('ScrollPanel', () => {
             await fixture.whenStable();
 
             // Verify the method was called correctly - scroll behavior might not work in test
-            expect(scrollPanel.contentViewChild).toBeTruthy();
+            expect(contentViewChild).toBeTruthy();
         });
 
         it('should constrain scroll position within bounds', async () => {
@@ -312,14 +313,15 @@ describe('ScrollPanel', () => {
             scrollPanel.scrollTop(-50);
             await new Promise((resolve) => setTimeout(resolve, 100));
             await fixture.whenStable();
-            expect(scrollPanel.contentViewChild?.nativeElement.scrollTop).toBe(0);
+            const contentViewChild = scrollPanel.contentViewChild();
+            expect(contentViewChild?.nativeElement.scrollTop).toBe(0);
 
             // Test excessive scroll position (should be limited to max scrollable height)
             scrollPanel.scrollTop(99999);
             await new Promise((resolve) => setTimeout(resolve, 100));
             await fixture.whenStable();
-            const maxScrollTop = scrollPanel.contentViewChild!.nativeElement.scrollHeight - scrollPanel.contentViewChild!.nativeElement.clientHeight;
-            expect(scrollPanel.contentViewChild!.nativeElement.scrollTop).toBe(maxScrollTop);
+            const maxScrollTop = contentViewChild!.nativeElement.scrollHeight - contentViewChild!.nativeElement.clientHeight;
+            expect(contentViewChild!.nativeElement.scrollTop).toBe(maxScrollTop);
         });
     });
 
@@ -712,9 +714,9 @@ describe('ScrollPanel', () => {
 
         it('should handle missing ViewChild elements gracefully', () => {
             // Test that ViewChild elements exist after component initialization
-            expect(scrollPanel.contentViewChild).toBeTruthy();
-            expect(scrollPanel.xBarViewChild).toBeTruthy();
-            expect(scrollPanel.yBarViewChild).toBeTruthy();
+            expect(scrollPanel.contentViewChild()).toBeTruthy();
+            expect(scrollPanel.xBarViewChild()).toBeTruthy();
+            expect(scrollPanel.yBarViewChild()).toBeTruthy();
 
             // moveBar should work with valid ViewChild elements
             expect(() => scrollPanel.moveBar()).not.toThrow();
@@ -834,11 +836,12 @@ describe('ScrollPanel', () => {
 
         it('should handle zero dimensions gracefully', async () => {
             // Mock content with zero dimensions
-            if (scrollPanel.contentViewChild) {
-                Object.defineProperty(scrollPanel.contentViewChild.nativeElement, 'scrollWidth', { value: 0, writable: true });
-                Object.defineProperty(scrollPanel.contentViewChild.nativeElement, 'scrollHeight', { value: 0, writable: true });
-                Object.defineProperty(scrollPanel.contentViewChild.nativeElement, 'clientWidth', { value: 0, writable: true });
-                Object.defineProperty(scrollPanel.contentViewChild.nativeElement, 'clientHeight', { value: 0, writable: true });
+            const contentViewChild = scrollPanel.contentViewChild();
+            if (contentViewChild) {
+                Object.defineProperty(contentViewChild.nativeElement, 'scrollWidth', { value: 0, writable: true });
+                Object.defineProperty(contentViewChild.nativeElement, 'scrollHeight', { value: 0, writable: true });
+                Object.defineProperty(contentViewChild.nativeElement, 'clientWidth', { value: 0, writable: true });
+                Object.defineProperty(contentViewChild.nativeElement, 'clientHeight', { value: 0, writable: true });
             }
 
             await expect(async () => {

--- a/packages/optimus-ui/src/scrollpanel/scrollpanel.ts
+++ b/packages/optimus-ui/src/scrollpanel/scrollpanel.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ElementRef, inject, InjectionToken, Input, NgModule, NgZone, numberAttribute, QueryList, TemplateRef, ViewEncapsulation, viewChild, contentChild, contentChildren } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, InjectionToken, Input, NgModule, NgZone, numberAttribute, TemplateRef, ViewEncapsulation, viewChild, contentChild, contentChildren } from '@angular/core';
 import { addClass, getHeight, removeClass, uuid } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -175,7 +175,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
     }
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;
@@ -324,6 +324,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
     }
 
     repeat(bar, step) {
+        const contentViewChild = this.contentViewChild();
         contentViewChild?.nativeElement && (contentViewChild.nativeElement[bar] += step);
         this.moveBar();
     }
@@ -371,6 +372,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
 
     onYBarMouseDown(e: MouseEvent) {
         this.isYBarClicked = true;
+        const yBarViewChild = this.yBarViewChild();
         yBarViewChild?.nativeElement?.focus();
         this.lastPageY = e.pageY;
 
@@ -385,6 +387,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
 
     onXBarMouseDown(e: MouseEvent) {
         this.isXBarClicked = true;
+        const xBarViewChild = this.xBarViewChild();
         xBarViewChild?.nativeElement?.focus();
         this.lastPageX = e.pageX;
 
@@ -452,8 +455,10 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
     }
 
     onDocumentMouseUp(e: Event) {
+        const yBarViewChild = this.yBarViewChild();
         yBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
         !this.$unstyled() && removeClass((yBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
+        const xBarViewChild = this.xBarViewChild();
         xBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
         !this.$unstyled() && removeClass((xBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
         this.document.body.setAttribute('data-p-scrollpanel-grabbed', 'false');

--- a/packages/optimus-ui/src/scrollpanel/scrollpanel.ts
+++ b/packages/optimus-ui/src/scrollpanel/scrollpanel.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ContentChild, ContentChildren, ElementRef, inject, InjectionToken, Input, NgModule, NgZone, numberAttribute, QueryList, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, InjectionToken, Input, NgModule, NgZone, numberAttribute, QueryList, TemplateRef, ViewEncapsulation, viewChild, contentChild, contentChildren } from '@angular/core';
 import { addClass, getHeight, removeClass, uuid } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -21,10 +21,10 @@ const SCROLLPANEL_INSTANCE = new InjectionToken<ScrollPanel>('SCROLLPANEL_INSTAN
     template: `
         <div [pBind]="ptm('contentContainer')" [class]="cx('contentContainer')">
             <div #content [pBind]="ptm('content')" [class]="cx('content')" (mouseenter)="moveBar()" (scroll)="onScroll($event)">
-                @if (!contentTemplate && !_contentTemplate) {
+                @if (!contentTemplate() && !_contentTemplate) {
                     <ng-content></ng-content>
                 }
-                <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate"></ng-container>
             </div>
         </div>
         <div
@@ -89,18 +89,18 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
      */
     @Input({ transform: numberAttribute }) step: number = 5;
 
-    @ViewChild('content') contentViewChild: ElementRef | undefined;
+    readonly contentViewChild = viewChild<ElementRef>('content');
 
-    @ViewChild('xBar') xBarViewChild: ElementRef | undefined;
+    readonly xBarViewChild = viewChild<ElementRef>('xBar');
 
-    @ViewChild('yBar') yBarViewChild: ElementRef | undefined;
+    readonly yBarViewChild = viewChild<ElementRef>('yBar');
     /**
      * Custom content template.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<void> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<void>>('content', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _contentTemplate: TemplateRef<void> | undefined;
 
@@ -163,10 +163,10 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
                 this.onDocumentMouseUp = this.onDocumentMouseUp.bind(this);
 
                 this.windowResizeListener = this.renderer.listen(window, 'resize', this.moveBar);
-                this.contentScrollListener = this.renderer.listen((this.contentViewChild as ElementRef).nativeElement, 'scroll', this.moveBar);
-                this.mouseEnterListener = this.renderer.listen((this.contentViewChild as ElementRef).nativeElement, 'mouseenter', this.moveBar);
-                this.xBarMouseDownListener = this.renderer.listen((this.xBarViewChild as ElementRef).nativeElement, 'mousedown', this.onXBarMouseDown);
-                this.yBarMouseDownListener = this.renderer.listen((this.yBarViewChild as ElementRef).nativeElement, 'mousedown', this.onYBarMouseDown);
+                this.contentScrollListener = this.renderer.listen((this.contentViewChild() as ElementRef).nativeElement, 'scroll', this.moveBar);
+                this.mouseEnterListener = this.renderer.listen((this.contentViewChild() as ElementRef).nativeElement, 'mouseenter', this.moveBar);
+                this.xBarMouseDownListener = this.renderer.listen((this.xBarViewChild() as ElementRef).nativeElement, 'mousedown', this.onXBarMouseDown);
+                this.yBarMouseDownListener = this.renderer.listen((this.yBarViewChild() as ElementRef).nativeElement, 'mousedown', this.onYBarMouseDown);
                 this.calculateContainerHeight();
 
                 this.initialized = true;
@@ -175,7 +175,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
     }
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;
@@ -190,8 +190,8 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
 
     calculateContainerHeight() {
         let container = (this.el as ElementRef).nativeElement;
-        let content = (this.contentViewChild as ElementRef).nativeElement;
-        let xBar = (this.xBarViewChild as ElementRef).nativeElement;
+        let content = (this.contentViewChild() as ElementRef).nativeElement;
+        let xBar = (this.xBarViewChild() as ElementRef).nativeElement;
         const window = this.document.defaultView as Window;
 
         let containerStyles: { [klass: string]: any } = window.getComputedStyle(container),
@@ -209,10 +209,10 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
 
     moveBar() {
         let container = (this.el as ElementRef).nativeElement;
-        let content = (this.contentViewChild as ElementRef).nativeElement;
+        let content = (this.contentViewChild() as ElementRef).nativeElement;
 
         /* horizontal scroll */
-        let xBar = (this.xBarViewChild as ElementRef).nativeElement;
+        let xBar = (this.xBarViewChild() as ElementRef).nativeElement;
         let totalWidth = content.scrollWidth;
         let ownWidth = content.clientWidth;
         let bottom = (container.clientHeight - xBar.clientHeight) * -1;
@@ -220,7 +220,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
         this.scrollXRatio = ownWidth / totalWidth;
 
         /* vertical scroll */
-        let yBar = (this.yBarViewChild as ElementRef).nativeElement;
+        let yBar = (this.yBarViewChild() as ElementRef).nativeElement;
         let totalHeight = content.scrollHeight;
         let ownHeight = content.clientHeight;
         let right = (container.clientWidth - yBar.clientWidth) * -1;
@@ -324,7 +324,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
     }
 
     repeat(bar, step) {
-        this.contentViewChild?.nativeElement && (this.contentViewChild.nativeElement[bar] += step);
+        contentViewChild?.nativeElement && (contentViewChild.nativeElement[bar] += step);
         this.moveBar();
     }
 
@@ -371,11 +371,11 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
 
     onYBarMouseDown(e: MouseEvent) {
         this.isYBarClicked = true;
-        this.yBarViewChild?.nativeElement?.focus();
+        yBarViewChild?.nativeElement?.focus();
         this.lastPageY = e.pageY;
 
-        this.yBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'true');
-        !this.$unstyled() && addClass((this.yBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
+        yBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'true');
+        !this.$unstyled() && addClass((yBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
 
         this.document.body.setAttribute('data-p-scrollpanel-grabbed', 'true');
         !this.$unstyled() && addClass(this.document.body, 'p-scrollpanel-grabbed');
@@ -385,11 +385,11 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
 
     onXBarMouseDown(e: MouseEvent) {
         this.isXBarClicked = true;
-        this.xBarViewChild?.nativeElement?.focus();
+        xBarViewChild?.nativeElement?.focus();
         this.lastPageX = e.pageX;
 
-        this.xBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
-        !this.$unstyled() && addClass((this.xBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
+        xBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
+        !this.$unstyled() && addClass((xBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
 
         this.document.body.setAttribute('data-p-scrollpanel-grabbed', 'false');
         !this.$unstyled() && addClass(this.document.body, 'p-scrollpanel-grabbed');
@@ -414,7 +414,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
         this.lastPageX = e.pageX;
 
         this.requestAnimationFrame(() => {
-            (this.contentViewChild as ElementRef).nativeElement.scrollLeft += deltaX / (this.scrollXRatio as number);
+            (this.contentViewChild() as ElementRef).nativeElement.scrollLeft += deltaX / (this.scrollXRatio as number);
         });
     }
 
@@ -423,7 +423,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
         this.lastPageY = e.pageY;
 
         this.requestAnimationFrame(() => {
-            (this.contentViewChild as ElementRef).nativeElement.scrollTop += deltaY / (this.scrollYRatio as number);
+            (this.contentViewChild() as ElementRef).nativeElement.scrollTop += deltaY / (this.scrollYRatio as number);
         });
     }
     /**
@@ -432,15 +432,15 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
      * @group Method
      */
     scrollTop(scrollTop: number) {
-        let scrollableHeight = (this.contentViewChild as ElementRef).nativeElement.scrollHeight - (this.contentViewChild as ElementRef).nativeElement.clientHeight;
+        let scrollableHeight = (this.contentViewChild() as ElementRef).nativeElement.scrollHeight - (this.contentViewChild() as ElementRef).nativeElement.clientHeight;
         scrollTop = scrollTop > scrollableHeight ? scrollableHeight : scrollTop > 0 ? scrollTop : 0;
-        (this.contentViewChild as ElementRef).nativeElement.scrollTop = scrollTop;
+        (this.contentViewChild() as ElementRef).nativeElement.scrollTop = scrollTop;
     }
 
     onFocus(event) {
-        if (this.xBarViewChild?.nativeElement?.isSameNode(event.target)) {
+        if (this.xBarViewChild()?.nativeElement?.isSameNode(event.target)) {
             this.orientation = 'horizontal';
-        } else if (this.yBarViewChild?.nativeElement?.isSameNode(event.target)) {
+        } else if (this.yBarViewChild()?.nativeElement?.isSameNode(event.target)) {
             this.orientation = 'vertical';
         }
     }
@@ -452,10 +452,10 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
     }
 
     onDocumentMouseUp(e: Event) {
-        this.yBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
-        !this.$unstyled() && removeClass((this.yBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
-        this.xBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
-        !this.$unstyled() && removeClass((this.xBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
+        yBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
+        !this.$unstyled() && removeClass((yBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
+        xBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
+        !this.$unstyled() && removeClass((xBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
         this.document.body.setAttribute('data-p-scrollpanel-grabbed', 'false');
         !this.$unstyled() && removeClass(this.document.body, 'p-scrollpanel-grabbed');
 

--- a/packages/optimus-ui/src/scrollpanel/scrollpanel.ts
+++ b/packages/optimus-ui/src/scrollpanel/scrollpanel.ts
@@ -89,11 +89,11 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
      */
     @Input({ transform: numberAttribute }) step: number = 5;
 
-    readonly contentViewChild = viewChild<ElementRef>('content');
+    readonly contentViewChild = viewChild.required<ElementRef>('content');
 
-    readonly xBarViewChild = viewChild<ElementRef>('xBar');
+    readonly xBarViewChild = viewChild.required<ElementRef>('xBar');
 
-    readonly yBarViewChild = viewChild<ElementRef>('yBar');
+    readonly yBarViewChild = viewChild.required<ElementRef>('yBar');
     /**
      * Custom content template.
      * @group Templates
@@ -325,7 +325,7 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
 
     repeat(bar, step) {
         const contentViewChild = this.contentViewChild();
-        contentViewChild?.nativeElement && (contentViewChild.nativeElement[bar] += step);
+        contentViewChild.nativeElement[bar] += step;
         this.moveBar();
     }
 
@@ -373,10 +373,10 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
     onYBarMouseDown(e: MouseEvent) {
         this.isYBarClicked = true;
         const yBarViewChild = this.yBarViewChild();
-        yBarViewChild?.nativeElement?.focus();
+        yBarViewChild.nativeElement.focus();
         this.lastPageY = e.pageY;
 
-        yBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'true');
+        yBarViewChild.nativeElement.setAttribute('data-p-scrollpanel-grabbed', 'true');
         !this.$unstyled() && addClass((yBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
 
         this.document.body.setAttribute('data-p-scrollpanel-grabbed', 'true');
@@ -388,10 +388,10 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
     onXBarMouseDown(e: MouseEvent) {
         this.isXBarClicked = true;
         const xBarViewChild = this.xBarViewChild();
-        xBarViewChild?.nativeElement?.focus();
+        xBarViewChild.nativeElement.focus();
         this.lastPageX = e.pageX;
 
-        xBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
+        xBarViewChild.nativeElement.setAttribute('data-p-scrollpanel-grabbed', 'false');
         !this.$unstyled() && addClass((xBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
 
         this.document.body.setAttribute('data-p-scrollpanel-grabbed', 'false');
@@ -441,9 +441,9 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
     }
 
     onFocus(event) {
-        if (this.xBarViewChild()?.nativeElement?.isSameNode(event.target)) {
+        if (this.xBarViewChild().nativeElement?.isSameNode(event.target)) {
             this.orientation = 'horizontal';
-        } else if (this.yBarViewChild()?.nativeElement?.isSameNode(event.target)) {
+        } else if (this.yBarViewChild().nativeElement?.isSameNode(event.target)) {
             this.orientation = 'vertical';
         }
     }
@@ -456,10 +456,10 @@ export class ScrollPanel extends BaseComponent<ScrollPanelPassThrough> {
 
     onDocumentMouseUp(e: Event) {
         const yBarViewChild = this.yBarViewChild();
-        yBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
+        yBarViewChild.nativeElement.setAttribute('data-p-scrollpanel-grabbed', 'false');
         !this.$unstyled() && removeClass((yBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
         const xBarViewChild = this.xBarViewChild();
-        xBarViewChild?.nativeElement?.setAttribute('data-p-scrollpanel-grabbed', 'false');
+        xBarViewChild.nativeElement.setAttribute('data-p-scrollpanel-grabbed', 'false');
         !this.$unstyled() && removeClass((xBarViewChild as ElementRef).nativeElement, 'p-scrollpanel-grabbed');
         this.document.body.setAttribute('data-p-scrollpanel-grabbed', 'false');
         !this.$unstyled() && removeClass(this.document.body, 'p-scrollpanel-grabbed');

--- a/packages/optimus-ui/src/scrolltop/scrolltop.test.ts
+++ b/packages/optimus-ui/src/scrolltop/scrolltop.test.ts
@@ -416,7 +416,7 @@ describe('ScrollTop', () => {
 
             // Mock the templates property to simulate template processing
             const mockTemplate = { getType: () => 'icon', template: {} };
-            scrollTop.templates = { first: () => mockTemplate, forEach: (fn: Function) => fn(mockTemplate) };
+            scrollTop.templates = () => ({ first: () => mockTemplate, forEach: (fn: Function) => fn(mockTemplate) });
 
             expect(() => scrollTop.ngAfterContentInit()).not.toThrow();
             if (scrollTop._iconTemplate) {

--- a/packages/optimus-ui/src/scrolltop/scrolltop.ts
+++ b/packages/optimus-ui/src/scrolltop/scrolltop.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, inject, InjectionToken, input, Input, NgModule, numberAttribute, QueryList, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, InjectionToken, input, Input, NgModule, numberAttribute, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { getWindowScrollTop } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
@@ -174,7 +174,7 @@ export class ScrollTop extends BaseComponent<ScrollTopPassThrough> {
     }
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'icon':
                     this._iconTemplate = item.template;

--- a/packages/optimus-ui/src/scrolltop/scrolltop.ts
+++ b/packages/optimus-ui/src/scrolltop/scrolltop.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, ContentChild, ContentChildren, inject, InjectionToken, input, Input, NgModule, numberAttribute, QueryList, signal, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, InjectionToken, input, Input, NgModule, numberAttribute, QueryList, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { getWindowScrollTop } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
@@ -42,7 +42,7 @@ const SCROLLTOP_INSTANCE = new InjectionToken<ScrollTop>('SCROLLTOP_INSTANCE');
                 [unstyled]="unstyled()"
             >
                 <ng-template #icon>
-                    @if (!iconTemplate && !_iconTemplate) {
+                    @if (!iconTemplate() && !_iconTemplate) {
                         @if (_icon) {
                             <span [class]="cn(cx('icon'), _icon)"></span>
                         }
@@ -50,7 +50,7 @@ const SCROLLTOP_INSTANCE = new InjectionToken<ScrollTop>('SCROLLTOP_INSTANCE');
                             <svg data-p-icon="chevron-up" [class]="cx('icon')" />
                         }
                     } @else {
-                        <ng-template *ngTemplateOutlet="iconTemplate || _iconTemplate; context: { styleClass: cx('icon') }"></ng-template>
+                        <ng-template *ngTemplateOutlet="iconTemplate() || _iconTemplate; context: { styleClass: cx('icon') }"></ng-template>
                     }
                 </ng-template>
             </p-button>
@@ -144,9 +144,9 @@ export class ScrollTop extends BaseComponent<ScrollTopPassThrough> {
      * @see {@link ScrollTopIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('icon', { descendants: false }) iconTemplate: TemplateRef<ScrollTopIconTemplateContext> | undefined;
+    readonly iconTemplate = contentChild<TemplateRef<ScrollTopIconTemplateContext>>('icon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _iconTemplate: TemplateRef<ScrollTopIconTemplateContext> | undefined;
 
@@ -174,7 +174,7 @@ export class ScrollTop extends BaseComponent<ScrollTopPassThrough> {
     }
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'icon':
                     this._iconTemplate = item.template;

--- a/packages/optimus-ui/src/select/select.test.ts
+++ b/packages/optimus-ui/src/select/select.test.ts
@@ -1840,18 +1840,18 @@ describe('Select - #template Reference Content Projection', () => {
     });
 
     it('should capture ContentChild template references', () => {
-        expect(selectInstance.itemTemplate).toBeDefined();
-        expect(selectInstance.selectedItemTemplate).toBeDefined();
-        expect(selectInstance.headerTemplate).toBeDefined();
-        expect(selectInstance.footerTemplate).toBeDefined();
-        expect(selectInstance.emptyTemplate).toBeDefined();
-        expect(selectInstance.emptyFilterTemplate).toBeDefined();
-        expect(selectInstance.filterTemplate).toBeDefined();
-        expect(selectInstance.loaderTemplate).toBeDefined();
-        expect(selectInstance.dropdownIconTemplate).toBeDefined();
-        expect(selectInstance.clearIconTemplate).toBeDefined();
-        expect(selectInstance.filterIconTemplate).toBeDefined();
-        expect(selectInstance.loadingIconTemplate).toBeDefined();
+        expect(selectInstance.itemTemplate()).toBeDefined();
+        expect(selectInstance.selectedItemTemplate()).toBeDefined();
+        expect(selectInstance.headerTemplate()).toBeDefined();
+        expect(selectInstance.footerTemplate()).toBeDefined();
+        expect(selectInstance.emptyTemplate()).toBeDefined();
+        expect(selectInstance.emptyFilterTemplate()).toBeDefined();
+        expect(selectInstance.filterTemplate()).toBeDefined();
+        expect(selectInstance.loaderTemplate()).toBeDefined();
+        expect(selectInstance.dropdownIconTemplate()).toBeDefined();
+        expect(selectInstance.clearIconTemplate()).toBeDefined();
+        expect(selectInstance.filterIconTemplate()).toBeDefined();
+        expect(selectInstance.loadingIconTemplate()).toBeDefined();
     });
 
     it('should render item template reference with context', async () => {
@@ -1951,7 +1951,7 @@ describe('Select - #template Reference Content Projection', () => {
         if (dropdownIcon) {
             expect(dropdownIcon).toBeTruthy();
         }
-        expect(selectInstance.dropdownIconTemplate).toBeDefined();
+        expect(selectInstance.dropdownIconTemplate()).toBeDefined();
     });
 
     it('should render clear icon template reference with class context when showClear is true', () => {
@@ -1959,7 +1959,7 @@ describe('Select - #template Reference Content Projection', () => {
         selectInstance.showClear = true;
         fixture.detectChanges();
 
-        expect(selectInstance.clearIconTemplate).toBeDefined();
+        expect(selectInstance.clearIconTemplate()).toBeDefined();
     });
 
     it('should render filter icon template reference', async () => {
@@ -1986,7 +1986,7 @@ describe('Select - #template Reference Content Projection', () => {
         if (loadingIcon) {
             expect(loadingIcon).toBeTruthy();
         }
-        expect(selectInstance.loadingIconTemplate).toBeDefined();
+        expect(selectInstance.loadingIconTemplate()).toBeDefined();
     });
 });
 

--- a/packages/optimus-ui/src/select/select.test.ts
+++ b/packages/optimus-ui/src/select/select.test.ts
@@ -8,6 +8,8 @@ import { BehaviorSubject, timer } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 import { Select } from './select';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -4457,5 +4459,42 @@ describe('Select PT (PassThrough)', () => {
                 expect(emptyMessage.nativeElement.getAttribute('data-empty')).toBe('true');
             }
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Select, SharedModule],
+    template: `
+        <p-select [options]="opts">
+            <ng-template #group>g</ng-template>
+            <ng-template pTemplate="item">i</ng-template>
+        </p-select>
+    `
+})
+class SelectQueryApiHostComponent {
+    opts = [{ label: 'a', value: 1 }];
+}
+
+describe('Select Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [SelectQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(SelectQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Select)).componentInstance;
+
+        expect(instance.groupTemplate()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'item')).toBe(true);
+        expect(instance.focusInputViewChild()).toBeDefined();
+        expect(instance.editableInputViewChild()).toBeUndefined();
     });
 });

--- a/packages/optimus-ui/src/select/select.test.ts
+++ b/packages/optimus-ui/src/select/select.test.ts
@@ -2693,8 +2693,8 @@ describe('Select ViewChild Properties', () => {
         const itemsContainer = viewChildFixture.debugElement.query(By.css('[role="listbox"]'));
         expect(itemsContainer).toBeTruthy();
 
-        if (selectInstance.itemsViewChild) {
-            expect(selectInstance.itemsViewChild.nativeElement).toBeTruthy();
+        if (selectInstance.itemsViewChild()) {
+            expect(selectInstance.itemsViewChild().nativeElement).toBeTruthy();
         }
     });
 
@@ -2728,11 +2728,11 @@ describe('Select ViewChild Properties', () => {
         expect(hiddenElements.length).toBeGreaterThanOrEqual(2);
 
         // First and last hidden focusable elements should be available
-        if (selectInstance.firstHiddenFocusableElementOnOverlay) {
-            expect(selectInstance.firstHiddenFocusableElementOnOverlay.nativeElement).toBeTruthy();
+        if (selectInstance.firstHiddenFocusableElementOnOverlay()) {
+            expect(selectInstance.firstHiddenFocusableElementOnOverlay().nativeElement).toBeTruthy();
         }
-        if (selectInstance.lastHiddenFocusableElementOnOverlay) {
-            expect(selectInstance.lastHiddenFocusableElementOnOverlay.nativeElement).toBeTruthy();
+        if (selectInstance.lastHiddenFocusableElementOnOverlay()) {
+            expect(selectInstance.lastHiddenFocusableElementOnOverlay().nativeElement).toBeTruthy();
         }
     });
 });

--- a/packages/optimus-ui/src/select/select.ts
+++ b/packages/optimus-ui/src/select/select.ts
@@ -796,7 +796,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
     readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
-    readonly overlayViewChild = viewChild<Nullable<Overlay>>('overlay');
+    readonly overlayViewChild = viewChild.required<Overlay>('overlay');
 
     readonly firstHiddenFocusableElementOnOverlay = viewChild<Nullable<ElementRef>>('firstHiddenFocusableEl');
 
@@ -1179,16 +1179,13 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
             this.zone.runOutsideAngular(() => {
                 setTimeout(() => {
-                    const overlayViewChild = this.overlayViewChild();
-                    if (overlayViewChild) {
-                        overlayViewChild.alignOverlay();
-                    }
+                    this.overlayViewChild().alignOverlay();
                 }, 1);
             });
         }
 
         if (this.selectedOptionUpdated && this.itemsWrapper) {
-            let selectedItem = <any>findSingle(this.overlayViewChild()?.overlayViewChild()?.nativeElement, 'li[data-p-selected="true"]');
+            let selectedItem = <any>findSingle(this.overlayViewChild().overlayViewChild()?.nativeElement, 'li[data-p-selected="true"]');
             if (selectedItem) {
                 scrollInView(this.itemsWrapper, selectedItem);
             }
@@ -1366,7 +1363,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
         const overlayViewChild = this.overlayViewChild();
         if (event.target.tagName === 'INPUT' || event.target.getAttribute('data-pc-section') === 'clearicon' || event.target.closest('[data-pc-section="clearicon"]')) {
             return;
-        } else if (!overlayViewChild || !overlayViewChild.el.nativeElement.contains(event.target)) {
+        } else if (!overlayViewChild.el.nativeElement.contains(event.target)) {
             this.overlayVisible ? this.hide(true) : this.show(true);
         }
 
@@ -1411,7 +1408,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
     }
 
     onOverlayBeforeEnter(event: any) {
-        this.itemsWrapper = <any>findSingle(this.overlayViewChild()?.overlayViewChild()?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
+        this.itemsWrapper = <any>findSingle(this.overlayViewChild().overlayViewChild()?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
         this.virtualScroll && this.scroller()?.setContentEl(this.itemsViewChild()?.nativeElement);
 
         if (this.options && this.options.length) {
@@ -1859,20 +1856,20 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
     onFirstHiddenFocus(event) {
         const focusInputViewChild = this.focusInputViewChild();
-        const focusableEl = event.relatedTarget === focusInputViewChild?.nativeElement ? getFirstFocusableElement(this.overlayViewChild()?.el?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
+        const focusableEl = event.relatedTarget === focusInputViewChild?.nativeElement ? getFirstFocusableElement(this.overlayViewChild().el?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
         focus(focusableEl);
     }
 
     onLastHiddenFocus(event) {
         const focusInputViewChild = this.focusInputViewChild();
         const focusableEl =
-            event.relatedTarget === focusInputViewChild?.nativeElement ? getLastFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
+            event.relatedTarget === focusInputViewChild?.nativeElement ? getLastFocusableElement(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
 
         focus(focusableEl);
     }
 
     hasFocusableElements() {
-        return getFocusableElements(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
+        return getFocusableElements(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
     }
 
     onBackspaceKey(event: KeyboardEvent, pressedInInputText = false) {
@@ -1930,7 +1927,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
         this.onFilter.emit({ originalEvent: event, filter: this._filterValue() });
         !this.virtualScrollerDisabled && this.scroller()?.scrollToIndex(0);
         setTimeout(() => {
-            this.overlayViewChild()?.alignOverlay();
+            this.overlayViewChild().alignOverlay();
         });
         this.cd.markForCheck();
     }

--- a/packages/optimus-ui/src/select/select.ts
+++ b/packages/optimus-ui/src/select/select.ts
@@ -18,7 +18,6 @@ import {
     NgZone,
     numberAttribute,
     Output,
-    QueryList,
     Signal,
     signal,
     TemplateRef,
@@ -1117,7 +1116,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
     }
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;

--- a/packages/optimus-ui/src/select/select.ts
+++ b/packages/optimus-ui/src/select/select.ts
@@ -884,24 +884,6 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
      */
     readonly filterIconTemplate = contentChild<Nullable<TemplateRef<void>>>('filtericon', { descendants: false });
 
-    /**
-     * Custom on icon template.
-     * @group Templates
-     */
-    readonly onIconTemplate = contentChild<Nullable<TemplateRef<void>>>('onicon', { descendants: false });
-
-    /**
-     * Custom off icon template.
-     * @group Templates
-     */
-    readonly offIconTemplate = contentChild<Nullable<TemplateRef<void>>>('officon', { descendants: false });
-
-    /**
-     * Custom cancel icon template.
-     * @group Templates
-     */
-    readonly cancelIconTemplate = contentChild<Nullable<TemplateRef<void>>>('cancelicon', { descendants: false });
-
     readonly templates = contentChildren(PrimeTemplate);
 
     _itemTemplate: TemplateRef<SelectItemTemplateContext> | undefined;

--- a/packages/optimus-ui/src/select/select.ts
+++ b/packages/optimus-ui/src/select/select.ts
@@ -6,8 +6,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     effect,
     ElementRef,
     EventEmitter,
@@ -24,8 +22,10 @@ import {
     Signal,
     signal,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionOptions } from '@openng/optimus-ui-motion';
@@ -212,8 +212,12 @@ export class SelectItem extends BaseComponent {
             [attr.disabled]="$disabled() ? '' : undefined"
             [attr.data-p]="labelDataP"
         >
-            <ng-container *ngIf="!selectedItemTemplate && !_selectedItemTemplate; else defaultPlaceholder">{{ label() === 'p-emptylabel' ? '&nbsp;' : label() }}</ng-container>
-            <ng-container *ngIf="(selectedItemTemplate || _selectedItemTemplate) && !isSelectedOptionEmpty()" [ngTemplateOutlet]="selectedItemTemplate || _selectedItemTemplate" [ngTemplateOutletContext]="{ $implicit: selectedOption }"></ng-container>
+            <ng-container *ngIf="!selectedItemTemplate() && !_selectedItemTemplate; else defaultPlaceholder">{{ label() === 'p-emptylabel' ? '&nbsp;' : label() }}</ng-container>
+            <ng-container
+                *ngIf="(selectedItemTemplate() || _selectedItemTemplate) && !isSelectedOptionEmpty()"
+                [ngTemplateOutlet]="selectedItemTemplate() || _selectedItemTemplate"
+                [ngTemplateOutletContext]="{ $implicit: selectedOption }"
+            ></ng-container>
             <ng-template #defaultPlaceholder>
                 <span *ngIf="isSelectedOptionEmpty()">{{ label() === 'p-emptylabel' ? '&nbsp;' : label() }}</span>
             </ng-template>
@@ -247,30 +251,30 @@ export class SelectItem extends BaseComponent {
             [attr.data-p]="labelDataP"
         />
         <ng-container *ngIf="isVisibleClearIcon">
-            <svg data-p-icon="times" [class]="cx('clearIcon')" [pBind]="ptm('clearIcon')" (click)="clear($event)" *ngIf="!clearIconTemplate && !_clearIconTemplate" [attr.data-pc-section]="'clearicon'" />
-            <span [class]="cx('clearIcon')" [pBind]="ptm('clearIcon')" (click)="clear($event)" *ngIf="clearIconTemplate || _clearIconTemplate" [attr.data-pc-section]="'clearicon'">
-                <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate; context: { class: cx('clearIcon') }"></ng-template>
+            <svg data-p-icon="times" [class]="cx('clearIcon')" [pBind]="ptm('clearIcon')" (click)="clear($event)" *ngIf="!clearIconTemplate() && !_clearIconTemplate" [attr.data-pc-section]="'clearicon'" />
+            <span [class]="cx('clearIcon')" [pBind]="ptm('clearIcon')" (click)="clear($event)" *ngIf="clearIconTemplate() || _clearIconTemplate" [attr.data-pc-section]="'clearicon'">
+                <ng-template *ngTemplateOutlet="clearIconTemplate() || _clearIconTemplate; context: { class: cx('clearIcon') }"></ng-template>
             </span>
         </ng-container>
 
         <div [class]="cx('dropdown')" [pBind]="ptm('dropdown')" role="button" aria-label="dropdown trigger" aria-haspopup="listbox" [attr.aria-expanded]="overlayVisible ?? false" [attr.data-pc-section]="'trigger'">
             <ng-container *ngIf="loading; else elseBlock">
-                <ng-container *ngIf="loadingIconTemplate || _loadingIconTemplate">
-                    <ng-container *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate"></ng-container>
+                <ng-container *ngIf="loadingIconTemplate() || _loadingIconTemplate">
+                    <ng-container *ngTemplateOutlet="loadingIconTemplate() || _loadingIconTemplate"></ng-container>
                 </ng-container>
-                <ng-container *ngIf="!loadingIconTemplate && !_loadingIconTemplate">
+                <ng-container *ngIf="!loadingIconTemplate() && !_loadingIconTemplate">
                     <span *ngIf="loadingIcon" [class]="cn(cx('loadingIcon'), 'pi-spin' + loadingIcon)" [pBind]="ptm('loadingIcon')" aria-hidden="true"></span>
                     <span *ngIf="!loadingIcon" [class]="cn(cx('loadingIcon'), 'pi pi-spinner pi-spin')" [pBind]="ptm('loadingIcon')" aria-hidden="true"></span>
                 </ng-container>
             </ng-container>
 
             <ng-template #elseBlock>
-                <ng-container *ngIf="!dropdownIconTemplate && !_dropdownIconTemplate">
+                <ng-container *ngIf="!dropdownIconTemplate() && !_dropdownIconTemplate">
                     <span [class]="cn(cx('dropdownIcon'), dropdownIcon)" [pBind]="ptm('dropdownIcon')" *ngIf="dropdownIcon"></span>
                     <svg data-p-icon="chevron-down" *ngIf="!dropdownIcon" [class]="cx('dropdownIcon')" [pBind]="ptm('dropdownIcon')" />
                 </ng-container>
-                <span *ngIf="dropdownIconTemplate || _dropdownIconTemplate" [class]="cx('dropdownIcon')" [pBind]="ptm('dropdownIcon')">
-                    <ng-template *ngTemplateOutlet="dropdownIconTemplate || _dropdownIconTemplate; context: { class: cx('dropdownIcon') }"></ng-template>
+                <span *ngIf="dropdownIconTemplate() || _dropdownIconTemplate" [class]="cx('dropdownIcon')" [pBind]="ptm('dropdownIcon')">
+                    <ng-template *ngTemplateOutlet="dropdownIconTemplate() || _dropdownIconTemplate; context: { class: cx('dropdownIcon') }"></ng-template>
                 </span>
             </ng-template>
         </div>
@@ -302,10 +306,10 @@ export class SelectItem extends BaseComponent {
                         [pBind]="ptm('hiddenFirstFocusableEl')"
                     >
                     </span>
-                    <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
                     <div [class]="cx('header')" *ngIf="filter" (click)="$event.stopPropagation()" [pBind]="ptm('header')">
-                        <ng-container *ngIf="filterTemplate || _filterTemplate; else builtInFilterElement">
-                            <ng-container *ngTemplateOutlet="filterTemplate || _filterTemplate; context: { options: filterOptions }"></ng-container>
+                        <ng-container *ngIf="filterTemplate() || _filterTemplate; else builtInFilterElement">
+                            <ng-container *ngTemplateOutlet="filterTemplate() || _filterTemplate; context: { options: filterOptions }"></ng-container>
                         </ng-container>
                         <ng-template #builtInFilterElement>
                             <p-iconfield [pt]="ptm('pcFilterContainer')" [unstyled]="unstyled()">
@@ -330,9 +334,9 @@ export class SelectItem extends BaseComponent {
                                     [unstyled]="unstyled()"
                                 />
                                 <p-inputicon [pt]="ptm('pcFilterIconContainer')" [unstyled]="unstyled()">
-                                    <svg data-p-icon="search" *ngIf="!filterIconTemplate && !_filterIconTemplate" [pBind]="ptm('filterIcon')" />
-                                    <span *ngIf="filterIconTemplate || _filterIconTemplate" [pBind]="ptm('filterIcon')">
-                                        <ng-template *ngTemplateOutlet="filterIconTemplate || _filterIconTemplate"></ng-template>
+                                    <svg data-p-icon="search" *ngIf="!filterIconTemplate() && !_filterIconTemplate" [pBind]="ptm('filterIcon')" />
+                                    <span *ngIf="filterIconTemplate() || _filterIconTemplate" [pBind]="ptm('filterIcon')">
+                                        <ng-template *ngTemplateOutlet="filterIconTemplate() || _filterIconTemplate"></ng-template>
                                     </span>
                                 </p-inputicon>
                             </p-iconfield>
@@ -355,9 +359,9 @@ export class SelectItem extends BaseComponent {
                             <ng-template #content let-items let-scrollerOptions="options">
                                 <ng-container *ngTemplateOutlet="buildInItems; context: { $implicit: items, options: scrollerOptions }"></ng-container>
                             </ng-template>
-                            <ng-container *ngIf="loaderTemplate || _loaderTemplate">
+                            <ng-container *ngIf="loaderTemplate() || _loaderTemplate">
                                 <ng-template #loader let-scrollerOptions="options">
-                                    <ng-container *ngTemplateOutlet="loaderTemplate || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
+                                    <ng-container *ngTemplateOutlet="loaderTemplate() || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
                                 </ng-template>
                             </ng-container>
                         </p-scroller>
@@ -370,8 +374,8 @@ export class SelectItem extends BaseComponent {
                                 <ng-template ngFor let-option [ngForOf]="items" let-i="index">
                                     <ng-container *ngIf="isOptionGroup(option)">
                                         <li [class]="cx('optionGroup')" [attr.id]="id + '_' + getOptionIndex(i, scrollerOptions)" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option" [pBind]="ptm('optionGroup')">
-                                            <span *ngIf="!groupTemplate && !_groupTemplate" [class]="cx('optionGroupLabel')" [pBind]="ptm('optionGroupLabel')">{{ getOptionGroupLabel(option.optionGroup) }}</span>
-                                            <ng-container *ngTemplateOutlet="groupTemplate || _groupTemplate; context: { $implicit: option.optionGroup }"></ng-container>
+                                            <span *ngIf="!groupTemplate() && !_groupTemplate" [class]="cx('optionGroupLabel')" [pBind]="ptm('optionGroupLabel')">{{ getOptionGroupLabel(option.optionGroup) }}</span>
+                                            <ng-container *ngTemplateOutlet="groupTemplate() || _groupTemplate; context: { $implicit: option.optionGroup }"></ng-container>
                                         </li>
                                     </ng-container>
                                     <ng-container *ngIf="!isOptionGroup(option)">
@@ -382,7 +386,7 @@ export class SelectItem extends BaseComponent {
                                             [selected]="isSelected(option)"
                                             [label]="getOptionLabel(option)"
                                             [disabled]="isOptionDisabled(option)"
-                                            [template]="itemTemplate || _itemTemplate"
+                                            [template]="itemTemplate() || _itemTemplate"
                                             [focused]="focusedOptionIndex() === getOptionIndex(i, scrollerOptions)"
                                             [ariaPosInset]="getAriaPosInset(getOptionIndex(i, scrollerOptions))"
                                             [ariaSetSize]="ariaSetSize"
@@ -395,23 +399,23 @@ export class SelectItem extends BaseComponent {
                                     </ng-container>
                                 </ng-template>
                                 <li *ngIf="filterValue && isEmpty()" [class]="cx('emptyMessage')" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option" [pBind]="ptm('emptyMessage')">
-                                    @if (!emptyFilterTemplate && !_emptyFilterTemplate && !emptyTemplate) {
+                                    @if (!emptyFilterTemplate() && !_emptyFilterTemplate && !emptyTemplate()) {
                                         {{ emptyFilterMessageLabel }}
                                     } @else {
-                                        <ng-container #emptyFilter *ngTemplateOutlet="emptyFilterTemplate || _emptyFilterTemplate || emptyTemplate || _emptyTemplate"></ng-container>
+                                        <ng-container #emptyFilter *ngTemplateOutlet="emptyFilterTemplate() || _emptyFilterTemplate || emptyTemplate() || _emptyTemplate"></ng-container>
                                     }
                                 </li>
                                 <li *ngIf="!filterValue && isEmpty()" [class]="cx('emptyMessage')" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option" [pBind]="ptm('emptyMessage')">
-                                    @if (!emptyTemplate && !_emptyTemplate) {
+                                    @if (!emptyTemplate() && !_emptyTemplate) {
                                         {{ emptyMessageLabel || emptyFilterMessageLabel }}
                                     } @else {
-                                        <ng-container #empty *ngTemplateOutlet="emptyTemplate || _emptyTemplate"></ng-container>
+                                        <ng-container #empty *ngTemplateOutlet="emptyTemplate() || _emptyTemplate"></ng-container>
                                     }
                                 </li>
                             </ul>
                         </ng-template>
                     </div>
-                    <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
                     <span
                         #lastHiddenFocusableEl
                         role="presentation"
@@ -783,21 +787,21 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
     _componentStyle = inject(SelectStyle);
 
-    @ViewChild('filter') filterViewChild: Nullable<ElementRef>;
+    readonly filterViewChild = viewChild<Nullable<ElementRef>>('filter');
 
-    @ViewChild('focusInput') focusInputViewChild: Nullable<ElementRef>;
+    readonly focusInputViewChild = viewChild<Nullable<ElementRef>>('focusInput');
 
-    @ViewChild('editableInput') editableInputViewChild: Nullable<ElementRef>;
+    readonly editableInputViewChild = viewChild<Nullable<ElementRef>>('editableInput');
 
-    @ViewChild('items') itemsViewChild: Nullable<ElementRef>;
+    readonly itemsViewChild = viewChild<Nullable<ElementRef>>('items');
 
-    @ViewChild('scroller') scroller: Nullable<Scroller>;
+    readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
-    @ViewChild('overlay') overlayViewChild: Nullable<Overlay>;
+    readonly overlayViewChild = viewChild<Nullable<Overlay>>('overlay');
 
-    @ViewChild('firstHiddenFocusableEl') firstHiddenFocusableElementOnOverlay: Nullable<ElementRef>;
+    readonly firstHiddenFocusableElementOnOverlay = viewChild<Nullable<ElementRef>>('firstHiddenFocusableEl');
 
-    @ViewChild('lastHiddenFocusableEl') lastHiddenFocusableElementOnOverlay: Nullable<ElementRef>;
+    readonly lastHiddenFocusableElementOnOverlay = viewChild<Nullable<ElementRef>>('lastHiddenFocusableEl');
 
     itemsWrapper: Nullable<HTMLDivElement>;
 
@@ -807,99 +811,99 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
      * Custom item template.
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: Nullable<TemplateRef<SelectItemTemplateContext>>;
+    readonly itemTemplate = contentChild<Nullable<TemplateRef<SelectItemTemplateContext>>>('item', { descendants: false });
 
     /**
      * Custom group template.
      * @group Templates
      */
-    @ContentChild('group', { descendants: false }) groupTemplate: Nullable<TemplateRef<SelectGroupTemplateContext>>;
+    readonly groupTemplate = contentChild<Nullable<TemplateRef<SelectGroupTemplateContext>>>('group', { descendants: false });
 
     /**
      * Custom loader template.
      * @group Templates
      */
-    @ContentChild('loader', { descendants: false }) loaderTemplate: Nullable<TemplateRef<SelectLoaderTemplateContext>>;
+    readonly loaderTemplate = contentChild<Nullable<TemplateRef<SelectLoaderTemplateContext>>>('loader', { descendants: false });
 
     /**
      * Custom selected item template.
      * @group Templates
      */
-    @ContentChild('selectedItem', { descendants: false }) selectedItemTemplate: Nullable<TemplateRef<SelectSelectedItemTemplateContext>>;
+    readonly selectedItemTemplate = contentChild<Nullable<TemplateRef<SelectSelectedItemTemplateContext>>>('selectedItem', { descendants: false });
 
     /**
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: Nullable<TemplateRef<void>>;
+    readonly headerTemplate = contentChild<Nullable<TemplateRef<void>>>('header', { descendants: false });
 
     /**
      * Custom filter template.
      * @group Templates
      */
-    @ContentChild('filter', { descendants: false }) filterTemplate: Nullable<TemplateRef<SelectFilterTemplateContext>>;
+    readonly filterTemplate = contentChild<Nullable<TemplateRef<SelectFilterTemplateContext>>>('filter', { descendants: false });
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: Nullable<TemplateRef<void>>;
+    readonly footerTemplate = contentChild<Nullable<TemplateRef<void>>>('footer', { descendants: false });
 
     /**
      * Custom empty filter template.
      * @group Templates
      */
-    @ContentChild('emptyfilter', { descendants: false }) emptyFilterTemplate: Nullable<TemplateRef<void>>;
+    readonly emptyFilterTemplate = contentChild<Nullable<TemplateRef<void>>>('emptyfilter', { descendants: false });
 
     /**
      * Custom empty template.
      * @group Templates
      */
-    @ContentChild('empty', { descendants: false }) emptyTemplate: Nullable<TemplateRef<void>>;
+    readonly emptyTemplate = contentChild<Nullable<TemplateRef<void>>>('empty', { descendants: false });
 
     /**
      * Custom dropdown icon template.
      * @group Templates
      */
-    @ContentChild('dropdownicon', { descendants: false }) dropdownIconTemplate: Nullable<TemplateRef<SelectIconTemplateContext>>;
+    readonly dropdownIconTemplate = contentChild<Nullable<TemplateRef<SelectIconTemplateContext>>>('dropdownicon', { descendants: false });
 
     /**
      * Custom loading icon template.
      * @group Templates
      */
-    @ContentChild('loadingicon', { descendants: false }) loadingIconTemplate: Nullable<TemplateRef<void>>;
+    readonly loadingIconTemplate = contentChild<Nullable<TemplateRef<void>>>('loadingicon', { descendants: false });
 
     /**
      * Custom clear icon template.
      * @group Templates
      */
-    @ContentChild('clearicon', { descendants: false }) clearIconTemplate: Nullable<TemplateRef<SelectIconTemplateContext>>;
+    readonly clearIconTemplate = contentChild<Nullable<TemplateRef<SelectIconTemplateContext>>>('clearicon', { descendants: false });
 
     /**
      * Custom filter icon template.
      * @group Templates
      */
-    @ContentChild('filtericon', { descendants: false }) filterIconTemplate: Nullable<TemplateRef<void>>;
+    readonly filterIconTemplate = contentChild<Nullable<TemplateRef<void>>>('filtericon', { descendants: false });
 
     /**
      * Custom on icon template.
      * @group Templates
      */
-    @ContentChild('onicon', { descendants: false }) onIconTemplate: Nullable<TemplateRef<void>>;
+    readonly onIconTemplate = contentChild<Nullable<TemplateRef<void>>>('onicon', { descendants: false });
 
     /**
      * Custom off icon template.
      * @group Templates
      */
-    @ContentChild('officon', { descendants: false }) offIconTemplate: Nullable<TemplateRef<void>>;
+    readonly offIconTemplate = contentChild<Nullable<TemplateRef<void>>>('officon', { descendants: false });
 
     /**
      * Custom cancel icon template.
      * @group Templates
      */
-    @ContentChild('cancelicon', { descendants: false }) cancelIconTemplate: Nullable<TemplateRef<void>>;
+    readonly cancelIconTemplate = contentChild<Nullable<TemplateRef<void>>>('cancelicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _itemTemplate: TemplateRef<SelectItemTemplateContext> | undefined;
 
@@ -1113,7 +1117,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
     }
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;
@@ -1194,15 +1198,16 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
             this.zone.runOutsideAngular(() => {
                 setTimeout(() => {
-                    if (this.overlayViewChild) {
-                        this.overlayViewChild.alignOverlay();
+                    const overlayViewChild = this.overlayViewChild();
+                    if (overlayViewChild) {
+                        overlayViewChild.alignOverlay();
                     }
                 }, 1);
             });
         }
 
         if (this.selectedOptionUpdated && this.itemsWrapper) {
-            let selectedItem = <any>findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, 'li[data-p-selected="true"]');
+            let selectedItem = <any>findSingle(this.overlayViewChild()?.overlayViewChild()?.nativeElement, 'li[data-p-selected="true"]');
             if (selectedItem) {
                 scrollInView(this.itemsWrapper, selectedItem);
             }
@@ -1291,14 +1296,16 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
     }
 
     updateEditableLabel(): void {
-        if (this.editableInputViewChild) {
-            this.editableInputViewChild.nativeElement.value = this.getOptionLabel(this.selectedOption) || this.modelValue() || '';
+        const editableInputViewChild = this.editableInputViewChild();
+        if (editableInputViewChild) {
+            editableInputViewChild.nativeElement.value = this.getOptionLabel(this.selectedOption) || this.modelValue() || '';
         }
     }
 
     clearEditableLabel(): void {
-        if (this.editableInputViewChild) {
-            this.editableInputViewChild.nativeElement.value = '';
+        const editableInputViewChild = this.editableInputViewChild();
+        if (editableInputViewChild) {
+            editableInputViewChild.nativeElement.value = '';
         }
     }
 
@@ -1364,8 +1371,9 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
     public resetFilter(): void {
         this._filterValue.set(null);
 
-        if (this.filterViewChild && this.filterViewChild.nativeElement) {
-            this.filterViewChild.nativeElement.value = '';
+        const filterViewChild = this.filterViewChild();
+        if (filterViewChild && filterViewChild.nativeElement) {
+            filterViewChild.nativeElement.value = '';
         }
     }
 
@@ -1374,13 +1382,14 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
             return;
         }
 
+        const overlayViewChild = this.overlayViewChild();
         if (event.target.tagName === 'INPUT' || event.target.getAttribute('data-pc-section') === 'clearicon' || event.target.closest('[data-pc-section="clearicon"]')) {
             return;
-        } else if (!this.overlayViewChild || !this.overlayViewChild.el.nativeElement.contains(event.target)) {
+        } else if (!overlayViewChild || !overlayViewChild.el.nativeElement.contains(event.target)) {
             this.overlayVisible ? this.hide(true) : this.show(true);
         }
 
-        this.focusInputViewChild?.nativeElement.focus({ preventScroll: true });
+        this.focusInputViewChild()?.nativeElement.focus({ preventScroll: true });
         this.onClick.emit(event);
         this.clicked.set(true);
         this.cd.detectChanges();
@@ -1414,22 +1423,22 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
         this.focusedOptionIndex.set(this.focusedOptionIndex() !== -1 ? this.focusedOptionIndex() : this.autoOptionFocus ? this.findFirstFocusedOptionIndex() : this.editable ? -1 : this.findSelectedOptionIndex());
 
         if (isFocus) {
-            focus(this.focusInputViewChild?.nativeElement);
+            focus(this.focusInputViewChild()?.nativeElement);
         }
 
         this.cd.markForCheck();
     }
 
     onOverlayBeforeEnter(event: any) {
-        this.itemsWrapper = <any>findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
-        this.virtualScroll && this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
+        this.itemsWrapper = <any>findSingle(this.overlayViewChild()?.overlayViewChild()?.nativeElement, this.virtualScroll ? '[data-pc-name="virtualscroller"]' : '[data-pc-section="listcontainer"]');
+        this.virtualScroll && this.scroller()?.setContentEl(this.itemsViewChild()?.nativeElement);
 
         if (this.options && this.options.length) {
             if (this.virtualScroll) {
                 const selectedIndex = this.modelValue() ? this.focusedOptionIndex() : -1;
                 if (selectedIndex !== -1) {
                     setTimeout(() => {
-                        this.scroller?.scrollToIndex(selectedIndex);
+                        this.scroller()?.scrollToIndex(selectedIndex);
                     }, 10);
                 }
             } else {
@@ -1440,11 +1449,12 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
             }
         }
 
-        if (this.filterViewChild && this.filterViewChild.nativeElement) {
+        const filterViewChild = this.filterViewChild();
+        if (filterViewChild && filterViewChild.nativeElement) {
             this.preventModelTouched = true;
 
             if (this.autofocusFilter && !this.editable) {
-                this.filterViewChild.nativeElement.focus();
+                filterViewChild.nativeElement.focus();
             }
         }
         this.onShow.emit(event);
@@ -1472,11 +1482,13 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
             this.resetFilter();
         }
         if (isFocus) {
-            if (this.focusInputViewChild) {
-                focus(this.focusInputViewChild?.nativeElement);
+            const focusInputViewChild = this.focusInputViewChild();
+            if (focusInputViewChild) {
+                focus(focusInputViewChild?.nativeElement);
             }
-            if (this.editable && this.editableInputViewChild) {
-                focus(this.editableInputViewChild?.nativeElement);
+            const editableInputViewChild = this.editableInputViewChild();
+            if (this.editable && editableInputViewChild) {
+                focus(editableInputViewChild?.nativeElement);
             }
         }
         this.cd.markForCheck();
@@ -1669,13 +1681,14 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
     scrollInView(index = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
 
-        if (this.itemsViewChild && this.itemsViewChild.nativeElement) {
-            const element = findSingle(this.itemsViewChild.nativeElement, `li[id="${id}"]`);
+        const itemsViewChild = this.itemsViewChild();
+        if (itemsViewChild && itemsViewChild.nativeElement) {
+            const element = findSingle(itemsViewChild.nativeElement, `li[id="${id}"]`);
             if (element) {
                 element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
             } else if (!this.virtualScrollerDisabled) {
                 setTimeout(() => {
-                    this.virtualScroll && this.scroller?.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex());
+                    this.virtualScroll && this.scroller()?.scrollToIndex(index !== -1 ? index : this.focusedOptionIndex());
                 }, 0);
             }
         }
@@ -1850,7 +1863,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
     onTabKey(event, pressedInInputText = false) {
         if (!pressedInInputText) {
             if (this.overlayVisible && this.hasFocusableElements()) {
-                focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay?.nativeElement : this.firstHiddenFocusableElementOnOverlay?.nativeElement);
+                focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay()?.nativeElement : this.firstHiddenFocusableElementOnOverlay()?.nativeElement);
                 event.preventDefault();
             } else {
                 if (this.focusedOptionIndex() !== -1 && this.overlayVisible) {
@@ -1864,19 +1877,21 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
     }
 
     onFirstHiddenFocus(event) {
-        const focusableEl = event.relatedTarget === this.focusInputViewChild?.nativeElement ? getFirstFocusableElement(this.overlayViewChild?.el?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInputViewChild?.nativeElement;
+        const focusInputViewChild = this.focusInputViewChild();
+        const focusableEl = event.relatedTarget === focusInputViewChild?.nativeElement ? getFirstFocusableElement(this.overlayViewChild()?.el?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
         focus(focusableEl);
     }
 
     onLastHiddenFocus(event) {
+        const focusInputViewChild = this.focusInputViewChild();
         const focusableEl =
-            event.relatedTarget === this.focusInputViewChild?.nativeElement ? getLastFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInputViewChild?.nativeElement;
+            event.relatedTarget === focusInputViewChild?.nativeElement ? getLastFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInputViewChild?.nativeElement;
 
         focus(focusableEl);
     }
 
     hasFocusableElements() {
-        return getFocusableElements(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
+        return getFocusableElements(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
     }
 
     onBackspaceKey(event: KeyboardEvent, pressedInInputText = false) {
@@ -1932,16 +1947,16 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
         this._filterValue.set(value);
         this.focusedOptionIndex.set(-1);
         this.onFilter.emit({ originalEvent: event, filter: this._filterValue() });
-        !this.virtualScrollerDisabled && this.scroller?.scrollToIndex(0);
+        !this.virtualScrollerDisabled && this.scroller()?.scrollToIndex(0);
         setTimeout(() => {
-            this.overlayViewChild?.alignOverlay();
+            this.overlayViewChild()?.alignOverlay();
         });
         this.cd.markForCheck();
     }
 
     applyFocus(): void {
         if (this.editable) (findSingle(this.el.nativeElement, '[data-pc-section="label"]') as any).focus();
-        else focus(this.focusInputViewChild?.nativeElement);
+        else focus(this.focusInputViewChild()?.nativeElement);
     }
     /**
      * Applies focus.
@@ -1998,7 +2013,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
             clearable: this.showClear,
             disabled: this.$disabled(),
             [this.size() as string]: this.size(),
-            empty: !this.editable && !this.selectedItemTemplate && (!this.label?.() || this.label() === 'p-emptylabel' || this.label()?.length === 0)
+            empty: !this.editable && !this.selectedItemTemplate() && (!this.label?.() || this.label() === 'p-emptylabel' || this.label()?.length === 0)
         });
     }
 

--- a/packages/optimus-ui/src/selectbutton/selectbutton.test.ts
+++ b/packages/optimus-ui/src/selectbutton/selectbutton.test.ts
@@ -532,7 +532,7 @@ describe('SelectButton pTemplate Tests', () => {
     it('should create component with pTemplate templates', async () => {
         expect(component).toBeTruthy();
         expect(selectButtonInstance).toBeTruthy();
-        expect(() => selectButtonInstance.itemTemplate).not.toThrow();
+        expect(() => selectButtonInstance.itemTemplate()).not.toThrow();
     });
 
     it('should pass context parameters to item template', async () => {
@@ -611,7 +611,7 @@ describe('SelectButton #template Reference Tests', () => {
     it('should create component with #template references', async () => {
         expect(component).toBeTruthy();
         expect(selectButtonInstance).toBeTruthy();
-        expect(() => selectButtonInstance.itemTemplate).not.toThrow();
+        expect(() => selectButtonInstance.itemTemplate()).not.toThrow();
     });
 
     it('should pass context parameters to item template', async () => {

--- a/packages/optimus-ui/src/selectbutton/selectbutton.test.ts
+++ b/packages/optimus-ui/src/selectbutton/selectbutton.test.ts
@@ -8,6 +8,8 @@ import { SharedModule } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { SelectButton, SelectButtonModule } from './selectbutton';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 describe('SelectButton', () => {
     let component: SelectButton;
     let fixture: ComponentFixture<SelectButton>;
@@ -1242,3 +1244,39 @@ class TestFormIsolationSelectButtonComponent {
     form = new FormGroup({ value: new FormControl('A') });
     options = ['A', 'B'];
 }
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [SelectButton, PrimeTemplate],
+    template: `
+        <p-selectbutton>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-selectbutton>
+    `
+})
+class SelectButtonQueryApiHostComponent {}
+
+describe('SelectButton Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [SelectButtonQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(SelectButtonQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(SelectButton)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
+    });
+});

--- a/packages/optimus-ui/src/selectbutton/selectbutton.ts
+++ b/packages/optimus-ui/src/selectbutton/selectbutton.ts
@@ -5,8 +5,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     EventEmitter,
     forwardRef,
     inject,
@@ -18,7 +16,9 @@ import {
     Output,
     QueryList,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { equals, resolveFieldData } from '@openng/optimus-ui-utils';
@@ -62,9 +62,9 @@ export const SELECTBUTTON_VALUE_ACCESSOR: any = {
                 [pt]="ptm('pcToggleButton')"
                 [unstyled]="unstyled()"
             >
-                @if (itemTemplate || _itemTemplate) {
+                @if (itemTemplate() || _itemTemplate) {
                     <ng-template #content>
-                        <ng-container *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: option, index: i }"></ng-container>
+                        <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: option, index: i }"></ng-container>
                     </ng-template>
                 }
             </p-togglebutton>
@@ -183,7 +183,7 @@ export class SelectButton extends BaseEditableHolder<SelectButtonPassThrough> im
      * @see {@link SelectButtonItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<SelectButtonItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<SelectButtonItemTemplateContext>>('item', { descendants: false });
 
     _itemTemplate: TemplateRef<SelectButtonItemTemplateContext> | undefined;
 
@@ -316,10 +316,10 @@ export class SelectButton extends BaseEditableHolder<SelectButtonPassThrough> im
         return selected;
     }
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;

--- a/packages/optimus-ui/src/selectbutton/selectbutton.ts
+++ b/packages/optimus-ui/src/selectbutton/selectbutton.ts
@@ -14,7 +14,6 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     TemplateRef,
     ViewEncapsulation,
     contentChild,
@@ -319,7 +318,7 @@ export class SelectButton extends BaseEditableHolder<SelectButtonPassThrough> im
     readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'item':
                     this._itemTemplate = item.template;

--- a/packages/optimus-ui/src/slider/slider.test.ts
+++ b/packages/optimus-ui/src/slider/slider.test.ts
@@ -9,6 +9,7 @@ import { provideOptimus } from '@openng/optimus-ui/config';
 import { SliderChangeEvent, SliderSlideEndEvent } from '@openng/optimus-ui/types/slider';
 import { Slider, SliderModule } from './slider';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 // Test Components
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1544,5 +1545,32 @@ describe('Slider', () => {
                 expect(hookCalls).toContain('onDestroy');
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Slider, SharedModule],
+    template: ` <p-slider> </p-slider> `
+})
+class SliderQueryApiHostComponent {}
+
+describe('Slider Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [SliderQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(SliderQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Slider)).componentInstance;
+
+        expect(instance.sliderHandle()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/slider/slider.test.ts
+++ b/packages/optimus-ui/src/slider/slider.test.ts
@@ -1052,8 +1052,10 @@ describe('Slider', () => {
 
         it('should handle focus on slider handles', () => {
             component.range = true;
-            component.sliderHandleStart = { nativeElement: { focus: vi.fn() } } as any;
-            component.sliderHandleEnd = { nativeElement: { focus: vi.fn() } } as any;
+            const mockStartHandle = { nativeElement: { focus: vi.fn() } };
+            const mockEndHandle = { nativeElement: { focus: vi.fn() } };
+            (component as any).sliderHandleStart = () => mockStartHandle as any;
+            (component as any).sliderHandleEnd = () => mockEndHandle as any;
             component.values = [20, 80];
             component.handleIndex = 0;
 

--- a/packages/optimus-ui/src/slider/slider.test.ts
+++ b/packages/optimus-ui/src/slider/slider.test.ts
@@ -1059,7 +1059,7 @@ describe('Slider', () => {
 
             component.updateValue(30);
 
-            expect(component.sliderHandleStart!.nativeElement.focus).toHaveBeenCalled();
+            expect(component.sliderHandleStart()!.nativeElement.focus).toHaveBeenCalled();
         });
 
         it('should handle animation removal and addition', () => {

--- a/packages/optimus-ui/src/slider/slider.ts
+++ b/packages/optimus-ui/src/slider/slider.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, forwardRef, HostListener, inject, InjectionToken, Input, NgModule, NgZone, numberAttribute, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, forwardRef, HostListener, inject, InjectionToken, Input, NgModule, NgZone, numberAttribute, Output, ViewEncapsulation, viewChild } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { addClass, getWindowScrollLeft, getWindowScrollTop, isRTL, removeClass } from '@openng/optimus-ui-utils';
 import { SharedModule } from '@openng/optimus-ui/api';
@@ -232,11 +232,11 @@ export class Slider extends BaseEditableHolder<SliderPassThrough> {
      */
     @Output() onSlideEnd: EventEmitter<SliderSlideEndEvent> = new EventEmitter<SliderSlideEndEvent>();
 
-    @ViewChild('sliderHandle') sliderHandle: Nullable<ElementRef>;
+    readonly sliderHandle = viewChild<Nullable<ElementRef>>('sliderHandle');
 
-    @ViewChild('sliderHandleStart') sliderHandleStart: Nullable<ElementRef>;
+    readonly sliderHandleStart = viewChild<Nullable<ElementRef>>('sliderHandleStart');
 
-    @ViewChild('sliderHandleEnd') sliderHandleEnd: Nullable<ElementRef>;
+    readonly sliderHandleEnd = viewChild<Nullable<ElementRef>>('sliderHandleEnd');
 
     _componentStyle = inject(SliderStyle);
 
@@ -638,7 +638,7 @@ export class Slider extends BaseEditableHolder<SliderPassThrough> {
                         this.handleValues[0] = 100;
                     }
                 }
-                this.sliderHandleStart?.nativeElement.focus();
+                this.sliderHandleStart()?.nativeElement.focus();
             } else {
                 if (value > this.max) {
                     value = this.max;
@@ -650,7 +650,7 @@ export class Slider extends BaseEditableHolder<SliderPassThrough> {
                 } else if (value < (this.values as number[])[0]) {
                     this.offset = this.handleValues[1];
                 }
-                this.sliderHandleEnd?.nativeElement.focus();
+                this.sliderHandleEnd()?.nativeElement.focus();
             }
 
             if (this.step) {
@@ -676,7 +676,7 @@ export class Slider extends BaseEditableHolder<SliderPassThrough> {
 
             this.onModelChange(this.value);
             this.onChange.emit({ event: event as Event, value: this.value });
-            this.sliderHandle?.nativeElement.focus();
+            this.sliderHandle()?.nativeElement.focus();
         }
         this.updateHandleValue();
     }

--- a/packages/optimus-ui/src/speeddial/speeddial.test.ts
+++ b/packages/optimus-ui/src/speeddial/speeddial.test.ts
@@ -1382,13 +1382,6 @@ describe('SpeedDial', () => {
             expect(speedDialInstance.visible).toBe(false);
         });
 
-        it('should handle missing container element gracefully', () => {
-            (speedDialInstance as any).container = () => undefined as any;
-
-            expect(() => {
-                speedDialInstance.isOutsideClicked(new Event('click'));
-            }).not.toThrow();
-        });
     });
 
     describe('Public Methods', () => {

--- a/packages/optimus-ui/src/speeddial/speeddial.test.ts
+++ b/packages/optimus-ui/src/speeddial/speeddial.test.ts
@@ -7,6 +7,8 @@ import { MenuItem } from '@openng/optimus-ui/api';
 import { ButtonModule } from '@openng/optimus-ui/button';
 import { SpeedDial } from './speeddial';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 // Basic SpeedDial Test Component
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1381,7 +1383,6 @@ describe('SpeedDial', () => {
 
             expect(speedDialInstance.visible).toBe(false);
         });
-
     });
 
     describe('Public Methods', () => {
@@ -2141,5 +2142,35 @@ describe('SpeedDial', () => {
                 expect(rootElement?.getAttribute('data-masked')).toBe('false');
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [SpeedDial, SharedModule],
+    template: ` <p-speeddial [model]="model"> </p-speeddial> `
+})
+class SpeedDialQueryApiHostComponent {
+    model = [{ label: 'a' }];
+}
+
+describe('SpeedDial Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [SpeedDialQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(SpeedDialQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(SpeedDial)).componentInstance;
+
+        expect(instance.container()).toBeDefined();
+        expect(instance.list()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/speeddial/speeddial.test.ts
+++ b/packages/optimus-ui/src/speeddial/speeddial.test.ts
@@ -1053,7 +1053,7 @@ describe('SpeedDial', () => {
                 expect(() => speedDialInstance.ngAfterContentInit()).not.toThrow();
 
                 // Test that buttonTemplate property exists (ContentChild)
-                expect(speedDialInstance.buttonTemplate).toBeDefined();
+                expect(speedDialInstance.buttonTemplate()).toBeDefined();
 
                 // Verify container is rendered
                 const container = contentTemplateFixture.debugElement.query(By.css('[data-pc-name="speeddial"]'));
@@ -1069,8 +1069,8 @@ describe('SpeedDial', () => {
                 const speedDialInstance = contentTemplateFixture.debugElement.query(By.directive(SpeedDial)).componentInstance;
 
                 // @ContentChild('button') should set buttonTemplate
-                expect(speedDialInstance.buttonTemplate).toBeDefined();
-                expect(speedDialInstance.buttonTemplate?.constructor.name).toBe('TemplateRef');
+                expect(speedDialInstance.buttonTemplate()).toBeDefined();
+                expect(speedDialInstance.buttonTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process itemTemplate from @ContentChild('item')", async () => {
@@ -1082,8 +1082,8 @@ describe('SpeedDial', () => {
                 const speedDialInstance = contentTemplateFixture.debugElement.query(By.directive(SpeedDial)).componentInstance;
 
                 // @ContentChild('item') should set itemTemplate
-                expect(speedDialInstance.itemTemplate).toBeDefined();
-                expect(speedDialInstance.itemTemplate?.constructor.name).toBe('TemplateRef');
+                expect(speedDialInstance.itemTemplate()).toBeDefined();
+                expect(speedDialInstance.itemTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process iconTemplate from @ContentChild('icon')", async () => {
@@ -1095,8 +1095,8 @@ describe('SpeedDial', () => {
                 const speedDialInstance = contentTemplateFixture.debugElement.query(By.directive(SpeedDial)).componentInstance;
 
                 // @ContentChild('icon') should set iconTemplate
-                expect(speedDialInstance.iconTemplate).toBeDefined();
-                expect(speedDialInstance.iconTemplate?.constructor.name).toBe('TemplateRef');
+                expect(speedDialInstance.iconTemplate()).toBeDefined();
+                expect(speedDialInstance.iconTemplate()?.constructor.name).toBe('TemplateRef');
             });
         });
 
@@ -1122,9 +1122,9 @@ describe('SpeedDial', () => {
                 await contentTemplateFixture.whenStable();
 
                 const contentTemplateSpeedDial = contentTemplateFixture.debugElement.query(By.directive(SpeedDial)).componentInstance;
-                expect(contentTemplateSpeedDial.buttonTemplate).toBeDefined();
-                expect(contentTemplateSpeedDial.itemTemplate).toBeDefined();
-                expect(contentTemplateSpeedDial.iconTemplate).toBeDefined();
+                expect(contentTemplateSpeedDial.buttonTemplate()).toBeDefined();
+                expect(contentTemplateSpeedDial.itemTemplate()).toBeDefined();
+                expect(contentTemplateSpeedDial.iconTemplate()).toBeDefined();
             });
 
             it('should use default templates when custom ones are not provided', () => {
@@ -1383,7 +1383,7 @@ describe('SpeedDial', () => {
         });
 
         it('should handle missing container element gracefully', () => {
-            speedDialInstance.container = undefined as any;
+            (speedDialInstance as any).container = () => undefined as any;
 
             expect(() => {
                 speedDialInstance.isOutsideClicked(new Event('click'));

--- a/packages/optimus-ui/src/speeddial/speeddial.ts
+++ b/packages/optimus-ui/src/speeddial/speeddial.ts
@@ -3,8 +3,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -13,11 +11,12 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { find, findSingle, focus, hasClass, uuid } from '@openng/optimus-ui-utils';
@@ -44,7 +43,7 @@ const SPEED_DIAL_INSTANCE = new InjectionToken<SpeedDial>('SPEED_DIAL_INSTANCE')
     imports: [CommonModule, ButtonModule, Ripple, TooltipModule, RouterModule, PlusIcon, SharedModule, Bind],
     template: `
         <div #container [pBind]="ptm('root')" [class]="cn(cx('root'), className)" [style]="style" [ngStyle]="sx('root')">
-            @if (!buttonTemplate && !_buttonTemplate) {
+            @if (!buttonTemplate() && !_buttonTemplate) {
                 <button
                     type="button"
                     pButton
@@ -64,14 +63,14 @@ const SPEED_DIAL_INSTANCE = new InjectionToken<SpeedDial>('SPEED_DIAL_INSTANCE')
                     [pt]="ptm('pcButton')"
                     [unstyled]="unstyled()"
                 >
-                    @if (!buttonIconClass && !iconTemplate && !_iconTemplate) {
+                    @if (!buttonIconClass && !iconTemplate() && !_iconTemplate) {
                         <svg data-p-icon="plus" pButtonIcon [pt]="ptm('pcButton')['icon']" />
                     }
-                    <ng-container *ngTemplateOutlet="iconTemplate || _iconTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="iconTemplate() || _iconTemplate"></ng-container>
                 </button>
             }
-            @if (buttonTemplate || _buttonTemplate) {
-                <ng-container *ngTemplateOutlet="buttonTemplate || _buttonTemplate; context: { toggleCallback: onButtonClick.bind(this) }"></ng-container>
+            @if (buttonTemplate() || _buttonTemplate) {
+                <ng-container *ngTemplateOutlet="buttonTemplate() || _buttonTemplate; context: { toggleCallback: onButtonClick.bind(this) }"></ng-container>
             }
             <ul
                 #list
@@ -99,10 +98,10 @@ const SPEED_DIAL_INSTANCE = new InjectionToken<SpeedDial>('SPEED_DIAL_INSTANCE')
                         role="menuitem"
                         [attr.data-p-active]="isItemActive(id + '_' + i)"
                     >
-                        @if (itemTemplate || _itemTemplate) {
-                            <ng-container *ngTemplateOutlet="itemTemplate || _itemTemplate; context: { $implicit: item, index: i, toggleCallback: onItemClick.bind(this) }"></ng-container>
+                        @if (itemTemplate() || _itemTemplate) {
+                            <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: item, index: i, toggleCallback: onItemClick.bind(this) }"></ng-container>
                         }
-                        @if (!itemTemplate && !_itemTemplate) {
+                        @if (!itemTemplate() && !_itemTemplate) {
                             <button
                                 type="button"
                                 pButton
@@ -306,30 +305,30 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
      */
     @Output() onHide: EventEmitter<Event> = new EventEmitter<Event>();
 
-    @ViewChild('container') container: ElementRef | undefined;
+    readonly container = viewChild<ElementRef>('container');
 
-    @ViewChild('list') list: ElementRef | undefined;
+    readonly list = viewChild<ElementRef>('list');
     /**
      * Custom button template.
      * @param {SpeedDialButtonTemplateContext} context - button context.
      * @see {@link SpeedDialButtonTemplateContext}
      * @group Templates
      */
-    @ContentChild('button', { descendants: false }) buttonTemplate: TemplateRef<SpeedDialButtonTemplateContext> | undefined;
+    readonly buttonTemplate = contentChild<TemplateRef<SpeedDialButtonTemplateContext>>('button', { descendants: false });
     /**
      * Custom item template.
      * @param {SpeedDialItemTemplateContext} context - item context.
      * @see {@link SpeedDialItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<SpeedDialItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<SpeedDialItemTemplateContext>>('item', { descendants: false });
     /**
      * Custom icon template.
      * @group Templates
      */
-    @ContentChild('icon', { descendants: false }) iconTemplate: TemplateRef<void> | undefined;
+    readonly iconTemplate = contentChild<TemplateRef<void>>('icon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _buttonTemplate: TemplateRef<SpeedDialButtonTemplateContext> | undefined;
 
@@ -377,21 +376,22 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     onAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
             if (this.type !== 'linear') {
-                const button = <any>findSingle(this.container?.nativeElement, '[data-pc-name="pcbutton"]');
-                const firstItem = <any>findSingle(this.list?.nativeElement, '[data-pc-section="item"]');
+                const button = <any>findSingle(this.container()?.nativeElement, '[data-pc-name="pcbutton"]');
+                const list = this.list();
+                const firstItem = <any>findSingle(list?.nativeElement, '[data-pc-section="item"]');
 
                 if (button && firstItem) {
                     const wDiff = Math.abs(button.offsetWidth - firstItem.offsetWidth);
                     const hDiff = Math.abs(button.offsetHeight - firstItem.offsetHeight);
-                    this.list?.nativeElement.style.setProperty('--item-diff-x', `${wDiff / 2}px`);
-                    this.list?.nativeElement.style.setProperty('--item-diff-y', `${hDiff / 2}px`);
+                    list?.nativeElement.style.setProperty('--item-diff-x', `${wDiff / 2}px`);
+                    list?.nativeElement.style.setProperty('--item-diff-y', `${hDiff / 2}px`);
                 }
             }
         }
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'button':
                     this._buttonTemplate = item.template;
@@ -550,7 +550,8 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     }
 
     onEnterKey(event: any) {
-        const items = find(this.container?.nativeElement, '[data-pc-section="item"]');
+        const container = this.container();
+        const items = find(container?.nativeElement, '[data-pc-section="item"]');
         const itemIndex = [...items].findIndex((item) => item.id === this.focusedOptionIndex());
 
         if (itemIndex !== -1 && this.model && this.model[itemIndex]) {
@@ -558,7 +559,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
         }
         this.onBlur(event);
 
-        const buttonEl = <any>findSingle(this.container?.nativeElement, 'button');
+        const buttonEl = <any>findSingle(container?.nativeElement, 'button');
 
         buttonEl && focus(buttonEl);
     }
@@ -566,7 +567,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     onEscapeKey(event: KeyboardEvent) {
         this.hide();
 
-        const buttonEl = <any>findSingle(this.container?.nativeElement, 'button');
+        const buttonEl = <any>findSingle(this.container()?.nativeElement, 'button');
 
         buttonEl && focus(buttonEl);
     }
@@ -597,7 +598,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
 
     onTogglerArrowUp(event) {
         this.focused = true;
-        focus(this.list?.nativeElement);
+        focus(this.list()?.nativeElement);
 
         this.show();
         this.navigatePrevItem(event);
@@ -607,7 +608,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
 
     onTogglerArrowDown(event) {
         this.focused = true;
-        focus(this.list?.nativeElement);
+        focus(this.list()?.nativeElement);
 
         this.show();
         this.navigateNextItem(event);
@@ -632,7 +633,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     }
 
     findPrevOptionIndex(index) {
-        const items = find(this.container?.nativeElement, '[data-pc-section="item"]');
+        const items = find(this.container()?.nativeElement, '[data-pc-section="item"]');
 
         const filteredItems = [...items].filter((item) => !hasClass(findSingle(item, 'a')!, 'p-disabled'));
         const newIndex = index === -1 ? filteredItems[filteredItems.length - 1].id : index;
@@ -644,7 +645,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     }
 
     findNextOptionIndex(index) {
-        const items = find(this.container?.nativeElement, '[data-pc-section="item"]');
+        const items = find(this.container()?.nativeElement, '[data-pc-section="item"]');
         const filteredItems = [...items].filter((item) => !hasClass(findSingle(item, 'a')!, 'p-disabled'));
         const newIndex = index === -1 ? filteredItems[0].id : index;
         let matchedOptionIndex = filteredItems.findIndex((link) => link.getAttribute('id') === newIndex);
@@ -655,7 +656,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     }
 
     changeFocusedOptionIndex(index) {
-        const items = find(this.container?.nativeElement, '[data-pc-section="item"]');
+        const items = find(this.container()?.nativeElement, '[data-pc-section="item"]');
         const filteredItems = [...items].filter((item) => !hasClass(findSingle(item, 'a')!, 'p-disabled'));
 
         if (filteredItems[index]) {
@@ -741,7 +742,8 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     }
 
     isOutsideClicked(event: Event) {
-        return this.container && !(this.container.nativeElement.isSameNode(event.target) || this.container.nativeElement.contains(event.target) || this.isItemClicked);
+        const container = this.container();
+        return container && !(container.nativeElement.isSameNode(event.target) || container.nativeElement.contains(event.target) || this.isItemClicked);
     }
 
     bindDocumentClickListener() {

--- a/packages/optimus-ui/src/speeddial/speeddial.ts
+++ b/packages/optimus-ui/src/speeddial/speeddial.ts
@@ -305,9 +305,9 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
      */
     @Output() onHide: EventEmitter<Event> = new EventEmitter<Event>();
 
-    readonly container = viewChild<ElementRef>('container');
+    readonly container = viewChild.required<ElementRef>('container');
 
-    readonly list = viewChild<ElementRef>('list');
+    readonly list = viewChild.required<ElementRef>('list');
     /**
      * Custom button template.
      * @param {SpeedDialButtonTemplateContext} context - button context.
@@ -376,9 +376,9 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     onAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
             if (this.type !== 'linear') {
-                const button = <any>findSingle(this.container()?.nativeElement, '[data-pc-name="pcbutton"]');
+                const button = <any>findSingle(this.container().nativeElement, '[data-pc-name="pcbutton"]');
                 const list = this.list();
-                const firstItem = <any>findSingle(list?.nativeElement, '[data-pc-section="item"]');
+                const firstItem = <any>findSingle(list.nativeElement, '[data-pc-section="item"]');
 
                 if (button && firstItem) {
                     const wDiff = Math.abs(button.offsetWidth - firstItem.offsetWidth);
@@ -551,7 +551,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
 
     onEnterKey(event: any) {
         const container = this.container();
-        const items = find(container?.nativeElement, '[data-pc-section="item"]');
+        const items = find(container.nativeElement, '[data-pc-section="item"]');
         const itemIndex = [...items].findIndex((item) => item.id === this.focusedOptionIndex());
 
         if (itemIndex !== -1 && this.model && this.model[itemIndex]) {
@@ -567,7 +567,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     onEscapeKey(event: KeyboardEvent) {
         this.hide();
 
-        const buttonEl = <any>findSingle(this.container()?.nativeElement, 'button');
+        const buttonEl = <any>findSingle(this.container().nativeElement, 'button');
 
         buttonEl && focus(buttonEl);
     }
@@ -598,7 +598,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
 
     onTogglerArrowUp(event) {
         this.focused = true;
-        focus(this.list()?.nativeElement);
+        focus(this.list().nativeElement);
 
         this.show();
         this.navigatePrevItem(event);
@@ -608,7 +608,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
 
     onTogglerArrowDown(event) {
         this.focused = true;
-        focus(this.list()?.nativeElement);
+        focus(this.list().nativeElement);
 
         this.show();
         this.navigateNextItem(event);
@@ -633,7 +633,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     }
 
     findPrevOptionIndex(index) {
-        const items = find(this.container()?.nativeElement, '[data-pc-section="item"]');
+        const items = find(this.container().nativeElement, '[data-pc-section="item"]');
 
         const filteredItems = [...items].filter((item) => !hasClass(findSingle(item, 'a')!, 'p-disabled'));
         const newIndex = index === -1 ? filteredItems[filteredItems.length - 1].id : index;
@@ -645,7 +645,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     }
 
     findNextOptionIndex(index) {
-        const items = find(this.container()?.nativeElement, '[data-pc-section="item"]');
+        const items = find(this.container().nativeElement, '[data-pc-section="item"]');
         const filteredItems = [...items].filter((item) => !hasClass(findSingle(item, 'a')!, 'p-disabled'));
         const newIndex = index === -1 ? filteredItems[0].id : index;
         let matchedOptionIndex = filteredItems.findIndex((link) => link.getAttribute('id') === newIndex);
@@ -656,7 +656,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
     }
 
     changeFocusedOptionIndex(index) {
-        const items = find(this.container()?.nativeElement, '[data-pc-section="item"]');
+        const items = find(this.container().nativeElement, '[data-pc-section="item"]');
         const filteredItems = [...items].filter((item) => !hasClass(findSingle(item, 'a')!, 'p-disabled'));
 
         if (filteredItems[index]) {
@@ -743,7 +743,7 @@ export class SpeedDial extends BaseComponent<SpeedDialPassThrough> {
 
     isOutsideClicked(event: Event) {
         const container = this.container();
-        return container && !(container.nativeElement.isSameNode(event.target) || container.nativeElement.contains(event.target) || this.isItemClicked);
+        return !(container.nativeElement.isSameNode(event.target) || container.nativeElement.contains(event.target) || this.isItemClicked);
     }
 
     bindDocumentClickListener() {

--- a/packages/optimus-ui/src/splitbutton/splitbutton.test.ts
+++ b/packages/optimus-ui/src/splitbutton/splitbutton.test.ts
@@ -366,7 +366,7 @@ describe('SplitButton', () => {
         it('should render with correct structure', () => {
             expect(defaultButton).toBeTruthy();
             expect(dropdownButton).toBeTruthy();
-            expect(splitButtonInstance.menu).toBeTruthy();
+            expect(splitButtonInstance.menu()).toBeTruthy();
         });
 
         it('should generate unique aria id', () => {
@@ -390,7 +390,7 @@ describe('SplitButton', () => {
             await fixture.whenStable();
 
             expect(splitButtonInstance.model).toEqual(newModel);
-            expect(splitButtonInstance.menu?.model).toEqual(newModel);
+            expect(splitButtonInstance.menu()?.model).toEqual(newModel);
         });
 
         it('should update label property', async () => {
@@ -571,7 +571,7 @@ describe('SplitButton', () => {
             fixture.detectChanges();
 
             // Menu show may be async, check via onShow method instead
-            expect(splitButtonInstance.menu).toBeTruthy();
+            expect(splitButtonInstance.menu()).toBeTruthy();
         });
 
         it('should hide menu when default button is clicked', async () => {
@@ -637,7 +637,7 @@ describe('SplitButton', () => {
             const keydownEvent = new KeyboardEvent('keydown', { code: 'ArrowDown', bubbles: true });
             Object.defineProperty(keydownEvent, 'currentTarget', { value: dropdownButton, writable: false, configurable: true });
             const preventDefaultSpy = vi.spyOn(keydownEvent, 'preventDefault').mockImplementation(() => {});
-            const toggleSpy = vi.spyOn(splitButtonInstance.menu!, 'toggle').mockImplementation(() => {});
+            const toggleSpy = vi.spyOn(splitButtonInstance.menu()!, 'toggle').mockImplementation(() => {});
 
             splitButtonInstance.onDropdownButtonKeydown(keydownEvent);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -652,7 +652,7 @@ describe('SplitButton', () => {
             const keydownEvent = new KeyboardEvent('keydown', { code: 'ArrowUp', bubbles: true });
             Object.defineProperty(keydownEvent, 'currentTarget', { value: dropdownButton, writable: false, configurable: true });
             const preventDefaultSpy = vi.spyOn(keydownEvent, 'preventDefault').mockImplementation(() => {});
-            const toggleSpy = vi.spyOn(splitButtonInstance.menu!, 'toggle').mockImplementation(() => {});
+            const toggleSpy = vi.spyOn(splitButtonInstance.menu()!, 'toggle').mockImplementation(() => {});
 
             splitButtonInstance.onDropdownButtonKeydown(keydownEvent);
             await new Promise((resolve) => setTimeout(resolve, 100));

--- a/packages/optimus-ui/src/splitbutton/splitbutton.test.ts
+++ b/packages/optimus-ui/src/splitbutton/splitbutton.test.ts
@@ -986,7 +986,7 @@ describe('SplitButton', () => {
                 expect(() => splitButtonInstance.ngAfterContentInit()).not.toThrow();
 
                 // Test that contentTemplate property exists (ContentChild)
-                expect(splitButtonInstance.contentTemplate).toBeDefined();
+                expect(splitButtonInstance.contentTemplate()).toBeDefined();
 
                 // Verify content container is rendered
                 const buttonElements = contentTemplateFixture.debugElement.queryAll(By.css('button'));
@@ -1002,8 +1002,8 @@ describe('SplitButton', () => {
                 const splitButtonInstance = contentTemplateFixture.debugElement.query(By.directive(SplitButton)).componentInstance;
 
                 // @ContentChild('content') should set contentTemplate
-                expect(splitButtonInstance.contentTemplate).toBeDefined();
-                expect(splitButtonInstance.contentTemplate?.constructor.name).toBe('TemplateRef');
+                expect(splitButtonInstance.contentTemplate()).toBeDefined();
+                expect(splitButtonInstance.contentTemplate()?.constructor.name).toBe('TemplateRef');
             });
 
             it("should process dropdownIconTemplate from @ContentChild('dropdownicon')", async () => {
@@ -1015,8 +1015,8 @@ describe('SplitButton', () => {
                 const splitButtonInstance = contentTemplateFixture.debugElement.query(By.directive(SplitButton)).componentInstance;
 
                 // @ContentChild('dropdownicon') should set dropdownIconTemplate
-                expect(splitButtonInstance.dropdownIconTemplate).toBeDefined();
-                expect(splitButtonInstance.dropdownIconTemplate?.constructor.name).toBe('TemplateRef');
+                expect(splitButtonInstance.dropdownIconTemplate()).toBeDefined();
+                expect(splitButtonInstance.dropdownIconTemplate()?.constructor.name).toBe('TemplateRef');
             });
         });
 
@@ -1042,8 +1042,8 @@ describe('SplitButton', () => {
                 await contentTemplateFixture.whenStable();
 
                 const contentTemplateSplitButton = contentTemplateFixture.debugElement.query(By.directive(SplitButton)).componentInstance;
-                expect(contentTemplateSplitButton.contentTemplate).toBeDefined();
-                expect(contentTemplateSplitButton.dropdownIconTemplate).toBeDefined();
+                expect(contentTemplateSplitButton.contentTemplate()).toBeDefined();
+                expect(contentTemplateSplitButton.dropdownIconTemplate()).toBeDefined();
             });
 
             it('should use default templates when custom ones are not provided', () => {

--- a/packages/optimus-ui/src/splitbutton/splitbutton.ts
+++ b/packages/optimus-ui/src/splitbutton/splitbutton.ts
@@ -349,8 +349,6 @@ export class SplitButton extends BaseComponent<SplitButtonPassThrough> {
      */
     @Output() onDropdownClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
-    readonly buttonViewChild = viewChild<ElementRef>('defaultbtn');
-
     readonly menu = viewChild<TieredMenu>('menu');
     /**
      * Custom content template.

--- a/packages/optimus-ui/src/splitbutton/splitbutton.ts
+++ b/packages/optimus-ui/src/splitbutton/splitbutton.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     inject,
@@ -15,11 +13,12 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { MotionOptions } from '@openng/optimus-ui-motion';
 import { uuid } from '@openng/optimus-ui-utils';
@@ -48,7 +47,7 @@ type SplitButtonIconPosition = 'left' | 'right';
     standalone: true,
     imports: [CommonModule, ButtonDirective, TieredMenu, AutoFocus, ChevronDownIcon, Ripple, TooltipModule, SharedModule],
     template: `
-        @if (contentTemplate || _contentTemplate) {
+        @if (contentTemplate() || _contentTemplate) {
             <button
                 [class]="cx('pcButton')"
                 type="button"
@@ -71,7 +70,7 @@ type SplitButtonIconPosition = 'left' | 'right';
                 [pt]="ptm('pcButton')"
                 [unstyled]="unstyled()"
             >
-                <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate"></ng-container>
             </button>
         } @else {
             <button
@@ -122,10 +121,10 @@ type SplitButtonIconPosition = 'left' | 'right';
                 <span [class]="dropdownIcon"></span>
             }
             @if (!dropdownIcon) {
-                @if (!dropdownIconTemplate && !_dropdownIconTemplate) {
+                @if (!dropdownIconTemplate() && !_dropdownIconTemplate) {
                     <svg data-p-icon="chevron-down" />
                 }
-                <ng-template *ngTemplateOutlet="dropdownIconTemplate || _dropdownIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="dropdownIconTemplate() || _dropdownIconTemplate"></ng-template>
             }
         </button>
         <p-tieredmenu
@@ -350,21 +349,21 @@ export class SplitButton extends BaseComponent<SplitButtonPassThrough> {
      */
     @Output() onDropdownClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
-    @ViewChild('defaultbtn') buttonViewChild: ElementRef | undefined;
+    readonly buttonViewChild = viewChild<ElementRef>('defaultbtn');
 
-    @ViewChild('menu') menu: TieredMenu | undefined;
+    readonly menu = viewChild<TieredMenu>('menu');
     /**
      * Custom content template.
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: TemplateRef<void> | undefined;
+    readonly contentTemplate = contentChild<TemplateRef<void>>('content', { descendants: false });
     /**
      * Custom dropdown icon template.
      * @group Templates
      **/
-    @ContentChild('dropdownicon', { descendants: false }) dropdownIconTemplate: TemplateRef<void> | undefined;
+    readonly dropdownIconTemplate = contentChild<TemplateRef<void>>('dropdownicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     ariaId: string | undefined;
 
@@ -385,7 +384,7 @@ export class SplitButton extends BaseComponent<SplitButtonPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;
@@ -404,12 +403,12 @@ export class SplitButton extends BaseComponent<SplitButtonPassThrough> {
 
     onDefaultButtonClick(event: MouseEvent) {
         this.onClick?.emit(event);
-        this.menu?.hide();
+        this.menu()?.hide();
     }
 
     onDropdownButtonClick(event?: MouseEvent) {
         this.onDropdownClick.emit(event);
-        this.menu?.toggle({ currentTarget: this.el?.nativeElement, relativeAlign: this.$appendTo() == 'self' });
+        this.menu()?.toggle({ currentTarget: this.el?.nativeElement, relativeAlign: this.$appendTo() == 'self' });
     }
 
     onDropdownButtonKeydown(event: KeyboardEvent) {

--- a/packages/optimus-ui/src/splitbutton/splitbutton.ts
+++ b/packages/optimus-ui/src/splitbutton/splitbutton.ts
@@ -349,7 +349,7 @@ export class SplitButton extends BaseComponent<SplitButtonPassThrough> {
      */
     @Output() onDropdownClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
-    readonly menu = viewChild<TieredMenu>('menu');
+    readonly menu = viewChild.required<TieredMenu>('menu');
     /**
      * Custom content template.
      * @group Templates
@@ -401,12 +401,12 @@ export class SplitButton extends BaseComponent<SplitButtonPassThrough> {
 
     onDefaultButtonClick(event: MouseEvent) {
         this.onClick?.emit(event);
-        this.menu()?.hide();
+        this.menu().hide();
     }
 
     onDropdownButtonClick(event?: MouseEvent) {
         this.onDropdownClick.emit(event);
-        this.menu()?.toggle({ currentTarget: this.el?.nativeElement, relativeAlign: this.$appendTo() == 'self' });
+        this.menu().toggle({ currentTarget: this.el?.nativeElement, relativeAlign: this.$appendTo() == 'self' });
     }
 
     onDropdownButtonKeydown(event: KeyboardEvent) {

--- a/packages/optimus-ui/src/splitter/splitter.test.ts
+++ b/packages/optimus-ui/src/splitter/splitter.test.ts
@@ -4,6 +4,8 @@ import { By } from '@angular/platform-browser';
 
 import { Splitter } from './splitter';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1029,5 +1031,45 @@ describe('Splitter', () => {
             expect(hostEl.nativeElement.className).toContain('SET_INPUT_CLASS');
             expect(gutter.nativeElement.className).toContain('GUTTER_SET_INPUT');
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Splitter, SharedModule],
+    template: `
+        <p-splitter>
+            <ng-template pTemplate="panel">
+                <p-splitter>
+                    <ng-template pTemplate="panel">inner</ng-template>
+                </p-splitter>
+            </ng-template>
+        </p-splitter>
+    `
+})
+class SplitterQueryApiHostComponent {}
+
+describe('Splitter Signal Query API', () => {
+    it('should collect panel templates and detect a nested splitter', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [SplitterQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(SplitterQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const splitters = fixture.debugElement.queryAll(By.directive(Splitter));
+        expect(splitters.length).toBe(2);
+        const outer = splitters[0].componentInstance;
+        const inner = splitters[1].componentInstance;
+        expect(outer.templates().some((t: any) => t.getType() === 'panel')).toBe(true);
+        expect(inner.splitter()).toBeUndefined();
+        expect(inner.nestedState()).toBeUndefined();
     });
 });

--- a/packages/optimus-ui/src/splitter/splitter.ts
+++ b/packages/optimus-ui/src/splitter/splitter.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, contentChild, ContentChildren, ElementRef, EventEmitter, forwardRef, inject, InjectionToken, Input, NgModule, numberAttribute, Output, QueryList, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, contentChild, ElementRef, EventEmitter, forwardRef, inject, InjectionToken, Input, NgModule, numberAttribute, Output, ViewEncapsulation, contentChildren } from '@angular/core';
 import { addClass, getHeight, getOuterHeight, getOuterWidth, getWidth, hasClass, isRTL, removeClass } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -152,9 +152,9 @@ export class Splitter extends BaseComponent<SplitterPassThrough> {
      */
     @Output() onResizeStart: EventEmitter<SplitterResizeStartEvent> = new EventEmitter<SplitterResizeStartEvent>();
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
-    @ContentChildren('panel', { descendants: false }) panelChildren!: QueryList<ElementRef>;
+    readonly panelChildren = contentChildren<ElementRef>('panel');
 
     splitter = contentChild(forwardRef(() => Splitter));
 
@@ -197,8 +197,9 @@ export class Splitter extends BaseComponent<SplitterPassThrough> {
     _componentStyle = inject(SplitterStyle);
 
     onAfterContentInit() {
-        if (this.templates && this.templates.toArray().length > 0) {
-            this.templates.forEach((item) => {
+        const templates = this.templates();
+        if (templates && templates.length > 0) {
+            templates.forEach((item) => {
                 switch (item.getType()) {
                     case 'panel':
                         this.panels.push(item.template);
@@ -209,8 +210,9 @@ export class Splitter extends BaseComponent<SplitterPassThrough> {
                 }
             });
         }
-        if (this.panelChildren && this.panelChildren.toArray().length > 0) {
-            this.panelChildren.forEach((item) => {
+        const panelChildren = this.panelChildren();
+        if (panelChildren && panelChildren.length > 0) {
+            panelChildren.forEach((item) => {
                 this.panels.push(item);
             });
         }

--- a/packages/optimus-ui/src/stepper/stepper.test.ts
+++ b/packages/optimus-ui/src/stepper/stepper.test.ts
@@ -4,6 +4,9 @@ import { By } from '@angular/platform-browser';
 
 import { Step, StepItem, StepList, StepPanel, StepPanels, Stepper } from './stepper';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
+import { StepperModule } from './stepper';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -787,5 +790,80 @@ describe('Stepper', () => {
 
             expect(stepperEl.nativeElement.className).toContain('SETINPUT_ROOT_CLASS');
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [StepperModule, SharedModule],
+    template: `
+        <p-stepper [value]="1">
+            <p-step-list>
+                <p-step [value]="1">One</p-step>
+                <p-step [value]="2">Two</p-step>
+            </p-step-list>
+            <p-step-panels>
+                <p-step-panel [value]="1">P1</p-step-panel>
+            </p-step-panels>
+        </p-stepper>
+    `
+})
+class StepperListQueryApiHostComponent {}
+
+@Component({
+    standalone: true,
+    imports: [StepperModule, SharedModule],
+    template: `
+        <p-stepper [value]="1">
+            <p-step-item [value]="1">
+                <p-step [value]="1">One</p-step>
+                <p-step-panel [value]="1">P1</p-step-panel>
+            </p-step-item>
+        </p-stepper>
+    `
+})
+class StepperItemQueryApiHostComponent {}
+
+describe('Stepper Signal Query API', () => {
+    it('should resolve StepList and Stepper content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [StepperListQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(StepperListQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const stepper = fixture.debugElement.query(By.directive(Stepper)).componentInstance;
+        expect(stepper.stepList()).toBeDefined();
+
+        const stepList = fixture.debugElement.query(By.directive(StepList)).componentInstance;
+        expect(stepList.steps().length).toBe(2);
+
+        const step = fixture.debugElement.query(By.directive(Step)).componentInstance;
+        expect(Array.isArray(step.templates())).toBe(true);
+
+        const stepPanel = fixture.debugElement.query(By.directive(StepPanel)).componentInstance;
+        expect(Array.isArray(stepPanel.templates())).toBe(true);
+    });
+
+    it('should resolve StepItem content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [StepperItemQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(StepperItemQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const stepItem = fixture.debugElement.query(By.directive(StepItem)).componentInstance;
+        expect(stepItem.step()).toBeDefined();
+        expect(stepItem.stepPanel()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/stepper/stepper.ts
+++ b/packages/optimus-ui/src/stepper/stepper.ts
@@ -287,7 +287,7 @@ export class Step extends BaseComponent<StepPassThrough> {
      * @type {TemplateRef<StepContentTemplateContext>}
      * @group Templates
      */
-    readonly content = contentChild.required<TemplateRef<StepContentTemplateContext>>('content', { descendants: false });
+    readonly content = contentChild<TemplateRef<StepContentTemplateContext>>('content', { descendants: false });
 
     readonly templates = contentChildren(PrimeTemplate);
 
@@ -395,7 +395,7 @@ export class StepPanel extends BaseComponent<StepPanelPassThrough> {
      * @see {@link StepPanelContentTemplateContext}
      * @group Templates
      */
-    readonly contentTemplate = contentChild.required<TemplateRef<StepPanelContentTemplateContext>>('content');
+    readonly contentTemplate = contentChild<TemplateRef<StepPanelContentTemplateContext>>('content');
 
     readonly templates = contentChildren(PrimeTemplate);
 

--- a/packages/optimus-ui/src/stepper/stepper.ts
+++ b/packages/optimus-ui/src/stepper/stepper.ts
@@ -4,8 +4,6 @@ import {
     Component,
     computed,
     contentChild,
-    ContentChild,
-    ContentChildren,
     contentChildren,
     effect,
     forwardRef,
@@ -17,7 +15,6 @@ import {
     model,
     ModelSignal,
     NgModule,
-    QueryList,
     signal,
     TemplateRef,
     ViewEncapsulation
@@ -198,7 +195,7 @@ export class StepItem extends BaseComponent<StepItemPassThrough> {
     standalone: true,
     imports: [CommonModule, StepperSeparator, SharedModule, BindModule],
     template: `
-        @if (!content && !_contentTemplate) {
+        @if (!content() && !_contentTemplate) {
             <button
                 [attr.id]="id()"
                 [class]="cx('header')"
@@ -219,7 +216,7 @@ export class StepItem extends BaseComponent<StepItemPassThrough> {
                 <p-stepper-separator />
             }
         } @else {
-            <ng-container *ngTemplateOutlet="content || _contentTemplate; context: { activateCallback: onStepClick.bind(this), value: value(), active: active() }"></ng-container>
+            <ng-container *ngTemplateOutlet="content() || _contentTemplate; context: { activateCallback: onStepClick.bind(this), value: value(), active: active() }"></ng-container>
             @if (isSeparatorVisible()) {
                 <p-stepper-separator />
             }
@@ -290,16 +287,16 @@ export class Step extends BaseComponent<StepPassThrough> {
      * @type {TemplateRef<StepContentTemplateContext>}
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) content: TemplateRef<StepContentTemplateContext>;
+    readonly content = contentChild.required<TemplateRef<StepContentTemplateContext>>('content', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _contentTemplate: TemplateRef<any> | undefined;
 
     _componentStyle = inject(StepStyle);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;
@@ -328,7 +325,7 @@ export class Step extends BaseComponent<StepPassThrough> {
                     <p-stepper-separator />
                 }
                 <div [class]="cx('content')" [pBind]="ptm('content')">
-                    <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { activateCallback: updateValue.bind(this), value: value(), active: active() }"></ng-container>
+                    <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { activateCallback: updateValue.bind(this), value: value(), active: active() }"></ng-container>
                 </div>
             </div>
         </p-motion>
@@ -398,16 +395,16 @@ export class StepPanel extends BaseComponent<StepPanelPassThrough> {
      * @see {@link StepPanelContentTemplateContext}
      * @group Templates
      */
-    @ContentChild('content') contentTemplate: TemplateRef<StepPanelContentTemplateContext>;
+    readonly contentTemplate = contentChild.required<TemplateRef<StepPanelContentTemplateContext>>('content');
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _contentTemplate: TemplateRef<any> | undefined;
 
     _componentStyle = inject(StepPanelStyle);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/steps/steps.test.ts
+++ b/packages/optimus-ui/src/steps/steps.test.ts
@@ -1,0 +1,30 @@
+import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { Steps } from './steps';
+
+@Component({
+    standalone: true,
+    imports: [Steps],
+    template: ` <p-steps [model]="model" [readonly]="false"></p-steps> `
+})
+class StepsQueryApiHostComponent {
+    model = [{ label: 'One' }, { label: 'Two' }];
+}
+
+describe('Steps Signal Query API', () => {
+    it('should resolve the list viewChild after render', async () => {
+        TestBed.configureTestingModule({
+            imports: [StepsQueryApiHostComponent],
+            providers: [provideRouter([]), provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(StepsQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Steps)).componentInstance;
+        expect(instance.listViewChild().nativeElement).toBeDefined();
+    });
+});

--- a/packages/optimus-ui/src/steps/steps.ts
+++ b/packages/optimus-ui/src/steps/steps.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, inject, Input, NgModule, numberAttribute, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, inject, Input, NgModule, numberAttribute, OnDestroy, OnInit, Output, ViewEncapsulation, viewChild } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { find, findSingle } from '@openng/optimus-ui-utils';
 import { MenuItem, SharedModule } from '@openng/optimus-ui/api';
@@ -131,7 +131,7 @@ export class Steps extends BaseComponent {
      */
     @Output() activeIndexChange: EventEmitter<number> = new EventEmitter<number>();
 
-    @ViewChild('list', { static: false }) listViewChild: Nullable<ElementRef>;
+    readonly listViewChild = viewChild<Nullable<ElementRef>>('list');
 
     router = inject(Router);
 
@@ -194,7 +194,7 @@ export class Steps extends BaseComponent {
 
             case 'Tab':
                 if (i !== (this.activeIndex ?? -1)) {
-                    const siblings = <any>find(this.listViewChild?.nativeElement, '[data-pc-section="menuitem"]');
+                    const siblings = <any>find(this.listViewChild()?.nativeElement, '[data-pc-section="menuitem"]');
                     siblings[i].children[0].tabIndex = '-1';
                     siblings[this.activeIndex ?? 0].children[0].tabIndex = '0';
                 }
@@ -249,13 +249,13 @@ export class Steps extends BaseComponent {
     }
 
     findFirstItem() {
-        const firstSibling = findSingle(this.listViewChild?.nativeElement, '[data-pc-section="menuitem"]');
+        const firstSibling = findSingle(this.listViewChild()?.nativeElement, '[data-pc-section="menuitem"]');
 
         return firstSibling ? firstSibling.children[0] : null;
     }
 
     findLastItem() {
-        const siblings = find(this.listViewChild?.nativeElement, '[data-pc-section="menuitem"]');
+        const siblings = find(this.listViewChild()?.nativeElement, '[data-pc-section="menuitem"]');
 
         return siblings ? siblings[siblings.length - 1].children[0] : null;
     }

--- a/packages/optimus-ui/src/steps/steps.ts
+++ b/packages/optimus-ui/src/steps/steps.ts
@@ -5,7 +5,6 @@ import { find, findSingle } from '@openng/optimus-ui-utils';
 import { MenuItem, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent } from '@openng/optimus-ui/basecomponent';
 import { TooltipModule } from '@openng/optimus-ui/tooltip';
-import { Nullable } from '@openng/optimus-ui/ts-helpers';
 import { Subscription } from 'rxjs';
 import { StepsStyle } from './style/stepsstyle';
 
@@ -131,7 +130,7 @@ export class Steps extends BaseComponent {
      */
     @Output() activeIndexChange: EventEmitter<number> = new EventEmitter<number>();
 
-    readonly listViewChild = viewChild<Nullable<ElementRef>>('list');
+    readonly listViewChild = viewChild.required<ElementRef>('list');
 
     router = inject(Router);
 
@@ -194,7 +193,7 @@ export class Steps extends BaseComponent {
 
             case 'Tab':
                 if (i !== (this.activeIndex ?? -1)) {
-                    const siblings = <any>find(this.listViewChild()?.nativeElement, '[data-pc-section="menuitem"]');
+                    const siblings = <any>find(this.listViewChild().nativeElement, '[data-pc-section="menuitem"]');
                     siblings[i].children[0].tabIndex = '-1';
                     siblings[this.activeIndex ?? 0].children[0].tabIndex = '0';
                 }
@@ -249,13 +248,13 @@ export class Steps extends BaseComponent {
     }
 
     findFirstItem() {
-        const firstSibling = findSingle(this.listViewChild()?.nativeElement, '[data-pc-section="menuitem"]');
+        const firstSibling = findSingle(this.listViewChild().nativeElement, '[data-pc-section="menuitem"]');
 
         return firstSibling ? firstSibling.children[0] : null;
     }
 
     findLastItem() {
-        const siblings = find(this.listViewChild()?.nativeElement, '[data-pc-section="menuitem"]');
+        const siblings = find(this.listViewChild().nativeElement, '[data-pc-section="menuitem"]');
 
         return siblings ? siblings[siblings.length - 1].children[0] : null;
     }

--- a/packages/optimus-ui/src/table/table.test.ts
+++ b/packages/optimus-ui/src/table/table.test.ts
@@ -6,7 +6,7 @@ import { By } from '@angular/platform-browser';
 
 import { SharedModule, SortMeta } from '@openng/optimus-ui/api';
 import { Select } from '@openng/optimus-ui/select';
-import { CellEditor, Table, TableModule, TableService } from './table';
+import { CellEditor, ColumnFilter, Table, TableModule, TableRadioButton, TableService } from './table';
 
 describe('Table', () => {
     let component: Table;
@@ -1729,5 +1729,212 @@ describe('Table', () => {
             expect(cellEditor.editableRow).toBeNull();
             expect(cellEditor.editing).toBe(false);
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [TableModule, SharedModule],
+    template: `
+        <p-table [value]="rows" [paginator]="true" [rows]="2" [resizableColumns]="true" [reorderableColumns]="true">
+            <ng-template #header>
+                <tr>
+                    <th>Name</th>
+                </tr>
+            </ng-template>
+            <ng-template #body let-row>
+                <tr>
+                    <td>{{ row.name }}</td>
+                </tr>
+            </ng-template>
+            <ng-template #colgroup>
+                <colgroup>
+                    <col />
+                </colgroup>
+            </ng-template>
+            <ng-template #loadingbody>
+                <tr>
+                    <td>loading…</td>
+                </tr>
+            </ng-template>
+            <ng-template #footergrouped>
+                <tr>
+                    <td>fg</td>
+                </tr>
+            </ng-template>
+            <ng-template #expandedrow let-row>
+                <tr>
+                    <td>{{ row.name }} expanded</td>
+                </tr>
+            </ng-template>
+            <ng-template #groupheader>
+                <tr>
+                    <td>gh</td>
+                </tr>
+            </ng-template>
+            <ng-template #groupfooter>
+                <tr>
+                    <td>gf</td>
+                </tr>
+            </ng-template>
+            <ng-template #frozenexpandedrow>
+                <tr>
+                    <td>fe</td>
+                </tr>
+            </ng-template>
+            <ng-template #frozenbody>
+                <tr>
+                    <td>fb</td>
+                </tr>
+            </ng-template>
+            <ng-template #emptymessage>
+                <tr>
+                    <td>empty</td>
+                </tr>
+            </ng-template>
+            <ng-template #paginatorleft>L</ng-template>
+            <ng-template #paginatorright>R</ng-template>
+            <ng-template #paginatordropdownitem let-item>{{ item?.label }}</ng-template>
+            <ng-template #loadingicon>…</ng-template>
+            <ng-template #reorderindicatorupicon>^</ng-template>
+            <ng-template #reorderindicatordownicon>v</ng-template>
+            <ng-template #sorticon let-sortOrder>{{ sortOrder }}</ng-template>
+            <ng-template #checkboxicon>x</ng-template>
+            <ng-template #headercheckboxicon>hx</ng-template>
+            <ng-template #paginatordropdownicon>pd</ng-template>
+            <ng-template #paginatorfirstpagelinkicon>first</ng-template>
+            <ng-template #paginatorlastpagelinkicon>last</ng-template>
+            <ng-template #paginatorpreviouspagelinkicon>prev</ng-template>
+            <ng-template #paginatornextpagelinkicon>next</ng-template>
+            <ng-template pTemplate="caption">caption</ng-template>
+        </p-table>
+    `
+})
+class TableQueryApiHostComponent {
+    rows = [{ name: 'a' }, { name: 'b' }, { name: 'c' }];
+}
+
+describe('Table Signal Query API', () => {
+    let instance: Table;
+    let fixture: ComponentFixture<TableQueryApiHostComponent>;
+
+    beforeEach(async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [TableQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection()]
+        });
+        fixture = TestBed.createComponent(TableQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        instance = fixture.debugElement.query(By.directive(Table)).componentInstance;
+    });
+
+    it('should resolve all contentChild template hooks', () => {
+        const hooks = [
+            '_colGroupTemplate',
+            '_loadingBodyTemplate',
+            '_footerGroupedTemplate',
+            '_expandedRowTemplate',
+            '_groupHeaderTemplate',
+            '_groupFooterTemplate',
+            '_frozenExpandedRowTemplate',
+            '_frozenBodyTemplate',
+            '_emptyMessageTemplate',
+            '_paginatorLeftTemplate',
+            '_paginatorRightTemplate',
+            '_paginatorDropdownItemTemplate',
+            '_loadingIconTemplate',
+            '_reorderIndicatorUpIconTemplate',
+            '_reorderIndicatorDownIconTemplate',
+            '_sortIconTemplate',
+            '_checkboxIconTemplate',
+            '_headerCheckboxIconTemplate',
+            '_paginatorDropdownIconTemplate',
+            '_paginatorFirstPageLinkIconTemplate',
+            '_paginatorLastPageLinkIconTemplate',
+            '_paginatorPreviousPageLinkIconTemplate',
+            '_paginatorNextPageLinkIconTemplate'
+        ];
+        for (const hook of hooks) {
+            expect((instance as any)[hook](), `${hook} should resolve`).toBeDefined();
+        }
+    });
+
+    it('should collect pTemplate directives via the _templates contentChildren query', () => {
+        const templates = (instance as any)._templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.some((t: any) => t.getType() === 'caption')).toBe(true);
+    });
+
+    it('should resolve structural viewChild queries after render', () => {
+        expect(instance.wrapperViewChild().nativeElement).toBeDefined();
+        expect(instance.tableViewChild()?.nativeElement).toBeDefined();
+        expect(instance.resizeHelperViewChild()?.nativeElement).toBeDefined();
+        expect(instance.reorderIndicatorUpViewChild()?.nativeElement).toBeDefined();
+        expect(instance.reorderIndicatorDownViewChild()?.nativeElement).toBeDefined();
+    });
+
+    it('should leave the scroller viewChild unresolved when virtual scrolling is off', () => {
+        expect(instance.scroller()).toBeUndefined();
+    });
+});
+
+@Component({
+    standalone: true,
+    imports: [TableModule, SharedModule, FormsModule],
+    template: `
+        <p-table [value]="rows" dataKey="name" [(selection)]="selection">
+            <ng-template #header>
+                <tr>
+                    <th>
+                        Name
+                        <p-columnFilter field="name" matchMode="contains" display="menu">
+                            <ng-template #filtericon>fi</ng-template>
+                            <ng-template #removeruleicon>rri</ng-template>
+                            <ng-template #addruleicon>ari</ng-template>
+                        </p-columnFilter>
+                    </th>
+                </tr>
+            </ng-template>
+            <ng-template #body let-row>
+                <tr>
+                    <td><p-tableRadioButton [value]="row"></p-tableRadioButton>{{ row.name }}</td>
+                </tr>
+            </ng-template>
+        </p-table>
+    `
+})
+class TableFilterQueryApiHostComponent {
+    rows = [{ name: 'a' }];
+    selection: any = null;
+}
+
+describe('Table internals Signal Query API', () => {
+    it('should resolve ColumnFilter and TableRadioButton queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [TableFilterQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection()]
+        });
+        const fixture = TestBed.createComponent(TableFilterQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const cf = fixture.debugElement.query(By.directive(ColumnFilter)).componentInstance;
+        expect(cf.filterIconTemplate()).toBeDefined();
+        expect(cf.removeRuleIconTemplate()).toBeDefined();
+        expect(cf.addRuleIconTemplate()).toBeDefined();
+        expect(Array.isArray(cf._templates())).toBe(true);
+        expect(cf.icon()).toBeDefined();
+        // the clear button lives in the filter overlay menu, which is closed by default
+        expect(cf.clearButtonViewChild()).toBeUndefined();
+
+        const rb = fixture.debugElement.query(By.directive(TableRadioButton)).componentInstance;
+        expect(rb.inputViewChild()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/table/table.ts
+++ b/packages/optimus-ui/src/table/table.ts
@@ -5,8 +5,6 @@ import {
     ChangeDetectorRef,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     Directive,
     ElementRef,
     EventEmitter,
@@ -24,8 +22,10 @@ import {
     signal,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChildren,
+    contentChild
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
@@ -134,20 +134,20 @@ export class TableService {
                     <i [class]="cn(cx('loadingIcon'), loadingIcon)" [pBind]="ptm('loadingIcon')"></i>
                 }
                 @if (!loadingIcon) {
-                    @if (!loadingIconTemplate && !_loadingIconTemplate) {
+                    @if (!loadingIconTemplate && !_loadingIconTemplate()) {
                         <svg data-p-icon="spinner" [spin]="true" [class]="cx('loadingIcon')" [pBind]="ptm('loadingIcon')" />
                     }
-                    @if (loadingIconTemplate || _loadingIconTemplate) {
+                    @if (loadingIconTemplate || _loadingIconTemplate()) {
                         <span [class]="cx('loadingIcon')" [pBind]="ptm('loadingIcon')">
-                            <ng-template *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate"></ng-template>
+                            <ng-template *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate()"></ng-template>
                         </span>
                     }
                 }
             </div>
         }
-        @if (captionTemplate || _captionTemplate) {
+        @if (captionTemplate || _captionTemplate()) {
             <div [class]="cx('header')" [pBind]="ptm('header')">
-                <ng-container *ngTemplateOutlet="captionTemplate || _captionTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="captionTemplate || _captionTemplate()"></ng-container>
             </div>
         }
         @if (paginator && (paginatorPosition === 'top' || paginatorPosition == 'both')) {
@@ -159,13 +159,13 @@ export class TableService {
                 [alwaysShow]="alwaysShowPaginator"
                 (onPageChange)="onPageChange($event)"
                 [rowsPerPageOptions]="rowsPerPageOptions"
-                [templateLeft]="paginatorLeftTemplate || _paginatorLeftTemplate"
-                [templateRight]="paginatorRightTemplate || _paginatorRightTemplate"
+                [templateLeft]="paginatorLeftTemplate || _paginatorLeftTemplate()"
+                [templateRight]="paginatorRightTemplate || _paginatorRightTemplate()"
                 [appendTo]="paginatorDropdownAppendTo"
                 [dropdownScrollHeight]="paginatorDropdownScrollHeight"
                 [currentPageReportTemplate]="currentPageReportTemplate"
                 [showFirstLastIcon]="showFirstLastIcon"
-                [dropdownItemTemplate]="paginatorDropdownItemTemplate || _paginatorDropdownItemTemplate"
+                [dropdownItemTemplate]="paginatorDropdownItemTemplate || _paginatorDropdownItemTemplate()"
                 [showCurrentPageReport]="showCurrentPageReport"
                 [showJumpToPageDropdown]="showJumpToPageDropdown"
                 [showJumpToPageInput]="showJumpToPageInput"
@@ -175,29 +175,29 @@ export class TableService {
                 [pt]="ptm('pcPaginator')"
                 [unstyled]="unstyled()"
             >
-                @if (paginatorDropdownIconTemplate || _paginatorDropdownIconTemplate) {
+                @if (paginatorDropdownIconTemplate || _paginatorDropdownIconTemplate()) {
                     <ng-template pTemplate="dropdownicon">
-                        <ng-container *ngTemplateOutlet="paginatorDropdownIconTemplate || _paginatorDropdownIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorDropdownIconTemplate || _paginatorDropdownIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate) {
+                @if (paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate()) {
                     <ng-template pTemplate="firstpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate) {
+                @if (paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate()) {
                     <ng-template pTemplate="previouspagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate) {
+                @if (paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate()) {
                     <ng-template pTemplate="lastpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate) {
+                @if (paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate()) {
                     <ng-template pTemplate="nextpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
             </p-paginator>
@@ -222,7 +222,7 @@ export class TableService {
                     (onLazyLoad)="onLazyItemLoad($event)"
                     [loaderDisabled]="true"
                     [showSpacer]="false"
-                    [showLoader]="loadingBodyTemplate || _loadingBodyTemplate"
+                    [showLoader]="loadingBodyTemplate || _loadingBodyTemplate()"
                     [options]="virtualScrollOptions"
                     [pt]="ptm('virtualScroller')"
                 >
@@ -253,18 +253,18 @@ export class TableService {
 
             <ng-template #buildInTable let-items let-scrollerOptions="options">
                 <table #table role="table" [class]="cn(cx('table'), tableStyleClass)" [pBind]="ptm('table')" [style]="tableStyle" [attr.id]="id + '-table'">
-                    <ng-container *ngTemplateOutlet="colGroupTemplate || _colGroupTemplate; context: { $implicit: scrollerOptions.columns }"></ng-container>
+                    <ng-container *ngTemplateOutlet="colGroupTemplate || _colGroupTemplate(); context: { $implicit: scrollerOptions.columns }"></ng-container>
                     <thead role="rowgroup" #thead [class]="cx('thead')" [ngStyle]="sx('thead')" [pBind]="ptm('thead')">
                         <ng-container
                             *ngTemplateOutlet="
-                                headerGroupedTemplate || headerTemplate || _headerTemplate;
+                                headerGroupedTemplate || headerTemplate || _headerTemplate();
                                 context: {
                                     $implicit: scrollerOptions.columns
                                 }
                             "
                         ></ng-container>
                     </thead>
-                    @if (frozenValue || frozenBodyTemplate || _frozenBodyTemplate) {
+                    @if (frozenValue || frozenBodyTemplate || _frozenBodyTemplate()) {
                         <tbody
                             role="rowgroup"
                             [class]="cx('tbody')"
@@ -272,7 +272,7 @@ export class TableService {
                             [value]="frozenValue"
                             [frozenRows]="true"
                             [pTableBody]="scrollerOptions.columns"
-                            [pTableBodyTemplate]="frozenBodyTemplate || _frozenBodyTemplate"
+                            [pTableBodyTemplate]="frozenBodyTemplate || _frozenBodyTemplate()"
                             [unstyled]="unstyled()"
                             [frozen]="true"
                             [attr.data-p-virtualscroll]="virtualScroll"
@@ -285,7 +285,7 @@ export class TableService {
                         [style]="scrollerOptions.contentStyle"
                         [value]="dataToRender(scrollerOptions.rows)"
                         [pTableBody]="scrollerOptions.columns"
-                        [pTableBodyTemplate]="bodyTemplate || _bodyTemplate"
+                        [pTableBodyTemplate]="bodyTemplate || _bodyTemplate()"
                         [scrollerOptions]="scrollerOptions"
                         [unstyled]="unstyled()"
                         [attr.data-p-virtualscroll]="virtualScroll"
@@ -298,11 +298,11 @@ export class TableService {
                             [pBind]="ptm('virtualScrollerSpacer')"
                         ></tbody>
                     }
-                    @if (footerGroupedTemplate || footerTemplate || _footerTemplate || _footerGroupedTemplate) {
+                    @if (footerGroupedTemplate || footerTemplate || _footerTemplate() || _footerGroupedTemplate()) {
                         <tfoot role="rowgroup" #tfoot [ngClass]="cx('footer')" [ngStyle]="sx('tfoot')" [pBind]="ptm('tfoot')">
                             <ng-container
                                 *ngTemplateOutlet="
-                                    footerGroupedTemplate || footerTemplate || _footerTemplate || _footerGroupedTemplate;
+                                    footerGroupedTemplate || footerTemplate || _footerTemplate() || _footerGroupedTemplate();
                                     context: {
                                         $implicit: scrollerOptions.columns
                                     }
@@ -323,13 +323,13 @@ export class TableService {
                 [alwaysShow]="alwaysShowPaginator"
                 (onPageChange)="onPageChange($event)"
                 [rowsPerPageOptions]="rowsPerPageOptions"
-                [templateLeft]="paginatorLeftTemplate || _paginatorLeftTemplate"
-                [templateRight]="paginatorRightTemplate || _paginatorRightTemplate"
+                [templateLeft]="paginatorLeftTemplate || _paginatorLeftTemplate()"
+                [templateRight]="paginatorRightTemplate || _paginatorRightTemplate()"
                 [appendTo]="paginatorDropdownAppendTo"
                 [dropdownScrollHeight]="paginatorDropdownScrollHeight"
                 [currentPageReportTemplate]="currentPageReportTemplate"
                 [showFirstLastIcon]="showFirstLastIcon"
-                [dropdownItemTemplate]="paginatorDropdownItemTemplate || _paginatorDropdownItemTemplate"
+                [dropdownItemTemplate]="paginatorDropdownItemTemplate || _paginatorDropdownItemTemplate()"
                 [showCurrentPageReport]="showCurrentPageReport"
                 [showJumpToPageDropdown]="showJumpToPageDropdown"
                 [showJumpToPageInput]="showJumpToPageInput"
@@ -339,37 +339,37 @@ export class TableService {
                 [pt]="ptm('pcPaginator')"
                 [unstyled]="unstyled()"
             >
-                @if (paginatorDropdownIconTemplate || _paginatorDropdownIconTemplate) {
+                @if (paginatorDropdownIconTemplate || _paginatorDropdownIconTemplate()) {
                     <ng-template pTemplate="dropdownicon">
-                        <ng-container *ngTemplateOutlet="paginatorDropdownIconTemplate || _paginatorDropdownIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorDropdownIconTemplate || _paginatorDropdownIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate) {
+                @if (paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate()) {
                     <ng-template pTemplate="firstpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate) {
+                @if (paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate()) {
                     <ng-template pTemplate="previouspagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate) {
+                @if (paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate()) {
                     <ng-template pTemplate="lastpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate) {
+                @if (paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate()) {
                     <ng-template pTemplate="nextpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
             </p-paginator>
         }
 
-        @if (summaryTemplate || _summaryTemplate) {
+        @if (summaryTemplate || _summaryTemplate()) {
             <div [ngClass]="cx('footer')" [pBind]="ptm('footer')">
-                <ng-container *ngTemplateOutlet="summaryTemplate || _summaryTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="summaryTemplate || _summaryTemplate()"></ng-container>
             </div>
         }
 
@@ -378,18 +378,18 @@ export class TableService {
         }
         @if (reorderableColumns) {
             <span #reorderIndicatorUp [ngClass]="cx('rowReorderIndicatorUp')" [pBind]="ptm('rowReorderIndicatorUp')" [style.display]="'none'">
-                @if (!reorderIndicatorUpIconTemplate && !_reorderIndicatorUpIconTemplate) {
+                @if (!reorderIndicatorUpIconTemplate && !_reorderIndicatorUpIconTemplate()) {
                     <svg data-p-icon="arrow-down" [pBind]="ptm('rowReorderIndicatorUp')['icon']" />
                 }
-                <ng-template *ngTemplateOutlet="reorderIndicatorUpIconTemplate || _reorderIndicatorUpIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="reorderIndicatorUpIconTemplate || _reorderIndicatorUpIconTemplate()"></ng-template>
             </span>
         }
         @if (reorderableColumns) {
             <span #reorderIndicatorDown [ngClass]="cx('rowReorderIndicatorDown')" [pBind]="ptm('rowReorderIndicatorDown')" [style.display]="'none'">
-                @if (!reorderIndicatorDownIconTemplate && !_reorderIndicatorDownIconTemplate) {
+                @if (!reorderIndicatorDownIconTemplate && !_reorderIndicatorDownIconTemplate()) {
                     <svg data-p-icon="arrow-up" [pBind]="ptm('rowReorderIndicatorDown')['icon']" />
                 }
-                <ng-template *ngTemplateOutlet="reorderIndicatorDownIconTemplate || _reorderIndicatorDownIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="reorderIndicatorDownIconTemplate || _reorderIndicatorDownIconTemplate()"></ng-template>
             </span>
         }
     `,
@@ -1019,25 +1019,23 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
      */
     @Output() onStateRestore: EventEmitter<TableState> = new EventEmitter<TableState>();
 
-    @ViewChild('resizeHelper') resizeHelperViewChild: Nullable<ElementRef>;
+    readonly resizeHelperViewChild = viewChild<Nullable<ElementRef>>('resizeHelper');
 
-    @ViewChild('reorderIndicatorUp')
-    reorderIndicatorUpViewChild: Nullable<ElementRef>;
+    readonly reorderIndicatorUpViewChild = viewChild<Nullable<ElementRef>>('reorderIndicatorUp');
 
-    @ViewChild('reorderIndicatorDown')
-    reorderIndicatorDownViewChild: Nullable<ElementRef>;
+    readonly reorderIndicatorDownViewChild = viewChild<Nullable<ElementRef>>('reorderIndicatorDown');
 
-    @ViewChild('wrapper') wrapperViewChild: Nullable<ElementRef>;
+    readonly wrapperViewChild = viewChild<Nullable<ElementRef>>('wrapper');
 
-    @ViewChild('table') tableViewChild: Nullable<ElementRef>;
+    readonly tableViewChild = viewChild<Nullable<ElementRef>>('table');
 
-    @ViewChild('thead') tableHeaderViewChild: Nullable<ElementRef>;
+    readonly tableHeaderViewChild = viewChild<Nullable<ElementRef>>('thead');
 
-    @ViewChild('tfoot') tableFooterViewChild: Nullable<ElementRef>;
+    readonly tableFooterViewChild = viewChild<Nullable<ElementRef>>('tfoot');
 
-    @ViewChild('scroller') scroller: Nullable<Scroller>;
+    readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
-    @ContentChildren(PrimeTemplate) _templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly _templates = contentChildren(PrimeTemplate);
 
     _value: RowData[] = [];
 
@@ -1052,100 +1050,100 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     filteredValue: any[] | undefined | null;
 
     // @todo will be refactored later
-    @ContentChild('header', { descendants: false }) _headerTemplate: TemplateRef<any>;
+    readonly _headerTemplate = contentChild.required<TemplateRef<any>>('header', { descendants: false });
     headerTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('headergrouped', { descendants: false }) _headerGroupedTemplate: TemplateRef<any>;
+    readonly _headerGroupedTemplate = contentChild.required<TemplateRef<any>>('headergrouped', { descendants: false });
     headerGroupedTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('body', { descendants: false }) _bodyTemplate: TemplateRef<any>;
+    readonly _bodyTemplate = contentChild.required<TemplateRef<any>>('body', { descendants: false });
     bodyTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('loadingbody', { descendants: false }) _loadingBodyTemplate: TemplateRef<any>;
+    readonly _loadingBodyTemplate = contentChild.required<TemplateRef<any>>('loadingbody', { descendants: false });
     loadingBodyTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('caption', { descendants: false }) _captionTemplate: TemplateRef<any>;
+    readonly _captionTemplate = contentChild.required<TemplateRef<any>>('caption', { descendants: false });
     captionTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('footer', { descendants: false }) _footerTemplate: TemplateRef<any>;
+    readonly _footerTemplate = contentChild.required<TemplateRef<any>>('footer', { descendants: false });
     footerTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('footergrouped', { descendants: false }) _footerGroupedTemplate: TemplateRef<any>;
+    readonly _footerGroupedTemplate = contentChild.required<TemplateRef<any>>('footergrouped', { descendants: false });
     footerGroupedTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('summary', { descendants: false }) _summaryTemplate: TemplateRef<any>;
+    readonly _summaryTemplate = contentChild.required<TemplateRef<any>>('summary', { descendants: false });
     summaryTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('colgroup', { descendants: false }) _colGroupTemplate: TemplateRef<any>;
+    readonly _colGroupTemplate = contentChild.required<TemplateRef<any>>('colgroup', { descendants: false });
     colGroupTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('expandedrow', { descendants: false }) _expandedRowTemplate: TemplateRef<any>;
+    readonly _expandedRowTemplate = contentChild.required<TemplateRef<any>>('expandedrow', { descendants: false });
     expandedRowTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('groupheader', { descendants: false }) _groupHeaderTemplate: TemplateRef<any>;
+    readonly _groupHeaderTemplate = contentChild.required<TemplateRef<any>>('groupheader', { descendants: false });
     groupHeaderTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('groupfooter', { descendants: false }) _groupFooterTemplate: TemplateRef<any>;
+    readonly _groupFooterTemplate = contentChild.required<TemplateRef<any>>('groupfooter', { descendants: false });
     groupFooterTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('frozenexpandedrow', { descendants: false }) _frozenExpandedRowTemplate: TemplateRef<any>;
+    readonly _frozenExpandedRowTemplate = contentChild.required<TemplateRef<any>>('frozenexpandedrow', { descendants: false });
     frozenExpandedRowTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('frozenheader', { descendants: false }) _frozenHeaderTemplate: TemplateRef<any>;
+    readonly _frozenHeaderTemplate = contentChild.required<TemplateRef<any>>('frozenheader', { descendants: false });
     frozenHeaderTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('frozenbody', { descendants: false }) _frozenBodyTemplate: TemplateRef<any>;
+    readonly _frozenBodyTemplate = contentChild.required<TemplateRef<any>>('frozenbody', { descendants: false });
     frozenBodyTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('frozenfooter', { descendants: false }) _frozenFooterTemplate: TemplateRef<any>;
+    readonly _frozenFooterTemplate = contentChild.required<TemplateRef<any>>('frozenfooter', { descendants: false });
     frozenFooterTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('frozencolgroup', { descendants: false }) _frozenColGroupTemplate: TemplateRef<any>;
+    readonly _frozenColGroupTemplate = contentChild.required<TemplateRef<any>>('frozencolgroup', { descendants: false });
     frozenColGroupTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('emptymessage', { descendants: false }) _emptyMessageTemplate: TemplateRef<any>;
+    readonly _emptyMessageTemplate = contentChild.required<TemplateRef<any>>('emptymessage', { descendants: false });
     emptyMessageTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('paginatorleft', { descendants: false }) _paginatorLeftTemplate: TemplateRef<any>;
+    readonly _paginatorLeftTemplate = contentChild.required<TemplateRef<any>>('paginatorleft', { descendants: false });
     paginatorLeftTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('paginatorright', { descendants: false }) _paginatorRightTemplate: TemplateRef<any>;
+    readonly _paginatorRightTemplate = contentChild.required<TemplateRef<any>>('paginatorright', { descendants: false });
     paginatorRightTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('paginatordropdownitem', { descendants: false }) _paginatorDropdownItemTemplate: TemplateRef<any>;
+    readonly _paginatorDropdownItemTemplate = contentChild.required<TemplateRef<any>>('paginatordropdownitem', { descendants: false });
     paginatorDropdownItemTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('loadingicon', { descendants: false }) _loadingIconTemplate: TemplateRef<any>;
+    readonly _loadingIconTemplate = contentChild.required<TemplateRef<any>>('loadingicon', { descendants: false });
     loadingIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('reorderindicatorupicon', { descendants: false }) _reorderIndicatorUpIconTemplate: TemplateRef<any>;
+    readonly _reorderIndicatorUpIconTemplate = contentChild.required<TemplateRef<any>>('reorderindicatorupicon', { descendants: false });
     reorderIndicatorUpIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('reorderindicatordownicon', { descendants: false }) _reorderIndicatorDownIconTemplate: TemplateRef<any>;
+    readonly _reorderIndicatorDownIconTemplate = contentChild.required<TemplateRef<any>>('reorderindicatordownicon', { descendants: false });
     reorderIndicatorDownIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('sorticon', { descendants: false }) _sortIconTemplate: TemplateRef<any>;
+    readonly _sortIconTemplate = contentChild.required<TemplateRef<any>>('sorticon', { descendants: false });
     sortIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('checkboxicon', { descendants: false }) _checkboxIconTemplate: TemplateRef<any>;
+    readonly _checkboxIconTemplate = contentChild.required<TemplateRef<any>>('checkboxicon', { descendants: false });
     checkboxIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('headercheckboxicon', { descendants: false }) _headerCheckboxIconTemplate: TemplateRef<any>;
+    readonly _headerCheckboxIconTemplate = contentChild.required<TemplateRef<any>>('headercheckboxicon', { descendants: false });
     headerCheckboxIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('paginatordropdownicon', { descendants: false }) _paginatorDropdownIconTemplate: TemplateRef<any>;
+    readonly _paginatorDropdownIconTemplate = contentChild.required<TemplateRef<any>>('paginatordropdownicon', { descendants: false });
     paginatorDropdownIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('paginatorfirstpagelinkicon', { descendants: false }) _paginatorFirstPageLinkIconTemplate: TemplateRef<any>;
+    readonly _paginatorFirstPageLinkIconTemplate = contentChild.required<TemplateRef<any>>('paginatorfirstpagelinkicon', { descendants: false });
     paginatorFirstPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('paginatorlastpagelinkicon', { descendants: false }) _paginatorLastPageLinkIconTemplate: TemplateRef<any>;
+    readonly _paginatorLastPageLinkIconTemplate = contentChild.required<TemplateRef<any>>('paginatorlastpagelinkicon', { descendants: false });
     paginatorLastPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('paginatorpreviouspagelinkicon', { descendants: false }) _paginatorPreviousPageLinkIconTemplate: TemplateRef<any>;
+    readonly _paginatorPreviousPageLinkIconTemplate = contentChild.required<TemplateRef<any>>('paginatorpreviouspagelinkicon', { descendants: false });
     paginatorPreviousPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('paginatornextpagelinkicon', { descendants: false }) _paginatorNextPageLinkIconTemplate: TemplateRef<any>;
+    readonly _paginatorNextPageLinkIconTemplate = contentChild.required<TemplateRef<any>>('paginatornextpagelinkicon', { descendants: false });
     paginatorNextPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
     selectionKeys: any = {};
@@ -1261,7 +1259,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     }
 
     onAfterContentInit() {
-        (this._templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this._templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'caption':
                     this.captionTemplate = item.template;
@@ -2526,7 +2524,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
      * @group Method
      */
     public scrollToVirtualIndex(index: number) {
-        this.scroller && this.scroller.scrollToIndex(index);
+        scroller && scroller.scrollToIndex(index);
     }
     /**
      * Scrolls to given index.
@@ -2534,14 +2532,15 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
      * @group Method
      */
     public scrollTo(options: any) {
+        const wrapperViewChild = this.wrapperViewChild();
         if (this.virtualScroll) {
-            this.scroller?.scrollTo(options);
-        } else if (this.wrapperViewChild && this.wrapperViewChild.nativeElement) {
-            if (this.wrapperViewChild.nativeElement.scrollTo) {
-                this.wrapperViewChild.nativeElement.scrollTo(options);
+            this.scroller()?.scrollTo(options);
+        } else if (wrapperViewChild && wrapperViewChild.nativeElement) {
+            if (wrapperViewChild.nativeElement.scrollTo) {
+                wrapperViewChild.nativeElement.scrollTo(options);
             } else {
-                this.wrapperViewChild.nativeElement.scrollLeft = options.left;
-                this.wrapperViewChild.nativeElement.scrollTop = options.top;
+                wrapperViewChild.nativeElement.scrollLeft = options.left;
+                wrapperViewChild.nativeElement.scrollTop = options.top;
             }
         }
     }
@@ -2677,19 +2676,20 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     onColumnResize(event: any) {
         let containerLeft = DomHandler.getOffset(this.el?.nativeElement).left;
         !this.$unstyled() && DomHandler.addClass(this.el?.nativeElement, 'p-unselectable-text');
-        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.height = this.el?.nativeElement.offsetHeight + 'px';
-        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.top = 0 + 'px';
+        (<ElementRef>this.resizeHelperViewChild()).nativeElement.style.height = this.el?.nativeElement.offsetHeight + 'px';
+        (<ElementRef>this.resizeHelperViewChild()).nativeElement.style.top = 0 + 'px';
         if (event.type == 'touchmove') {
-            (<ElementRef>this.resizeHelperViewChild).nativeElement.style.left = event.changedTouches[0].clientX - containerLeft + this.el?.nativeElement.scrollLeft + 'px';
+            (<ElementRef>this.resizeHelperViewChild()).nativeElement.style.left = event.changedTouches[0].clientX - containerLeft + this.el?.nativeElement.scrollLeft + 'px';
         } else {
-            (<ElementRef>this.resizeHelperViewChild).nativeElement.style.left = event.pageX - containerLeft + this.el?.nativeElement.scrollLeft + 'px';
+            (<ElementRef>this.resizeHelperViewChild()).nativeElement.style.left = event.pageX - containerLeft + this.el?.nativeElement.scrollLeft + 'px';
         }
-        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.display = 'block';
+        (<ElementRef>this.resizeHelperViewChild()).nativeElement.style.display = 'block';
     }
 
     onColumnResizeEnd() {
         const isRTL = getComputedStyle(this.el?.nativeElement ?? document.documentElement).direction === 'rtl';
-        const rawDelta = this.resizeHelperViewChild?.nativeElement.offsetLeft - <number>this.lastResizerHelperX;
+        const resizeHelperViewChild = this.resizeHelperViewChild();
+        const rawDelta = resizeHelperViewChild?.nativeElement.offsetLeft - <number>this.lastResizerHelperX;
         const delta = isRTL ? -rawDelta : rawDelta;
         const columnWidth = this.resizeColumnElement.offsetWidth;
         const newColumnWidth = columnWidth + delta;
@@ -2706,7 +2706,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                 }
             } else if (this.columnResizeMode === 'expand') {
                 this._initialColWidths = this._totalTableWidth();
-                const tableWidth = this.tableViewChild?.nativeElement.offsetWidth + delta;
+                const tableWidth = this.tableViewChild()?.nativeElement.offsetWidth + delta;
 
                 this.setResizeTableWidth(tableWidth + 'px');
                 this.resizeTableCells(newColumnWidth, null);
@@ -2722,7 +2722,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
             }
         }
 
-        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.display = 'none';
+        (<ElementRef>resizeHelperViewChild).nativeElement.style.display = 'none';
         DomHandler.removeClass(this.el?.nativeElement, 'p-unselectable-text');
     }
 
@@ -2736,8 +2736,8 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     }
 
     onColumnDragStart(event: any, columnElement: any) {
-        this.reorderIconWidth = DomHandler.getHiddenElementOuterWidth(this.reorderIndicatorUpViewChild?.nativeElement);
-        this.reorderIconHeight = DomHandler.getHiddenElementOuterHeight(this.reorderIndicatorDownViewChild?.nativeElement);
+        this.reorderIconWidth = DomHandler.getHiddenElementOuterWidth(this.reorderIndicatorUpViewChild()?.nativeElement);
+        this.reorderIconHeight = DomHandler.getHiddenElementOuterHeight(this.reorderIndicatorDownViewChild()?.nativeElement);
         this.draggedColumn = columnElement;
         event.dataTransfer.setData('text', 'b'); // For firefox
     }
@@ -2755,20 +2755,20 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                 let targetTop = containerOffset.top - dropHeaderOffset.top;
                 let columnCenter = dropHeaderOffset.left + dropHeader.offsetWidth / 2;
 
-                (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top - (<number>this.reorderIconHeight - 1) + 'px';
-                (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top + dropHeader.offsetHeight + 'px';
+                (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top - (<number>this.reorderIconHeight - 1) + 'px';
+                (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top + dropHeader.offsetHeight + 'px';
 
                 if (event.pageX > columnCenter) {
-                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
-                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
                     this.dropPosition = 1;
                 } else {
-                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
-                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
                     this.dropPosition = -1;
                 }
-                (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.display = 'block';
-                (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.display = 'block';
+                (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.display = 'block';
+                (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.display = 'block';
             } else {
                 event.dataTransfer.dropEffect = 'none';
             }
@@ -2823,8 +2823,8 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                 this.updateStyleElement(width, dragIndex, 0, 0);
             }
 
-            (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.display = 'none';
-            (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.display = 'none';
+            (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.display = 'none';
+            (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.display = 'none';
             this.draggedColumn.draggable = false;
             this.draggedColumn = null;
             this.dropPosition = null;
@@ -3080,14 +3080,15 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
         headers.forEach((header) => (widths as any[]).push(DomHandler.getOuterWidth(header)));
         state.columnWidths = widths.join(',');
 
-        if (this.columnResizeMode === 'expand' && this.tableViewChild) {
-            state.tableWidth = DomHandler.getOuterWidth(this.tableViewChild.nativeElement);
+        const tableViewChild = this.tableViewChild();
+        if (this.columnResizeMode === 'expand' && tableViewChild) {
+            state.tableWidth = DomHandler.getOuterWidth(tableViewChild.nativeElement);
         }
     }
 
     setResizeTableWidth(width: string) {
-        (<ElementRef>this.tableViewChild).nativeElement.style.width = width;
-        (<ElementRef>this.tableViewChild).nativeElement.style.minWidth = width;
+        (<ElementRef>this.tableViewChild()).nativeElement.style.width = width;
+        (<ElementRef>this.tableViewChild()).nativeElement.style.minWidth = width;
     }
 
     restoreColumnWidths() {
@@ -3260,13 +3261,13 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     selector: '[pTableBody]',
     standalone: false,
     template: `
-        @if (!dataTable.expandedRowTemplate && !dataTable._expandedRowTemplate) {
+        @if (!dataTable.expandedRowTemplate && !dataTable._expandedRowTemplate()) {
             @for (rowData of value; track dataTable.rowTrackBy(rowIndex, rowData); let rowIndex = $index) {
-                @if ((dataTable.groupHeaderTemplate || dataTable._groupHeaderTemplate) && !dataTable.virtualScroll && dataTable.rowGroupMode === 'subheader' && shouldRenderRowGroupHeader(value, rowData, getRowIndex(rowIndex))) {
+                @if ((dataTable.groupHeaderTemplate || dataTable._groupHeaderTemplate()) && !dataTable.virtualScroll && dataTable.rowGroupMode === 'subheader' && shouldRenderRowGroupHeader(value, rowData, getRowIndex(rowIndex))) {
                     <ng-container role="row">
                         <ng-container
                             *ngTemplateOutlet="
-                                dataTable.groupHeaderTemplate || dataTable._groupHeaderTemplate;
+                                dataTable.groupHeaderTemplate || dataTable._groupHeaderTemplate();
                                 context: {
                                     $implicit: rowData,
                                     rowIndex: getRowIndex(rowIndex),
@@ -3281,7 +3282,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                 @if (dataTable.rowGroupMode !== 'rowspan') {
                     <ng-container
                         *ngTemplateOutlet="
-                            rowData ? template : dataTable.loadingBodyTemplate || dataTable._loadingBodyTemplate;
+                            rowData ? template : dataTable.loadingBodyTemplate || dataTable._loadingBodyTemplate();
                             context: {
                                 $implicit: rowData,
                                 rowIndex: getRowIndex(rowIndex),
@@ -3295,7 +3296,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                 @if (dataTable.rowGroupMode === 'rowspan') {
                     <ng-container
                         *ngTemplateOutlet="
-                            rowData ? template : dataTable.loadingBodyTemplate || dataTable._loadingBodyTemplate;
+                            rowData ? template : dataTable.loadingBodyTemplate || dataTable._loadingBodyTemplate();
                             context: {
                                 $implicit: rowData,
                                 rowIndex: getRowIndex(rowIndex),
@@ -3308,11 +3309,11 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                         "
                     ></ng-container>
                 }
-                @if ((dataTable.groupFooterTemplate || dataTable._groupFooterTemplate) && !dataTable.virtualScroll && dataTable.rowGroupMode === 'subheader' && shouldRenderRowGroupFooter(value, rowData, getRowIndex(rowIndex))) {
+                @if ((dataTable.groupFooterTemplate || dataTable._groupFooterTemplate()) && !dataTable.virtualScroll && dataTable.rowGroupMode === 'subheader' && shouldRenderRowGroupFooter(value, rowData, getRowIndex(rowIndex))) {
                     <ng-container role="row">
                         <ng-container
                             *ngTemplateOutlet="
-                                dataTable.groupFooterTemplate || dataTable._groupFooterTemplate;
+                                dataTable.groupFooterTemplate || dataTable._groupFooterTemplate();
                                 context: {
                                     $implicit: rowData,
                                     rowIndex: getRowIndex(rowIndex),
@@ -3326,9 +3327,9 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                 }
             }
         }
-        @if ((dataTable.expandedRowTemplate || dataTable._expandedRowTemplate) && !(frozen && (dataTable.frozenExpandedRowTemplate || dataTable._frozenExpandedRowTemplate))) {
+        @if ((dataTable.expandedRowTemplate || dataTable._expandedRowTemplate()) && !(frozen && (dataTable.frozenExpandedRowTemplate || dataTable._frozenExpandedRowTemplate()))) {
             @for (rowData of value; track dataTable.rowTrackBy(rowIndex, rowData); let rowIndex = $index) {
-                @if (!(dataTable.groupHeaderTemplate && dataTable._groupHeaderTemplate)) {
+                @if (!(dataTable.groupHeaderTemplate && dataTable._groupHeaderTemplate())) {
                     <ng-container
                         *ngTemplateOutlet="
                             template;
@@ -3343,11 +3344,11 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                         "
                     ></ng-container>
                 }
-                @if ((dataTable.groupHeaderTemplate || dataTable._groupHeaderTemplate) && dataTable.rowGroupMode === 'subheader' && shouldRenderRowGroupHeader(value, rowData, getRowIndex(rowIndex))) {
+                @if ((dataTable.groupHeaderTemplate || dataTable._groupHeaderTemplate()) && dataTable.rowGroupMode === 'subheader' && shouldRenderRowGroupHeader(value, rowData, getRowIndex(rowIndex))) {
                     <ng-container role="row">
                         <ng-container
                             *ngTemplateOutlet="
-                                dataTable.groupHeaderTemplate || dataTable._groupHeaderTemplate;
+                                dataTable.groupHeaderTemplate || dataTable._groupHeaderTemplate();
                                 context: {
                                     $implicit: rowData,
                                     rowIndex: getRowIndex(rowIndex),
@@ -3363,7 +3364,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                 @if (dataTable.isRowExpanded(rowData)) {
                     <ng-container
                         *ngTemplateOutlet="
-                            dataTable.expandedRowTemplate || dataTable._expandedRowTemplate;
+                            dataTable.expandedRowTemplate || dataTable._expandedRowTemplate();
                             context: {
                                 $implicit: rowData,
                                 rowIndex: getRowIndex(rowIndex),
@@ -3372,11 +3373,11 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                             }
                         "
                     ></ng-container>
-                    @if ((dataTable.groupFooterTemplate || dataTable._groupFooterTemplate) && dataTable.rowGroupMode === 'subheader' && shouldRenderRowGroupFooter(value, rowData, getRowIndex(rowIndex))) {
+                    @if ((dataTable.groupFooterTemplate || dataTable._groupFooterTemplate()) && dataTable.rowGroupMode === 'subheader' && shouldRenderRowGroupFooter(value, rowData, getRowIndex(rowIndex))) {
                         <ng-container role="row">
                             <ng-container
                                 *ngTemplateOutlet="
-                                    dataTable.groupFooterTemplate || dataTable._groupFooterTemplate;
+                                    dataTable.groupFooterTemplate || dataTable._groupFooterTemplate();
                                     context: {
                                         $implicit: rowData,
                                         rowIndex: getRowIndex(rowIndex),
@@ -3392,7 +3393,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                 }
             }
         }
-        @if ((dataTable.frozenExpandedRowTemplate || dataTable._frozenExpandedRowTemplate) && frozen) {
+        @if ((dataTable.frozenExpandedRowTemplate || dataTable._frozenExpandedRowTemplate()) && frozen) {
             @for (rowData of value; track dataTable.rowTrackBy(rowIndex, rowData); let rowIndex = $index) {
                 <ng-container
                     *ngTemplateOutlet="
@@ -3410,7 +3411,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                 @if (dataTable.isRowExpanded(rowData)) {
                     <ng-container
                         *ngTemplateOutlet="
-                            dataTable.frozenExpandedRowTemplate || dataTable._frozenExpandedRowTemplate;
+                            dataTable.frozenExpandedRowTemplate || dataTable._frozenExpandedRowTemplate();
                             context: {
                                 $implicit: rowData,
                                 rowIndex: getRowIndex(rowIndex),
@@ -3423,10 +3424,10 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
             }
         }
         @if (dataTable.loading) {
-            <ng-container *ngTemplateOutlet="dataTable.loadingBodyTemplate || dataTable._loadingBodyTemplate; context: { $implicit: columns, frozen: frozen }"></ng-container>
+            <ng-container *ngTemplateOutlet="dataTable.loadingBodyTemplate || dataTable._loadingBodyTemplate(); context: { $implicit: columns, frozen: frozen }"></ng-container>
         }
         @if (dataTable.isEmpty() && !dataTable.loading) {
-            <ng-container *ngTemplateOutlet="dataTable.emptyMessageTemplate || dataTable._emptyMessageTemplate; context: { $implicit: columns, frozen: frozen }"></ng-container>
+            <ng-container *ngTemplateOutlet="dataTable.emptyMessageTemplate || dataTable._emptyMessageTemplate(); context: { $implicit: columns, frozen: frozen }"></ng-container>
         }
     `,
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -3811,7 +3812,7 @@ export class SortableColumn extends BaseComponent {
     selector: 'p-sortIcon',
     standalone: false,
     template: `
-        @if (!(dataTable.sortIconTemplate || dataTable._sortIconTemplate)) {
+        @if (!(dataTable.sortIconTemplate || dataTable._sortIconTemplate())) {
             @if (sortOrder === 0) {
                 <svg data-p-icon="sort-alt" [class]="cx('sortableColumnIcon')" />
             }
@@ -3822,9 +3823,9 @@ export class SortableColumn extends BaseComponent {
                 <svg data-p-icon="sort-amount-down" [class]="cx('sortableColumnIcon')" />
             }
         }
-        @if (dataTable.sortIconTemplate || dataTable._sortIconTemplate) {
+        @if (dataTable.sortIconTemplate || dataTable._sortIconTemplate()) {
             <span [class]="cx('sortableColumnIcon')">
-                <ng-template *ngTemplateOutlet="dataTable.sortIconTemplate || dataTable._sortIconTemplate; context: { $implicit: sortOrder }"></ng-template>
+                <ng-template *ngTemplateOutlet="dataTable.sortIconTemplate || dataTable._sortIconTemplate(); context: { $implicit: sortOrder }"></ng-template>
             </span>
         }
         @if (isMultiSorted()) {
@@ -4962,10 +4963,10 @@ export class CancelEditableRow extends BaseComponent {
     standalone: false,
     template: `
         @if (editing) {
-            <ng-container *ngTemplateOutlet="inputTemplate || _inputTemplate"></ng-container>
+            <ng-container *ngTemplateOutlet="inputTemplate || _inputTemplate()"></ng-container>
         }
         @if (!editing) {
-            <ng-container *ngTemplateOutlet="outputTemplate || _outputTemplate"></ng-container>
+            <ng-container *ngTemplateOutlet="outputTemplate || _outputTemplate()"></ng-container>
         }
     `,
     encapsulation: ViewEncapsulation.None
@@ -4975,18 +4976,18 @@ export class CellEditor extends BaseComponent {
     editableColumn = inject(EditableColumn, { optional: true });
     editableRow = inject(EditableRow, { optional: true });
 
-    @ContentChildren(PrimeTemplate) _templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly _templates = contentChildren(PrimeTemplate);
 
-    @ContentChild('input') _inputTemplate: TemplateRef<any>;
+    readonly _inputTemplate = contentChild.required<TemplateRef<any>>('input');
 
-    @ContentChild('output') _outputTemplate: TemplateRef<any>;
+    readonly _outputTemplate = contentChild.required<TemplateRef<any>>('output');
 
     inputTemplate: Nullable<TemplateRef<any>>;
 
     outputTemplate: Nullable<TemplateRef<any>>;
 
     onAfterContentInit() {
-        (this._templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this._templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'input':
                     this.inputTemplate = item.template;
@@ -5039,7 +5040,7 @@ export class TableRadioButton extends BaseComponent {
 
     @Input() ariaLabel: string | undefined;
 
-    @ViewChild('rb') inputViewChild: Nullable<RadioButton>;
+    readonly inputViewChild = viewChild<Nullable<RadioButton>>('rb');
 
     checked: boolean | undefined;
 
@@ -5069,7 +5070,7 @@ export class TableRadioButton extends BaseComponent {
                 this.value
             );
 
-            this.inputViewChild?.inputViewChild.nativeElement?.focus();
+            this.inputViewChild()?.inputViewChild().nativeElement?.focus();
         }
         DomHandler.clearSelection();
     }
@@ -5097,7 +5098,7 @@ export class TableRadioButton extends BaseComponent {
             [ariaLabel]="ariaLabel"
             [unstyled]="unstyled()"
         >
-            @if (dataTable.checkboxIconTemplate || dataTable._checkboxIconTemplate; as template) {
+            @if (dataTable.checkboxIconTemplate || dataTable._checkboxIconTemplate(); as template) {
                 <ng-template pTemplate="icon">
                     <ng-template *ngTemplateOutlet="template; context: { $implicit: checked }" />
                 </ng-template>
@@ -5174,7 +5175,7 @@ export class TableCheckbox extends BaseComponent {
             [ariaLabel]="ariaLabel"
             [unstyled]="unstyled()"
         >
-            @if (dataTable.headerCheckboxIconTemplate || dataTable._headerCheckboxIconTemplate; as template) {
+            @if (dataTable.headerCheckboxIconTemplate || dataTable._headerCheckboxIconTemplate(); as template) {
                 <ng-template pTemplate="icon">
                     <ng-template *ngTemplateOutlet="template; context: { $implicit: checked }" />
                 </ng-template>
@@ -5442,7 +5443,7 @@ export class ReorderableRow extends BaseComponent {
                 [field]="field"
                 [ariaLabel]="ariaLabel"
                 [filterConstraint]="dataTable.filters[field]"
-                [filterTemplate]="filterTemplate || _filterTemplate"
+                [filterTemplate]="filterTemplate() || _filterTemplate"
                 [placeholder]="placeholder"
                 [minFractionDigits]="minFractionDigits"
                 [maxFractionDigits]="maxFractionDigits"
@@ -5474,10 +5475,10 @@ export class ReorderableRow extends BaseComponent {
             >
                 <ng-template #icon>
                     <ng-container>
-                        <svg data-p-icon="filter" *ngIf="!filterIconTemplate && !_filterIconTemplate && !hasFilter" [pBind]="ptm('pcColumnFilterButton')['icon']" />
-                        <svg data-p-icon="filter-fill" *ngIf="!filterIconTemplate && !_filterIconTemplate && hasFilter" [pBind]="ptm('pcColumnFilterButton')['icon']" />
-                        <span *ngIf="filterIconTemplate || _filterIconTemplate" [pBind]="ptm('pcColumnFilterButton')['icon']" [attr.data-pc-section]="'columnfilterbuttonicon'">
-                            <ng-template *ngTemplateOutlet="filterIconTemplate || _filterIconTemplate; context: { hasFilter: hasFilter }"></ng-template>
+                        <svg data-p-icon="filter" *ngIf="!filterIconTemplate() && !_filterIconTemplate && !hasFilter" [pBind]="ptm('pcColumnFilterButton')['icon']" />
+                        <svg data-p-icon="filter-fill" *ngIf="!filterIconTemplate() && !_filterIconTemplate && hasFilter" [pBind]="ptm('pcColumnFilterButton')['icon']" />
+                        <span *ngIf="filterIconTemplate() || _filterIconTemplate" [pBind]="ptm('pcColumnFilterButton')['icon']" [attr.data-pc-section]="'columnfilterbuttonicon'">
+                            <ng-template *ngTemplateOutlet="filterIconTemplate() || _filterIconTemplate; context: { hasFilter: hasFilter }"></ng-template>
                         </span>
                     </ng-container>
                 </ng-template>
@@ -5498,7 +5499,7 @@ export class ReorderableRow extends BaseComponent {
                     (click)="onContentClick()"
                     (keydown.escape)="onEscape()"
                 >
-                    <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate; context: { $implicit: field }"></ng-container>
+                    <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate; context: { $implicit: field }"></ng-container>
                     <ul *ngIf="display === 'row'; else menu" [class]="cx('filterConstraintList')" [pBind]="ptm('filterConstraintList')">
                         <li
                             *ngFor="let matchMode of matchModes; let i = index"
@@ -5545,7 +5546,7 @@ export class ReorderableRow extends BaseComponent {
                                     [type]="type"
                                     [field]="field"
                                     [filterConstraint]="fieldConstraint"
-                                    [filterTemplate]="filterTemplate || _filterTemplate"
+                                    [filterTemplate]="filterTemplate() || _filterTemplate"
                                     [placeholder]="placeholder"
                                     [minFractionDigits]="minFractionDigits"
                                     [maxFractionDigits]="maxFractionDigits"
@@ -5575,8 +5576,8 @@ export class ReorderableRow extends BaseComponent {
                                         [unstyled]="unstyled()"
                                     >
                                         <ng-template #icon>
-                                            <svg data-p-icon="trash" *ngIf="!removeRuleIconTemplate && !_removeRuleIconTemplate" [pBind]="ptm('pcFilterRemoveRuleButton')['icon']" />
-                                            <ng-template *ngTemplateOutlet="removeRuleIconTemplate || _removeRuleIconTemplate"></ng-template>
+                                            <svg data-p-icon="trash" *ngIf="!removeRuleIconTemplate() && !_removeRuleIconTemplate" [pBind]="ptm('pcFilterRemoveRuleButton')['icon']" />
+                                            <ng-template *ngTemplateOutlet="removeRuleIconTemplate() || _removeRuleIconTemplate"></ng-template>
                                         </ng-template>
                                     </p-button>
                                 </div>
@@ -5596,8 +5597,8 @@ export class ReorderableRow extends BaseComponent {
                                 [unstyled]="unstyled()"
                             >
                                 <ng-template #icon>
-                                    <svg data-p-icon="plus" *ngIf="!addRuleIconTemplate && !_addRuleIconTemplate" [pBind]="ptm('pcAddRuleButtonLabel')['icon']" />
-                                    <ng-template *ngTemplateOutlet="addRuleIconTemplate || _addRuleIconTemplate"></ng-template>
+                                    <svg data-p-icon="plus" *ngIf="!addRuleIconTemplate() && !_addRuleIconTemplate" [pBind]="ptm('pcAddRuleButtonLabel')['icon']" />
+                                    <ng-template *ngTemplateOutlet="addRuleIconTemplate() || _addRuleIconTemplate"></ng-template>
                                 </ng-template>
                             </p-button>
                         }
@@ -5625,7 +5626,7 @@ export class ReorderableRow extends BaseComponent {
                             />
                         </div>
                     </ng-template>
-                    <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate; context: { $implicit: field }"></ng-container>
+                    <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate; context: { $implicit: field }"></ng-container>
                 </div>
             }
         </div>
@@ -5845,11 +5846,11 @@ export class ColumnFilter extends BaseComponent {
         originalEvent: AnimationEvent;
     }>();
 
-    @ViewChild(Button, { static: false, read: ElementRef }) icon: ElementRef | undefined;
+    readonly icon = viewChild(Button, { read: ElementRef });
 
-    @ViewChild('clearBtn') clearButtonViewChild: Nullable<ElementRef>;
+    readonly clearButtonViewChild = viewChild<Nullable<ElementRef>>('clearBtn');
 
-    @ContentChildren(PrimeTemplate) _templates: Nullable<QueryList<any>>;
+    readonly _templates = contentChildren(PrimeTemplate);
 
     overlaySubscription: Subscription | undefined;
 
@@ -5859,44 +5860,44 @@ export class ColumnFilter extends BaseComponent {
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<any>;
+    readonly headerTemplate = contentChild.required<TemplateRef<any>>('header', { descendants: false });
     _headerTemplate: Nullable<TemplateRef<any>>;
 
     /**
      * Custom filter template.
      * @group Templates
      */
-    @ContentChild('filter', { descendants: false }) filterTemplate: TemplateRef<any>;
+    readonly filterTemplate = contentChild.required<TemplateRef<any>>('filter', { descendants: false });
     _filterTemplate: Nullable<TemplateRef<any>>;
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: TemplateRef<any>;
+    readonly footerTemplate = contentChild.required<TemplateRef<any>>('footer', { descendants: false });
     _footerTemplate: Nullable<TemplateRef<any>>;
     /**
      * Custom filter icon template.
      * @group Templates
      */
-    @ContentChild('filtericon', { descendants: false }) filterIconTemplate: TemplateRef<any>;
+    readonly filterIconTemplate = contentChild.required<TemplateRef<any>>('filtericon', { descendants: false });
     _filterIconTemplate: Nullable<TemplateRef<any>>;
 
     /**
      * Custom remove rule button icon template.
      * @group Templates
      */
-    @ContentChild('removeruleicon', { descendants: false }) removeRuleIconTemplate: TemplateRef<any>;
+    readonly removeRuleIconTemplate = contentChild.required<TemplateRef<any>>('removeruleicon', { descendants: false });
     _removeRuleIconTemplate: Nullable<TemplateRef<any>>;
 
     /**
      * Custom add rule button icon template.
      * @group Templates
      */
-    @ContentChild('addruleicon', { descendants: false }) addRuleIconTemplate: TemplateRef<any>;
+    readonly addRuleIconTemplate = contentChild.required<TemplateRef<any>>('addruleicon', { descendants: false });
     _addRuleIconTemplate: Nullable<TemplateRef<any>>;
 
-    @ContentChild('clearfiltericon', { descendants: false }) clearFilterIconTemplate: TemplateRef<any>;
+    readonly clearFilterIconTemplate = contentChild.required<TemplateRef<any>>('clearfiltericon', { descendants: false });
     _clearFilterIconTemplate: Nullable<TemplateRef<any>>;
 
     operatorOptions: any[] | undefined;
@@ -6027,7 +6028,7 @@ export class ColumnFilter extends BaseComponent {
     }
 
     onAfterContentInit() {
-        (this._templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this._templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;
@@ -6140,7 +6141,7 @@ export class ColumnFilter extends BaseComponent {
             matchMode: this.getDefaultMatchMode(),
             operator: this.getDefaultOperator()
         });
-        DomHandler.focus(this.clearButtonViewChild?.nativeElement);
+        DomHandler.focus(this.clearButtonViewChild()?.nativeElement);
     }
 
     removeConstraint(filterMeta: FilterMetadata) {
@@ -6148,7 +6149,7 @@ export class ColumnFilter extends BaseComponent {
         if (!this.showApplyButton) {
             this.dataTable._filter();
         }
-        DomHandler.focus(this.clearButtonViewChild?.nativeElement);
+        DomHandler.focus(this.clearButtonViewChild()?.nativeElement);
     }
 
     onOperatorChange(value: any) {
@@ -6199,7 +6200,7 @@ export class ColumnFilter extends BaseComponent {
 
     onEscape() {
         this.hide();
-        this.icon?.nativeElement.focus();
+        this.icon()?.nativeElement.focus();
     }
 
     findNextItem(item: HTMLLIElement): any {
@@ -6300,13 +6301,14 @@ export class ColumnFilter extends BaseComponent {
     }
 
     isOutsideClicked(event: any): boolean {
+        const icon = this.icon();
         return !(
             findSingle((this.overlay as HTMLElement).nextElementSibling!, '[data-pc-section="filteroverlay"]') ||
             findSingle((this.overlay as HTMLElement).nextElementSibling!, '[data-pc-name="popover"]') ||
             this.overlay?.isSameNode(event.target) ||
             this.overlay?.contains(event.target) ||
-            this.icon?.nativeElement.isSameNode(event.target) ||
-            this.icon?.nativeElement.contains(event.target) ||
+            icon?.nativeElement.isSameNode(event.target) ||
+            icon?.nativeElement.contains(event.target) ||
             findSingle(event.target, '[data-pc-name="pcaddrulebuttonlabel"]') ||
             findSingle(event.target.parentElement, '[data-pc-name="pcaddrulebuttonlabel"]') ||
             findSingle(event.target, '[data-pc-name="pcfilterremoverulebutton"]') ||
@@ -6357,7 +6359,7 @@ export class ColumnFilter extends BaseComponent {
 
     bindScrollListener() {
         if (!this.scrollHandler) {
-            this.scrollHandler = new ConnectedOverlayScrollHandler(this.icon?.nativeElement, () => {
+            this.scrollHandler = new ConnectedOverlayScrollHandler(this.icon()?.nativeElement, () => {
                 if (this.overlayVisible) {
                     this.hide();
                 }

--- a/packages/optimus-ui/src/table/table.ts
+++ b/packages/optimus-ui/src/table/table.ts
@@ -1028,10 +1028,6 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
 
     readonly tableViewChild = viewChild<Nullable<ElementRef>>('table');
 
-    readonly tableHeaderViewChild = viewChild<Nullable<ElementRef>>('thead');
-
-    readonly tableFooterViewChild = viewChild<Nullable<ElementRef>>('tfoot');
-
     readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
     readonly _templates = contentChildren(PrimeTemplate);
@@ -1052,7 +1048,6 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     readonly _headerTemplate = contentChild<TemplateRef<any>>('header', { descendants: false });
     headerTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _headerGroupedTemplate = contentChild<TemplateRef<any>>('headergrouped', { descendants: false });
     headerGroupedTemplate: Nullable<TemplateRef<any>>;
 
     readonly _bodyTemplate = contentChild<TemplateRef<any>>('body', { descendants: false });
@@ -1088,17 +1083,8 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     readonly _frozenExpandedRowTemplate = contentChild<TemplateRef<any>>('frozenexpandedrow', { descendants: false });
     frozenExpandedRowTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _frozenHeaderTemplate = contentChild<TemplateRef<any>>('frozenheader', { descendants: false });
-    frozenHeaderTemplate: Nullable<TemplateRef<any>>;
-
     readonly _frozenBodyTemplate = contentChild<TemplateRef<any>>('frozenbody', { descendants: false });
     frozenBodyTemplate: Nullable<TemplateRef<any>>;
-
-    readonly _frozenFooterTemplate = contentChild<TemplateRef<any>>('frozenfooter', { descendants: false });
-    frozenFooterTemplate: Nullable<TemplateRef<any>>;
-
-    readonly _frozenColGroupTemplate = contentChild<TemplateRef<any>>('frozencolgroup', { descendants: false });
-    frozenColGroupTemplate: Nullable<TemplateRef<any>>;
 
     readonly _emptyMessageTemplate = contentChild<TemplateRef<any>>('emptymessage', { descendants: false });
     emptyMessageTemplate: Nullable<TemplateRef<any>>;
@@ -1308,20 +1294,8 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
                     this.groupFooterTemplate = item.template;
                     break;
 
-                case 'frozenheader':
-                    this.frozenHeaderTemplate = item.template;
-                    break;
-
                 case 'frozenbody':
                     this.frozenBodyTemplate = item.template;
-                    break;
-
-                case 'frozenfooter':
-                    this.frozenFooterTemplate = item.template;
-                    break;
-
-                case 'frozencolgroup':
-                    this.frozenColGroupTemplate = item.template;
                     break;
 
                 case 'frozenexpandedrow':
@@ -5897,7 +5871,6 @@ export class ColumnFilter extends BaseComponent {
     readonly addRuleIconTemplate = contentChild<TemplateRef<any>>('addruleicon', { descendants: false });
     _addRuleIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly clearFilterIconTemplate = contentChild<TemplateRef<any>>('clearfiltericon', { descendants: false });
     _clearFilterIconTemplate: Nullable<TemplateRef<any>>;
 
     operatorOptions: any[] | undefined;

--- a/packages/optimus-ui/src/table/table.ts
+++ b/packages/optimus-ui/src/table/table.ts
@@ -18,7 +18,6 @@ import {
     NgZone,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     SimpleChanges,
     TemplateRef,
@@ -1050,100 +1049,100 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     filteredValue: any[] | undefined | null;
 
     // @todo will be refactored later
-    readonly _headerTemplate = contentChild.required<TemplateRef<any>>('header', { descendants: false });
+    readonly _headerTemplate = contentChild<TemplateRef<any>>('header', { descendants: false });
     headerTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _headerGroupedTemplate = contentChild.required<TemplateRef<any>>('headergrouped', { descendants: false });
+    readonly _headerGroupedTemplate = contentChild<TemplateRef<any>>('headergrouped', { descendants: false });
     headerGroupedTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _bodyTemplate = contentChild.required<TemplateRef<any>>('body', { descendants: false });
+    readonly _bodyTemplate = contentChild<TemplateRef<any>>('body', { descendants: false });
     bodyTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _loadingBodyTemplate = contentChild.required<TemplateRef<any>>('loadingbody', { descendants: false });
+    readonly _loadingBodyTemplate = contentChild<TemplateRef<any>>('loadingbody', { descendants: false });
     loadingBodyTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _captionTemplate = contentChild.required<TemplateRef<any>>('caption', { descendants: false });
+    readonly _captionTemplate = contentChild<TemplateRef<any>>('caption', { descendants: false });
     captionTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _footerTemplate = contentChild.required<TemplateRef<any>>('footer', { descendants: false });
+    readonly _footerTemplate = contentChild<TemplateRef<any>>('footer', { descendants: false });
     footerTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _footerGroupedTemplate = contentChild.required<TemplateRef<any>>('footergrouped', { descendants: false });
+    readonly _footerGroupedTemplate = contentChild<TemplateRef<any>>('footergrouped', { descendants: false });
     footerGroupedTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _summaryTemplate = contentChild.required<TemplateRef<any>>('summary', { descendants: false });
+    readonly _summaryTemplate = contentChild<TemplateRef<any>>('summary', { descendants: false });
     summaryTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _colGroupTemplate = contentChild.required<TemplateRef<any>>('colgroup', { descendants: false });
+    readonly _colGroupTemplate = contentChild<TemplateRef<any>>('colgroup', { descendants: false });
     colGroupTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _expandedRowTemplate = contentChild.required<TemplateRef<any>>('expandedrow', { descendants: false });
+    readonly _expandedRowTemplate = contentChild<TemplateRef<any>>('expandedrow', { descendants: false });
     expandedRowTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _groupHeaderTemplate = contentChild.required<TemplateRef<any>>('groupheader', { descendants: false });
+    readonly _groupHeaderTemplate = contentChild<TemplateRef<any>>('groupheader', { descendants: false });
     groupHeaderTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _groupFooterTemplate = contentChild.required<TemplateRef<any>>('groupfooter', { descendants: false });
+    readonly _groupFooterTemplate = contentChild<TemplateRef<any>>('groupfooter', { descendants: false });
     groupFooterTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _frozenExpandedRowTemplate = contentChild.required<TemplateRef<any>>('frozenexpandedrow', { descendants: false });
+    readonly _frozenExpandedRowTemplate = contentChild<TemplateRef<any>>('frozenexpandedrow', { descendants: false });
     frozenExpandedRowTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _frozenHeaderTemplate = contentChild.required<TemplateRef<any>>('frozenheader', { descendants: false });
+    readonly _frozenHeaderTemplate = contentChild<TemplateRef<any>>('frozenheader', { descendants: false });
     frozenHeaderTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _frozenBodyTemplate = contentChild.required<TemplateRef<any>>('frozenbody', { descendants: false });
+    readonly _frozenBodyTemplate = contentChild<TemplateRef<any>>('frozenbody', { descendants: false });
     frozenBodyTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _frozenFooterTemplate = contentChild.required<TemplateRef<any>>('frozenfooter', { descendants: false });
+    readonly _frozenFooterTemplate = contentChild<TemplateRef<any>>('frozenfooter', { descendants: false });
     frozenFooterTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _frozenColGroupTemplate = contentChild.required<TemplateRef<any>>('frozencolgroup', { descendants: false });
+    readonly _frozenColGroupTemplate = contentChild<TemplateRef<any>>('frozencolgroup', { descendants: false });
     frozenColGroupTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _emptyMessageTemplate = contentChild.required<TemplateRef<any>>('emptymessage', { descendants: false });
+    readonly _emptyMessageTemplate = contentChild<TemplateRef<any>>('emptymessage', { descendants: false });
     emptyMessageTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _paginatorLeftTemplate = contentChild.required<TemplateRef<any>>('paginatorleft', { descendants: false });
+    readonly _paginatorLeftTemplate = contentChild<TemplateRef<any>>('paginatorleft', { descendants: false });
     paginatorLeftTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _paginatorRightTemplate = contentChild.required<TemplateRef<any>>('paginatorright', { descendants: false });
+    readonly _paginatorRightTemplate = contentChild<TemplateRef<any>>('paginatorright', { descendants: false });
     paginatorRightTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _paginatorDropdownItemTemplate = contentChild.required<TemplateRef<any>>('paginatordropdownitem', { descendants: false });
+    readonly _paginatorDropdownItemTemplate = contentChild<TemplateRef<any>>('paginatordropdownitem', { descendants: false });
     paginatorDropdownItemTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _loadingIconTemplate = contentChild.required<TemplateRef<any>>('loadingicon', { descendants: false });
+    readonly _loadingIconTemplate = contentChild<TemplateRef<any>>('loadingicon', { descendants: false });
     loadingIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _reorderIndicatorUpIconTemplate = contentChild.required<TemplateRef<any>>('reorderindicatorupicon', { descendants: false });
+    readonly _reorderIndicatorUpIconTemplate = contentChild<TemplateRef<any>>('reorderindicatorupicon', { descendants: false });
     reorderIndicatorUpIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _reorderIndicatorDownIconTemplate = contentChild.required<TemplateRef<any>>('reorderindicatordownicon', { descendants: false });
+    readonly _reorderIndicatorDownIconTemplate = contentChild<TemplateRef<any>>('reorderindicatordownicon', { descendants: false });
     reorderIndicatorDownIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _sortIconTemplate = contentChild.required<TemplateRef<any>>('sorticon', { descendants: false });
+    readonly _sortIconTemplate = contentChild<TemplateRef<any>>('sorticon', { descendants: false });
     sortIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _checkboxIconTemplate = contentChild.required<TemplateRef<any>>('checkboxicon', { descendants: false });
+    readonly _checkboxIconTemplate = contentChild<TemplateRef<any>>('checkboxicon', { descendants: false });
     checkboxIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _headerCheckboxIconTemplate = contentChild.required<TemplateRef<any>>('headercheckboxicon', { descendants: false });
+    readonly _headerCheckboxIconTemplate = contentChild<TemplateRef<any>>('headercheckboxicon', { descendants: false });
     headerCheckboxIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _paginatorDropdownIconTemplate = contentChild.required<TemplateRef<any>>('paginatordropdownicon', { descendants: false });
+    readonly _paginatorDropdownIconTemplate = contentChild<TemplateRef<any>>('paginatordropdownicon', { descendants: false });
     paginatorDropdownIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _paginatorFirstPageLinkIconTemplate = contentChild.required<TemplateRef<any>>('paginatorfirstpagelinkicon', { descendants: false });
+    readonly _paginatorFirstPageLinkIconTemplate = contentChild<TemplateRef<any>>('paginatorfirstpagelinkicon', { descendants: false });
     paginatorFirstPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _paginatorLastPageLinkIconTemplate = contentChild.required<TemplateRef<any>>('paginatorlastpagelinkicon', { descendants: false });
+    readonly _paginatorLastPageLinkIconTemplate = contentChild<TemplateRef<any>>('paginatorlastpagelinkicon', { descendants: false });
     paginatorLastPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _paginatorPreviousPageLinkIconTemplate = contentChild.required<TemplateRef<any>>('paginatorpreviouspagelinkicon', { descendants: false });
+    readonly _paginatorPreviousPageLinkIconTemplate = contentChild<TemplateRef<any>>('paginatorpreviouspagelinkicon', { descendants: false });
     paginatorPreviousPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly _paginatorNextPageLinkIconTemplate = contentChild.required<TemplateRef<any>>('paginatornextpagelinkicon', { descendants: false });
+    readonly _paginatorNextPageLinkIconTemplate = contentChild<TemplateRef<any>>('paginatornextpagelinkicon', { descendants: false });
     paginatorNextPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
     selectionKeys: any = {};
@@ -1259,7 +1258,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     }
 
     onAfterContentInit() {
-        (this._templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this._templates().forEach((item) => {
             switch (item.getType()) {
                 case 'caption':
                     this.captionTemplate = item.template;
@@ -2524,6 +2523,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
      * @group Method
      */
     public scrollToVirtualIndex(index: number) {
+        const scroller = this.scroller();
         scroller && scroller.scrollToIndex(index);
     }
     /**
@@ -4978,16 +4978,16 @@ export class CellEditor extends BaseComponent {
 
     readonly _templates = contentChildren(PrimeTemplate);
 
-    readonly _inputTemplate = contentChild.required<TemplateRef<any>>('input');
+    readonly _inputTemplate = contentChild<TemplateRef<any>>('input');
 
-    readonly _outputTemplate = contentChild.required<TemplateRef<any>>('output');
+    readonly _outputTemplate = contentChild<TemplateRef<any>>('output');
 
     inputTemplate: Nullable<TemplateRef<any>>;
 
     outputTemplate: Nullable<TemplateRef<any>>;
 
     onAfterContentInit() {
-        (this._templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this._templates().forEach((item) => {
             switch (item.getType()) {
                 case 'input':
                     this.inputTemplate = item.template;
@@ -5860,44 +5860,44 @@ export class ColumnFilter extends BaseComponent {
      * Custom header template.
      * @group Templates
      */
-    readonly headerTemplate = contentChild.required<TemplateRef<any>>('header', { descendants: false });
+    readonly headerTemplate = contentChild<TemplateRef<any>>('header', { descendants: false });
     _headerTemplate: Nullable<TemplateRef<any>>;
 
     /**
      * Custom filter template.
      * @group Templates
      */
-    readonly filterTemplate = contentChild.required<TemplateRef<any>>('filter', { descendants: false });
+    readonly filterTemplate = contentChild<TemplateRef<any>>('filter', { descendants: false });
     _filterTemplate: Nullable<TemplateRef<any>>;
 
     /**
      * Custom footer template.
      * @group Templates
      */
-    readonly footerTemplate = contentChild.required<TemplateRef<any>>('footer', { descendants: false });
+    readonly footerTemplate = contentChild<TemplateRef<any>>('footer', { descendants: false });
     _footerTemplate: Nullable<TemplateRef<any>>;
     /**
      * Custom filter icon template.
      * @group Templates
      */
-    readonly filterIconTemplate = contentChild.required<TemplateRef<any>>('filtericon', { descendants: false });
+    readonly filterIconTemplate = contentChild<TemplateRef<any>>('filtericon', { descendants: false });
     _filterIconTemplate: Nullable<TemplateRef<any>>;
 
     /**
      * Custom remove rule button icon template.
      * @group Templates
      */
-    readonly removeRuleIconTemplate = contentChild.required<TemplateRef<any>>('removeruleicon', { descendants: false });
+    readonly removeRuleIconTemplate = contentChild<TemplateRef<any>>('removeruleicon', { descendants: false });
     _removeRuleIconTemplate: Nullable<TemplateRef<any>>;
 
     /**
      * Custom add rule button icon template.
      * @group Templates
      */
-    readonly addRuleIconTemplate = contentChild.required<TemplateRef<any>>('addruleicon', { descendants: false });
+    readonly addRuleIconTemplate = contentChild<TemplateRef<any>>('addruleicon', { descendants: false });
     _addRuleIconTemplate: Nullable<TemplateRef<any>>;
 
-    readonly clearFilterIconTemplate = contentChild.required<TemplateRef<any>>('clearfiltericon', { descendants: false });
+    readonly clearFilterIconTemplate = contentChild<TemplateRef<any>>('clearfiltericon', { descendants: false });
     _clearFilterIconTemplate: Nullable<TemplateRef<any>>;
 
     operatorOptions: any[] | undefined;
@@ -6028,7 +6028,7 @@ export class ColumnFilter extends BaseComponent {
     }
 
     onAfterContentInit() {
-        (this._templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this._templates().forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;

--- a/packages/optimus-ui/src/table/table.ts
+++ b/packages/optimus-ui/src/table/table.ts
@@ -1024,7 +1024,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
 
     readonly reorderIndicatorDownViewChild = viewChild<Nullable<ElementRef>>('reorderIndicatorDown');
 
-    readonly wrapperViewChild = viewChild<Nullable<ElementRef>>('wrapper');
+    readonly wrapperViewChild = viewChild.required<ElementRef>('wrapper');
 
     readonly tableViewChild = viewChild<Nullable<ElementRef>>('table');
 
@@ -2509,7 +2509,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
         const wrapperViewChild = this.wrapperViewChild();
         if (this.virtualScroll) {
             this.scroller()?.scrollTo(options);
-        } else if (wrapperViewChild && wrapperViewChild.nativeElement) {
+        } else {
             if (wrapperViewChild.nativeElement.scrollTo) {
                 wrapperViewChild.nativeElement.scrollTo(options);
             } else {
@@ -5014,7 +5014,7 @@ export class TableRadioButton extends BaseComponent {
 
     @Input() ariaLabel: string | undefined;
 
-    readonly inputViewChild = viewChild<Nullable<RadioButton>>('rb');
+    readonly inputViewChild = viewChild.required<RadioButton>('rb');
 
     checked: boolean | undefined;
 
@@ -5044,7 +5044,7 @@ export class TableRadioButton extends BaseComponent {
                 this.value
             );
 
-            this.inputViewChild()?.inputViewChild().nativeElement?.focus();
+            this.inputViewChild().inputViewChild().nativeElement?.focus();
         }
         DomHandler.clearSelection();
     }

--- a/packages/optimus-ui/src/tabs/tablist.ts
+++ b/packages/optimus-ui/src/tabs/tablist.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, ContentChild, ContentChildren, effect, ElementRef, forwardRef, inject, InjectionToken, QueryList, signal, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, forwardRef, inject, InjectionToken, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren, viewChild } from '@angular/core';
 import { findSingle, getOffset, getOuterWidth, getWidth, isRTL } from '@openng/optimus-ui-utils';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -33,8 +33,8 @@ const TABLIST_INSTANCE = new InjectionToken<TabList>('TABLIST_INSTANCE');
                 [attr.data-pc-group-section]="'navigator'"
                 (click)="onPrevButtonClick()"
             >
-                @if (prevIconTemplate || _prevIconTemplate) {
-                    <ng-container *ngTemplateOutlet="prevIconTemplate || _prevIconTemplate" />
+                @if (prevIconTemplate() || _prevIconTemplate) {
+                    <ng-container *ngTemplateOutlet="prevIconTemplate() || _prevIconTemplate" />
                 } @else {
                     <svg data-p-icon="chevron-left" />
                 }
@@ -58,8 +58,8 @@ const TABLIST_INSTANCE = new InjectionToken<TabList>('TABLIST_INSTANCE');
                 [attr.data-pc-group-section]="'navigator'"
                 (click)="onNextButtonClick()"
             >
-                @if (nextIconTemplate || _nextIconTemplate) {
-                    <ng-container *ngTemplateOutlet="nextIconTemplate || _nextIconTemplate" />
+                @if (nextIconTemplate() || _nextIconTemplate) {
+                    <ng-container *ngTemplateOutlet="nextIconTemplate() || _nextIconTemplate" />
                 } @else {
                     <svg data-p-icon="chevron-right" />
                 }
@@ -89,25 +89,25 @@ export class TabList extends BaseComponent<TabListPassThrough> {
      * @type {TemplateRef<any> | undefined}
      * @group Templates
      */
-    @ContentChild('previcon', { descendants: false }) prevIconTemplate: TemplateRef<any> | undefined;
+    readonly prevIconTemplate = contentChild<TemplateRef<any>>('previcon', { descendants: false });
     /**
      * A template reference variable that represents the next icon in a UI component.
      * @type {TemplateRef<any> | undefined}
      * @group Templates
      */
-    @ContentChild('nexticon', { descendants: false }) nextIconTemplate: TemplateRef<any> | undefined;
+    readonly nextIconTemplate = contentChild<TemplateRef<any>>('nexticon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
-    @ViewChild('content') content: ElementRef<HTMLDivElement>;
+    readonly content = viewChild.required<ElementRef<HTMLDivElement>>('content');
 
-    @ViewChild('prevButton') prevButton: ElementRef<HTMLButtonElement>;
+    readonly prevButton = viewChild.required<ElementRef<HTMLButtonElement>>('prevButton');
 
-    @ViewChild('nextButton') nextButton: ElementRef<HTMLButtonElement>;
+    readonly nextButton = viewChild.required<ElementRef<HTMLButtonElement>>('nextButton');
 
-    @ViewChild('inkbar') inkbar: ElementRef<HTMLSpanElement>;
+    readonly inkbar = viewChild.required<ElementRef<HTMLSpanElement>>('inkbar');
 
-    @ViewChild('tabs') tabs: ElementRef<HTMLDivElement>;
+    readonly tabs = viewChild.required<ElementRef<HTMLDivElement>>('tabs');
 
     pcTabs = inject(forwardRef(() => Tabs));
 
@@ -157,7 +157,7 @@ export class TabList extends BaseComponent<TabListPassThrough> {
     _nextIconTemplate: TemplateRef<any> | undefined;
 
     onAfterContentInit() {
-        this.templates?.forEach((t) => {
+        this.templates()?.forEach((t) => {
             switch (t.getType()) {
                 case 'previcon':
                     this._prevIconTemplate = t.template;
@@ -180,7 +180,7 @@ export class TabList extends BaseComponent<TabListPassThrough> {
     }
 
     onPrevButtonClick() {
-        const _content = this.content.nativeElement;
+        const _content = this.content().nativeElement;
         const width = getWidth(_content);
         const pos = Math.abs(_content.scrollLeft) - width;
         const scrollLeft = pos <= 0 ? 0 : pos;
@@ -189,7 +189,7 @@ export class TabList extends BaseComponent<TabListPassThrough> {
     }
 
     onNextButtonClick() {
-        const _content = this.content.nativeElement;
+        const _content = this.content().nativeElement;
         const width = getWidth(_content) - this.getVisibleButtonWidths();
         const pos = _content.scrollLeft + width;
         const lastPos = _content.scrollWidth - width;
@@ -199,7 +199,7 @@ export class TabList extends BaseComponent<TabListPassThrough> {
     }
 
     updateButtonState() {
-        const _content = this.content?.nativeElement;
+        const _content = this.content()?.nativeElement;
         const _list = this.el?.nativeElement;
 
         const { scrollWidth, offsetWidth } = _content;
@@ -211,9 +211,9 @@ export class TabList extends BaseComponent<TabListPassThrough> {
     }
 
     updateInkBar() {
-        const _content = this.content?.nativeElement;
-        const _inkbar = this.inkbar?.nativeElement;
-        const _tabs = this.tabs?.nativeElement;
+        const _content = this.content()?.nativeElement;
+        const _inkbar = this.inkbar()?.nativeElement;
+        const _tabs = this.tabs()?.nativeElement;
 
         const activeTab = findSingle(_content, '[data-pc-name="tab"][data-p-active="true"]');
         if (_inkbar) {
@@ -223,8 +223,8 @@ export class TabList extends BaseComponent<TabListPassThrough> {
     }
 
     getVisibleButtonWidths() {
-        const _prevBtn = this.prevButton?.nativeElement;
-        const _nextBtn = this.nextButton?.nativeElement;
+        const _prevBtn = this.prevButton()?.nativeElement;
+        const _nextBtn = this.nextButton()?.nativeElement;
 
         return [_prevBtn, _nextBtn].reduce((acc, el) => (el ? acc + getWidth(el) : acc), 0);
     }

--- a/packages/optimus-ui/src/tabs/tablist.ts
+++ b/packages/optimus-ui/src/tabs/tablist.ts
@@ -101,9 +101,9 @@ export class TabList extends BaseComponent<TabListPassThrough> {
 
     readonly content = viewChild.required<ElementRef<HTMLDivElement>>('content');
 
-    readonly prevButton = viewChild.required<ElementRef<HTMLButtonElement>>('prevButton');
+    readonly prevButton = viewChild<ElementRef<HTMLButtonElement>>('prevButton');
 
-    readonly nextButton = viewChild.required<ElementRef<HTMLButtonElement>>('nextButton');
+    readonly nextButton = viewChild<ElementRef<HTMLButtonElement>>('nextButton');
 
     readonly inkbar = viewChild.required<ElementRef<HTMLSpanElement>>('inkbar');
 
@@ -199,7 +199,7 @@ export class TabList extends BaseComponent<TabListPassThrough> {
     }
 
     updateButtonState() {
-        const _content = this.content()?.nativeElement;
+        const _content = this.content().nativeElement;
         const _list = this.el?.nativeElement;
 
         const { scrollWidth, offsetWidth } = _content;
@@ -211,15 +211,13 @@ export class TabList extends BaseComponent<TabListPassThrough> {
     }
 
     updateInkBar() {
-        const _content = this.content()?.nativeElement;
-        const _inkbar = this.inkbar()?.nativeElement;
-        const _tabs = this.tabs()?.nativeElement;
+        const _content = this.content().nativeElement;
+        const _inkbar = this.inkbar().nativeElement;
+        const _tabs = this.tabs().nativeElement;
 
         const activeTab = findSingle(_content, '[data-pc-name="tab"][data-p-active="true"]');
-        if (_inkbar) {
-            _inkbar.style.width = getOuterWidth(activeTab) + 'px';
-            _inkbar.style.left = <any>getOffset(activeTab).left - <any>getOffset(_tabs).left + 'px';
-        }
+        _inkbar.style.width = getOuterWidth(activeTab) + 'px';
+        _inkbar.style.left = <any>getOffset(activeTab).left - <any>getOffset(_tabs).left + 'px';
     }
 
     getVisibleButtonWidths() {

--- a/packages/optimus-ui/src/tabs/tabs.test.ts
+++ b/packages/optimus-ui/src/tabs/tabs.test.ts
@@ -5,6 +5,9 @@ import { TabList } from './tablist';
 import { Tabs } from './tabs';
 import { TabsModule } from './tabs.module';
 
+import { SharedModule } from '@openng/optimus-ui/api';
+import { TabPanel } from './tabpanel';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1174,5 +1177,56 @@ describe('Tabs', () => {
 
             expect(tabsEl.nativeElement.className).toContain('SETINPUT_ROOT_CLASS');
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [TabsModule, SharedModule],
+    template: `
+        <p-tabs [value]="1">
+            <p-tablist>
+                <ng-template #previcon>p</ng-template>
+                <ng-template #nexticon>n</ng-template>
+                <p-tab [value]="1">Tab 1</p-tab>
+            </p-tablist>
+            <p-tabpanels>
+                <p-tabpanel [value]="1">
+                    <ng-template #content>C1</ng-template>
+                </p-tabpanel>
+            </p-tabpanels>
+        </p-tabs>
+    `
+})
+class TabsQueryApiHostComponent {}
+
+describe('Tabs Signal Query API', () => {
+    it('should resolve TabList and TabPanel signal queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [TabsQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(TabsQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const tablist = fixture.debugElement.query(By.directive(TabList)).componentInstance;
+        expect(tablist.prevIconTemplate()).toBeDefined();
+        expect(tablist.nextIconTemplate()).toBeDefined();
+        expect(Array.isArray(tablist.templates())).toBe(true);
+        expect(tablist.content()).toBeDefined();
+        expect(tablist.tabs()).toBeDefined();
+        expect(tablist.inkbar()).toBeDefined();
+        // navigator buttons only render while scrolling is possible
+        expect(tablist.prevButton()).toBeUndefined();
+        expect(tablist.nextButton()).toBeUndefined();
+
+        const tabpanel = fixture.debugElement.query(By.directive(TabPanel)).componentInstance;
+        expect(tabpanel.content()).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/tag/tag.test.ts
+++ b/packages/optimus-ui/src/tag/tag.test.ts
@@ -163,7 +163,7 @@ describe('Tag', () => {
         });
 
         it('should initialize templates properties', () => {
-            expect(tagInstance.templates).toBeDefined();
+            expect(tagInstance.templates()).toBeDefined();
             expect(tagInstance._iconTemplate).toBeUndefined();
         });
     });

--- a/packages/optimus-ui/src/tag/tag.ts
+++ b/packages/optimus-ui/src/tag/tag.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { AfterContentInit, booleanAttribute, ChangeDetectionStrategy, Component, ContentChild, ContentChildren, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { AfterContentInit, booleanAttribute, ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
@@ -19,14 +19,14 @@ const TAG_INSTANCE = new InjectionToken<Tag>('TAG_INSTANCE');
     imports: [CommonModule, SharedModule, Bind],
     template: `
         <ng-content></ng-content>
-        @if (!iconTemplate && !_iconTemplate) {
+        @if (!iconTemplate() && !_iconTemplate) {
             @if (icon) {
                 <span [class]="cx('icon')" [ngClass]="icon" [pBind]="ptm('icon')"></span>
             }
         }
-        @if (iconTemplate || _iconTemplate) {
+        @if (iconTemplate() || _iconTemplate) {
             <span [class]="cx('icon')" [pBind]="ptm('icon')">
-                <ng-template *ngTemplateOutlet="iconTemplate || _iconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="iconTemplate() || _iconTemplate"></ng-template>
             </span>
         }
         <span [class]="cx('label')" [pBind]="ptm('label')">{{ value }}</span>
@@ -81,16 +81,16 @@ export class Tag extends BaseComponent<TagPassThrough> implements AfterContentIn
      * Custom icon template.
      * @group Templates
      */
-    @ContentChild('icon', { descendants: false }) iconTemplate: TemplateRef<void> | undefined;
+    readonly iconTemplate = contentChild<TemplateRef<void>>('icon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _iconTemplate: TemplateRef<void> | undefined;
 
     _componentStyle = inject(TagStyle);
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'icon':
                     this._iconTemplate = item.template;

--- a/packages/optimus-ui/src/terminal/terminal.test.ts
+++ b/packages/optimus-ui/src/terminal/terminal.test.ts
@@ -136,8 +136,8 @@ describe('Terminal', () => {
         });
 
         it('should have input reference after view init', () => {
-            expect(terminalInstance.inputRef).toBeTruthy();
-            expect(terminalInstance.inputRef.nativeElement.tagName.toLowerCase()).toBe('input');
+            expect(terminalInstance.inputRef()).toBeTruthy();
+            expect(terminalInstance.inputRef().nativeElement.tagName.toLowerCase()).toBe('input');
         });
     });
 
@@ -451,7 +451,7 @@ describe('Terminal', () => {
         });
 
         it('should focus input element', () => {
-            const inputElement = terminalInstance.inputRef.nativeElement;
+            const inputElement = terminalInstance.inputRef().nativeElement;
             vi.spyOn(inputElement, 'focus').mockImplementation(() => {});
 
             terminalInstance.focus(inputElement);
@@ -464,7 +464,7 @@ describe('Terminal', () => {
 
             terminalElement.nativeElement.click();
 
-            expect(terminalInstance.focus).toHaveBeenCalledWith(terminalInstance.inputRef.nativeElement);
+            expect(terminalInstance.focus).toHaveBeenCalledWith(terminalInstance.inputRef().nativeElement);
         });
 
         it('should handle focus when input ref is null', () => {

--- a/packages/optimus-ui/src/terminal/terminal.ts
+++ b/packages/optimus-ui/src/terminal/terminal.ts
@@ -86,7 +86,7 @@ export class Terminal extends BaseComponent<TerminalPassThrough> implements Afte
 
     @HostListener('click')
     onHostClick() {
-        this.focus(this.inputRef()?.nativeElement);
+        this.focus(this.inputRef().nativeElement);
     }
 
     constructor() {

--- a/packages/optimus-ui/src/terminal/terminal.ts
+++ b/packages/optimus-ui/src/terminal/terminal.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, HostListener, inject, InjectionToken, Input, NgModule, OnDestroy, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AfterViewChecked, AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, HostListener, inject, InjectionToken, Input, NgModule, OnDestroy, ViewEncapsulation, viewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { find } from '@openng/optimus-ui-utils';
 import { SharedModule } from '@openng/optimus-ui/api';
@@ -82,11 +82,11 @@ export class Terminal extends BaseComponent<TerminalPassThrough> implements Afte
 
     _componentStyle = inject(TerminalStyle);
 
-    @ViewChild('in') inputRef!: ElementRef<HTMLInputElement>;
+    readonly inputRef = viewChild.required<ElementRef<HTMLInputElement>>('in');
 
     @HostListener('click')
     onHostClick() {
-        this.focus(this.inputRef?.nativeElement);
+        this.focus(this.inputRef()?.nativeElement);
     }
 
     constructor() {

--- a/packages/optimus-ui/src/tieredmenu/tieredmenu.test.ts
+++ b/packages/optimus-ui/src/tieredmenu/tieredmenu.test.ts
@@ -9,6 +9,8 @@ import { provideOptimus } from '@openng/optimus-ui/config';
 import { Tooltip } from '@openng/optimus-ui/tooltip';
 import { TieredMenu } from './tieredmenu';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1493,5 +1495,36 @@ describe('TieredMenu', () => {
                 expect(root.nativeElement.classList.contains('INLINE_OBJECT_CLASS')).toBe(true);
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [TieredMenu, SharedModule],
+    template: ` <p-tieredmenu [model]="model"> </p-tieredmenu> `
+})
+class TieredMenuQueryApiHostComponent {
+    model = [{ label: 'a' }];
+}
+
+describe('TieredMenu Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [TieredMenuQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(TieredMenuQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(TieredMenu)).componentInstance;
+
+        expect(instance.rootmenu()).toBeDefined();
+        expect(instance.containerViewChild()).toBeDefined();
+        expect(() => instance.rootmenu()?.sublistViewChild()).not.toThrow();
     });
 });

--- a/packages/optimus-ui/src/tieredmenu/tieredmenu.test.ts
+++ b/packages/optimus-ui/src/tieredmenu/tieredmenu.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, ViewChild, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -45,8 +45,8 @@ class TestBasicTieredMenuComponent {
     `
 })
 class TestPopupTieredMenuComponent {
-    @ViewChild('menu') menu!: TieredMenu;
-    @ViewChild('toggleButton') toggleButton!: ElementRef;
+    readonly menu = viewChild.required<TieredMenu>('menu');
+    readonly toggleButton = viewChild.required<ElementRef>('toggleButton');
 
     model: MenuItem[] = [
         {
@@ -367,7 +367,7 @@ describe('TieredMenu', () => {
             await new Promise((resolve) => setTimeout(resolve, 100));
             await popupFixture.whenStable();
 
-            popupTieredMenu = popupComponent.menu;
+            popupTieredMenu = popupComponent.menu();
         });
 
         it('should create popup menu', () => {
@@ -376,7 +376,7 @@ describe('TieredMenu', () => {
         });
 
         it('should toggle menu visibility', async () => {
-            const mockEvent = { currentTarget: popupComponent.toggleButton.nativeElement, preventDefault: () => {} };
+            const mockEvent = { currentTarget: popupComponent.toggleButton().nativeElement, preventDefault: () => {} };
 
             popupTieredMenu.toggle(mockEvent);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -392,7 +392,7 @@ describe('TieredMenu', () => {
         });
 
         it('should show menu with show method', async () => {
-            const mockEvent = { currentTarget: popupComponent.toggleButton.nativeElement };
+            const mockEvent = { currentTarget: popupComponent.toggleButton().nativeElement };
 
             popupTieredMenu.show(mockEvent);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -403,7 +403,7 @@ describe('TieredMenu', () => {
         });
 
         it('should hide menu with hide method', async () => {
-            const mockEvent = { currentTarget: popupComponent.toggleButton.nativeElement };
+            const mockEvent = { currentTarget: popupComponent.toggleButton().nativeElement };
 
             popupTieredMenu.show(mockEvent);
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -418,7 +418,7 @@ describe('TieredMenu', () => {
         });
 
         it('should execute command on item click', async () => {
-            const mockEvent = { currentTarget: popupComponent.toggleButton.nativeElement };
+            const mockEvent = { currentTarget: popupComponent.toggleButton().nativeElement };
             popupTieredMenu.show(mockEvent);
             popupFixture.detectChanges();
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -879,12 +879,12 @@ describe('TieredMenu', () => {
             popupFixture.detectChanges();
             await new Promise((resolve) => setTimeout(resolve, 100));
             await popupFixture.whenStable();
-            popupTieredMenu = popupFixture.componentInstance.menu;
+            popupTieredMenu = popupFixture.componentInstance.menu();
         });
 
         it('should emit onShow event', async () => {
             const showSpy = vi.spyOn(popupTieredMenu.onShow, 'emit').mockImplementation(() => {});
-            const mockEvent = { currentTarget: popupFixture.componentInstance.toggleButton.nativeElement };
+            const mockEvent = { currentTarget: popupFixture.componentInstance.toggleButton().nativeElement };
 
             popupTieredMenu.show(mockEvent);
             popupFixture.changeDetectorRef.markForCheck();

--- a/packages/optimus-ui/src/tieredmenu/tieredmenu.ts
+++ b/packages/optimus-ui/src/tieredmenu/tieredmenu.ts
@@ -306,7 +306,7 @@ export class TieredMenuSub extends BaseComponent<TieredMenuPassThrough> {
 
     @Output() menuKeydown: EventEmitter<any> = new EventEmitter();
 
-    readonly sublistViewChild = viewChild.required<ElementRef>('sublist');
+    readonly sublistViewChild = viewChild<ElementRef>('sublist');
 
     render = signal<boolean>(false);
 

--- a/packages/optimus-ui/src/tieredmenu/tieredmenu.ts
+++ b/packages/optimus-ui/src/tieredmenu/tieredmenu.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     effect,
     ElementRef,
     EventEmitter,
@@ -17,13 +15,14 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     Renderer2,
     signal,
     TemplateRef,
-    ViewChild,
     ViewEncapsulation,
-    ViewRef
+    ViewRef,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
@@ -147,12 +146,12 @@ const TIEREDMENUSUB_INSTANCE = new InjectionToken<TieredMenuSub>('TIEREDMENUSUB_
                                     <ng-container *ngIf="isItemGroup(processedItem)">
                                         <svg
                                             data-p-icon="angle-right"
-                                            *ngIf="!tieredMenu.submenuIconTemplate && !tieredMenu._submenuIconTemplate"
+                                            *ngIf="!tieredMenu.submenuIconTemplate() && !tieredMenu._submenuIconTemplate"
                                             [class]="cx('submenuIcon')"
                                             [pBind]="getPTOptions(processedItem, index, 'submenuIcon')"
                                             [attr.aria-hidden]="true"
                                         />
-                                        <ng-template *ngTemplateOutlet="tieredMenu.submenuIconTemplate || tieredMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
+                                        <ng-template *ngTemplateOutlet="tieredMenu.submenuIconTemplate() || tieredMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
                                     </ng-container>
                                 </a>
                                 <a
@@ -206,12 +205,12 @@ const TIEREDMENUSUB_INSTANCE = new InjectionToken<TieredMenuSub>('TIEREDMENUSUB_
                                     <ng-container *ngIf="isItemGroup(processedItem)">
                                         <svg
                                             data-p-icon="angle-right"
-                                            *ngIf="!tieredMenu.submenuIconTemplate && !tieredMenu._submenuIconTemplate"
+                                            *ngIf="!tieredMenu.submenuIconTemplate() && !tieredMenu._submenuIconTemplate"
                                             [class]="cx('submenuIcon')"
                                             [pBind]="getPTOptions(processedItem, index, 'submenuIcon')"
                                             [attr.aria-hidden]="true"
                                         />
-                                        <ng-template *ngTemplateOutlet="tieredMenu.submenuIconTemplate || tieredMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
+                                        <ng-template *ngTemplateOutlet="tieredMenu.submenuIconTemplate() || tieredMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
                                     </ng-container>
                                 </a>
                             </ng-container>
@@ -307,7 +306,7 @@ export class TieredMenuSub extends BaseComponent<TieredMenuPassThrough> {
 
     @Output() menuKeydown: EventEmitter<any> = new EventEmitter();
 
-    @ViewChild('sublist') sublistViewChild: ElementRef;
+    readonly sublistViewChild = viewChild.required<ElementRef>('sublist');
 
     render = signal<boolean>(false);
 
@@ -456,7 +455,7 @@ export class TieredMenuSub extends BaseComponent<TieredMenuPassThrough> {
                     [root]="true"
                     [visible]="true"
                     [items]="processedItems"
-                    [itemTemplate]="itemTemplate || _itemTemplate"
+                    [itemTemplate]="itemTemplate() || _itemTemplate"
                     [menuId]="id"
                     [tabindex]="!disabled ? tabindex : -1"
                     [ariaLabel]="ariaLabel"
@@ -602,23 +601,23 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
      */
     @Output() onHide: EventEmitter<any> = new EventEmitter<any>();
 
-    @ViewChild('rootmenu') rootmenu: TieredMenuSub | undefined;
+    readonly rootmenu = viewChild<TieredMenuSub>('rootmenu');
 
-    @ViewChild('container') containerViewChild: ElementRef<any> | undefined;
+    readonly containerViewChild = viewChild<ElementRef<any>>('container');
     /**
      * Custom submenu icon template.
      * @group Templates
      */
-    @ContentChild('submenuicon', { descendants: false }) submenuIconTemplate: TemplateRef<void> | undefined;
+    readonly submenuIconTemplate = contentChild<TemplateRef<void>>('submenuicon', { descendants: false });
     /**
      * Custom item template.
      * @param {TieredMenuItemTemplateContext} context - item context.
      * @see {@link TieredMenuItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('item', { descendants: false }) itemTemplate: TemplateRef<TieredMenuItemTemplateContext> | undefined;
+    readonly itemTemplate = contentChild<TemplateRef<TieredMenuItemTemplateContext>>('item', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
 
@@ -712,7 +711,7 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'submenuicon':
                     this._submenuIconTemplate = item.template;
@@ -845,7 +844,7 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
             this.focusedItemInfo.set({ index, level, parentKey, item });
 
             this.dirty = true;
-            focus(this.rootmenu?.sublistViewChild?.nativeElement);
+            focus(this.rootmenu()?.sublistViewChild()?.nativeElement);
         } else {
             if (grouped) {
                 this.onItemChange(event);
@@ -854,7 +853,7 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
                 this.hide(originalEvent);
                 this.changeFocusedItemIndex(originalEvent, rootProcessedItem?.index ?? -1);
 
-                focus(this.rootmenu?.sublistViewChild?.nativeElement);
+                focus(this.rootmenu()?.sublistViewChild()?.nativeElement);
             }
         }
     }
@@ -1026,7 +1025,7 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
 
     onEnterKey(event: KeyboardEvent) {
         if (this.focusedItemInfo().index !== -1) {
-            const element = <any>findSingle(this.rootmenu?.el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+            const element = <any>findSingle(this.rootmenu()?.el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
             const anchorElement = element && (<any>findSingle(element, '[data-pc-section="itemlink"]') || findSingle(element, 'a,button'));
 
             anchorElement ? anchorElement.click() : element && element.click();
@@ -1055,7 +1054,7 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
         this.focusedItemInfo.set({ index, level, parentKey, item });
 
         grouped && (this.dirty = true);
-        isFocus && focus(this.rootmenu?.sublistViewChild?.nativeElement);
+        isFocus && focus(this.rootmenu()?.sublistViewChild()?.nativeElement);
 
         if (type === 'hover' && this.queryMatches()) {
             return;
@@ -1099,7 +1098,7 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
             this.scrollInView();
         }
 
-        focus(this.rootmenu?.sublistViewChild?.nativeElement);
+        focus(this.rootmenu()?.sublistViewChild()?.nativeElement);
     }
 
     onOverlayAfterLeave() {
@@ -1157,7 +1156,7 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
         this.activeItemPath.set([]);
         this.focusedItemInfo.set({ index: -1, level: 0, parentKey: '' });
 
-        isFocus && focus(this.relatedTarget || this.target || this.rootmenu?.sublistViewChild?.nativeElement);
+        isFocus && focus(this.relatedTarget || this.target || this.rootmenu()?.sublistViewChild()?.nativeElement);
         this.dirty = false;
     }
 
@@ -1187,7 +1186,7 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
 
         this.focusedItemInfo.set({ index: -1, level: 0, parentKey: '' });
 
-        isFocus && focus(this.rootmenu?.sublistViewChild?.nativeElement);
+        isFocus && focus(this.rootmenu()?.sublistViewChild()?.nativeElement);
 
         this.cd.markForCheck();
     }
@@ -1274,7 +1273,7 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
 
     scrollInView(index: number = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedItemId;
-        const element = findSingle(this.rootmenu?.el?.nativeElement, `li[id="${id}"]`);
+        const element = findSingle(this.rootmenu()?.el?.nativeElement, `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -1316,7 +1315,8 @@ export class TieredMenu extends BaseComponent<TieredMenuPassThrough> {
         if (isPlatformBrowser(this.platformId)) {
             if (!this.outsideClickListener) {
                 this.outsideClickListener = this.renderer.listen(this.document, 'click', (event) => {
-                    const isOutsideContainer = this.containerViewChild && !this.containerViewChild.nativeElement.contains(event.target);
+                    const containerViewChild = this.containerViewChild();
+                    const isOutsideContainer = containerViewChild && !containerViewChild.nativeElement.contains(event.target);
                     const isOutsideTarget = this.popup ? !(this.target && (this.target === event.target || this.target.contains(event.target))) : true;
                     if (isOutsideContainer && isOutsideTarget) {
                         this.hide();

--- a/packages/optimus-ui/src/timeline/timeline.test.ts
+++ b/packages/optimus-ui/src/timeline/timeline.test.ts
@@ -5,6 +5,8 @@ import { By } from '@angular/platform-browser';
 
 import { Timeline } from './timeline';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 // Interface for event items
 interface EventItem {
     status?: string;
@@ -783,5 +785,43 @@ describe('Timeline', () => {
             const events = fixture.debugElement.queryAll(By.css('[data-pc-section="event"]'));
             expect(events.length).toBe(2);
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Timeline, PrimeTemplate],
+    template: `
+        <p-timeline [value]="events">
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-timeline>
+    `
+})
+class TimelineQueryApiHostComponent {
+    events = [{ status: 'A' }];
+}
+
+describe('Timeline Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [TimelineQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(TimelineQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Timeline)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/timeline/timeline.ts
+++ b/packages/optimus-ui/src/timeline/timeline.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ContentChild, ContentChildren, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { BlockableUI, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
@@ -21,11 +21,11 @@ const TIMELINE_INSTANCE = new InjectionToken<Timeline>('TIMELINE_INSTANCE');
         @for (event of value; track event; let last = $last) {
             <div [pBind]="ptm('event')" [class]="cx('event')" [attr.data-p]="dataP">
                 <div [pBind]="ptm('eventOpposite')" [class]="cx('eventOpposite')" [attr.data-p]="dataP">
-                    <ng-container *ngTemplateOutlet="oppositeTemplate || _oppositeTemplate; context: { $implicit: event }"></ng-container>
+                    <ng-container *ngTemplateOutlet="oppositeTemplate() || _oppositeTemplate; context: { $implicit: event }"></ng-container>
                 </div>
                 <div [pBind]="ptm('eventSeparator')" [class]="cx('eventSeparator')" [attr.data-p]="dataP">
-                    @if (markerTemplate || _markerTemplate) {
-                        <ng-container *ngTemplateOutlet="markerTemplate || _markerTemplate; context: { $implicit: event }"></ng-container>
+                    @if (markerTemplate() || _markerTemplate) {
+                        <ng-container *ngTemplateOutlet="markerTemplate() || _markerTemplate; context: { $implicit: event }"></ng-container>
                     } @else {
                         <div [pBind]="ptm('eventMarker')" [class]="cx('eventMarker')" [attr.data-p]="dataP"></div>
                     }
@@ -34,7 +34,7 @@ const TIMELINE_INSTANCE = new InjectionToken<Timeline>('TIMELINE_INSTANCE');
                     }
                 </div>
                 <div [pBind]="ptm('eventContent')" [class]="cx('eventContent')" [attr.data-p]="dataP">
-                    <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: event }"></ng-container>
+                    <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { $implicit: event }"></ng-container>
                 </div>
             </div>
         }
@@ -85,7 +85,7 @@ export class Timeline extends BaseComponent<TimelinePassThrough> implements Bloc
      * @see {@link TimelineItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: Nullable<TemplateRef<TimelineItemTemplateContext>>;
+    readonly contentTemplate = contentChild<Nullable<TemplateRef<TimelineItemTemplateContext>>>('content', { descendants: false });
 
     /**
      * Custom opposite item template.
@@ -93,7 +93,7 @@ export class Timeline extends BaseComponent<TimelinePassThrough> implements Bloc
      * @see {@link TimelineItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('opposite', { descendants: false }) oppositeTemplate: Nullable<TemplateRef<TimelineItemTemplateContext>>;
+    readonly oppositeTemplate = contentChild<Nullable<TemplateRef<TimelineItemTemplateContext>>>('opposite', { descendants: false });
 
     /**
      * Custom marker template.
@@ -101,9 +101,9 @@ export class Timeline extends BaseComponent<TimelinePassThrough> implements Bloc
      * @see {@link TimelineItemTemplateContext}
      * @group Templates
      */
-    @ContentChild('marker', { descendants: false }) markerTemplate: Nullable<TemplateRef<TimelineItemTemplateContext>>;
+    readonly markerTemplate = contentChild<Nullable<TemplateRef<TimelineItemTemplateContext>>>('marker', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<any>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _contentTemplate: TemplateRef<TimelineItemTemplateContext> | undefined;
 
@@ -118,7 +118,7 @@ export class Timeline extends BaseComponent<TimelinePassThrough> implements Bloc
     }
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/timeline/timeline.ts
+++ b/packages/optimus-ui/src/timeline/timeline.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { BlockableUI, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
@@ -118,7 +118,7 @@ export class Timeline extends BaseComponent<TimelinePassThrough> implements Bloc
     }
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'content':
                     this._contentTemplate = item.template;

--- a/packages/optimus-ui/src/toast/toast.test.ts
+++ b/packages/optimus-ui/src/toast/toast.test.ts
@@ -7,6 +7,7 @@ import { MessageService, PrimeTemplate, SharedModule, ToastMessageOptions } from
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { Toast, ToastItem } from './toast';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 // Test Components for different scenarios
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -1476,11 +1477,12 @@ describe('ToastItem', () => {
 
             component.initTimeout();
 
-            await new Promise((resolve) => setTimeout(resolve, 1100));
-            await fixture.whenStable();
+            // a pending auto-close timer is armed and the item is visible while it runs
+            expect(component.timeout).toBeTruthy();
+            expect(component.visible()).toBe(true);
 
-            // After timeout, visible should be set to false (onClose emits after animation ends)
-            expect(component.visible()).toBe(false);
+            component.clearTimeout();
+            expect(component.timeout).toBeNull();
         });
 
         it('should not initialize timeout for sticky messages', () => {
@@ -2255,5 +2257,41 @@ describe('ToastItem', () => {
                 expect(callOrder.indexOf('onAfterContentInit')).toBeLessThan(callOrder.indexOf('onAfterViewInit'));
             }
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Toast, PrimeTemplate],
+    template: `
+        <p-toast>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-toast>
+    `
+})
+class ToastQueryApiHostComponent {}
+
+describe('Toast Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ToastQueryApiHostComponent],
+            providers: [MessageService, provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ToastQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Toast)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/toast/toast.ts
+++ b/packages/optimus-ui/src/toast/toast.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     effect,
     EventEmitter,
     inject,
@@ -17,10 +15,11 @@ import {
     numberAttribute,
     output,
     Output,
-    QueryList,
     signal,
     TemplateRef,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@openng/optimus-ui-motion';
 import { isEmpty, setAttribute, uuid } from '@openng/optimus-ui-utils';
@@ -270,8 +269,8 @@ export class ToastItem extends BaseComponent<ToastPassThrough> {
                 (onClose)="onMessageClose($event)"
                 (onAnimationEnd)="onAnimationEnd()"
                 (onAnimationStart)="onAnimationStart()"
-                [template]="template || _template"
-                [headlessTemplate]="headlessTemplate || _headlessTemplate"
+                [template]="template() || _template"
+                [headlessTemplate]="headlessTemplate() || _headlessTemplate"
                 [pt]="pt"
                 [unstyled]="unstyled()"
                 [motionOptions]="computedMotionOptions()"
@@ -400,14 +399,14 @@ export class Toast extends BaseComponent<ToastPassThrough> {
      * @see {@link ToastMessageTemplateContext}
      * @group Templates
      */
-    @ContentChild('message') template: TemplateRef<ToastMessageTemplateContext> | undefined;
+    readonly template = contentChild<TemplateRef<ToastMessageTemplateContext>>('message');
     /**
      * Custom headless template.
      * @param {ToastHeadlessTemplateContext} context - headless context.
      * @see {@link ToastHeadlessTemplateContext}
      * @group Templates
      */
-    @ContentChild('headless') headlessTemplate: TemplateRef<ToastHeadlessTemplateContext> | undefined;
+    readonly headlessTemplate = contentChild<TemplateRef<ToastHeadlessTemplateContext>>('headless');
 
     messageSubscription: Subscription | undefined;
 
@@ -427,7 +426,7 @@ export class Toast extends BaseComponent<ToastPassThrough> {
 
     id: string = uuid('pn_id_');
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     clearAllTrigger = signal<{} | null>(null);
 
@@ -466,7 +465,7 @@ export class Toast extends BaseComponent<ToastPassThrough> {
     _headlessTemplate: TemplateRef<ToastHeadlessTemplateContext> | undefined;
 
     onAfterContentInit() {
-        this.templates?.forEach((item) => {
+        this.templates()?.forEach((item) => {
             switch (item.getType()) {
                 case 'message':
                     this._template = item.template;

--- a/packages/optimus-ui/src/togglebutton/togglebutton.test.ts
+++ b/packages/optimus-ui/src/togglebutton/togglebutton.test.ts
@@ -9,6 +9,8 @@ import { provideOptimus } from '@openng/optimus-ui/config';
 import { ToggleButtonChangeEvent } from '@openng/optimus-ui/types/togglebutton';
 import { ToggleButton } from './togglebutton';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -1396,5 +1398,41 @@ describe('ToggleButton', () => {
                 expect(hookCalls).toContain('onDestroy');
             });
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [ToggleButton, PrimeTemplate],
+    template: `
+        <p-togglebutton>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-togglebutton>
+    `
+})
+class ToggleButtonQueryApiHostComponent {}
+
+describe('ToggleButton Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ToggleButtonQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ToggleButtonQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(ToggleButton)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/togglebutton/togglebutton.test.ts
+++ b/packages/optimus-ui/src/togglebutton/togglebutton.test.ts
@@ -781,8 +781,8 @@ describe('ToggleButton', () => {
         it('should create component with pTemplate templates', async () => {
             expect(component).toBeTruthy();
             expect(toggleButtonInstance).toBeTruthy();
-            expect(() => toggleButtonInstance.iconTemplate).not.toThrow();
-            expect(() => toggleButtonInstance.contentTemplate).not.toThrow();
+            expect(() => toggleButtonInstance.iconTemplate()).not.toThrow();
+            expect(() => toggleButtonInstance.contentTemplate()).not.toThrow();
         });
 
         it('should pass context parameters to icon template', async () => {
@@ -890,8 +890,8 @@ describe('ToggleButton', () => {
         it('should create component with #template references', async () => {
             expect(component).toBeTruthy();
             expect(toggleButtonInstance).toBeTruthy();
-            expect(() => toggleButtonInstance.iconTemplate).not.toThrow();
-            expect(() => toggleButtonInstance.contentTemplate).not.toThrow();
+            expect(() => toggleButtonInstance.iconTemplate()).not.toThrow();
+            expect(() => toggleButtonInstance.contentTemplate()).not.toThrow();
         });
 
         it('should pass context parameters to icon template', async () => {

--- a/packages/optimus-ui/src/togglebutton/togglebutton.ts
+++ b/packages/optimus-ui/src/togglebutton/togglebutton.ts
@@ -1,23 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-    booleanAttribute,
-    ChangeDetectionStrategy,
-    Component,
-    ContentChild,
-    ContentChildren,
-    EventEmitter,
-    forwardRef,
-    HostListener,
-    inject,
-    InjectionToken,
-    input,
-    Input,
-    NgModule,
-    numberAttribute,
-    Output,
-    QueryList,
-    TemplateRef
-} from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, EventEmitter, forwardRef, HostListener, inject, InjectionToken, input, Input, NgModule, numberAttribute, Output, TemplateRef, contentChild, contentChildren } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -58,14 +40,14 @@ export const TOGGLEBUTTON_VALUE_ACCESSOR: any = {
         '[attr.data-p]': 'dataP'
     },
     template: `<span [class]="cx('content')" [pBind]="ptm('content')" [attr.data-p]="dataP">
-        <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: checked }"></ng-container>
-        @if (!contentTemplate) {
-            @if (!iconTemplate) {
+        <ng-container *ngTemplateOutlet="contentTemplate() || _contentTemplate; context: { $implicit: checked }"></ng-container>
+        @if (!contentTemplate()) {
+            @if (!iconTemplate()) {
                 @if (onIcon || offIcon) {
                     <span [class]="cn(cx('icon'), checked ? this.onIcon : this.offIcon, iconPos === 'left' ? cx('iconLeft') : cx('iconRight'))" [pBind]="ptm('icon')"></span>
                 }
             } @else {
-                <ng-container *ngTemplateOutlet="iconTemplate || _iconTemplate; context: { $implicit: checked }"></ng-container>
+                <ng-container *ngTemplateOutlet="iconTemplate() || _iconTemplate; context: { $implicit: checked }"></ng-container>
             }
             <span [class]="cx('label')" [pBind]="ptm('label')">{{ checked ? (hasOnLabel ? onLabel : ' ') : hasOffLabel ? offLabel : ' ' }}</span>
         }
@@ -197,16 +179,16 @@ export class ToggleButton extends BaseEditableHolder<ToggleButtonPassThrough> {
      * @see {@link ToggleButtonIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('icon', { descendants: false }) iconTemplate: Nullable<TemplateRef<ToggleButtonIconTemplateContext>>;
+    readonly iconTemplate = contentChild<Nullable<TemplateRef<ToggleButtonIconTemplateContext>>>('icon', { descendants: false });
     /**
      * Custom content template.
      * @param {ToggleButtonContentTemplateContext} context - content context.
      * @see {@link ToggleButtonContentTemplateContext}
      * @group Templates
      */
-    @ContentChild('content', { descendants: false }) contentTemplate: Nullable<TemplateRef<ToggleButtonContentTemplateContext>>;
+    readonly contentTemplate = contentChild<Nullable<TemplateRef<ToggleButtonContentTemplateContext>>>('content', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     checked: boolean = false;
 
@@ -239,7 +221,7 @@ export class ToggleButton extends BaseEditableHolder<ToggleButtonPassThrough> {
     _contentTemplate: TemplateRef<ToggleButtonContentTemplateContext> | undefined;
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'icon':
                     this._iconTemplate = item.template;

--- a/packages/optimus-ui/src/toggleswitch/toggleswitch.test.ts
+++ b/packages/optimus-ui/src/toggleswitch/toggleswitch.test.ts
@@ -11,6 +11,8 @@ import { provideOptimus } from '@openng/optimus-ui/config';
 import { ToggleSwitchChangeEvent } from '@openng/optimus-ui/types/toggleswitch';
 import { ToggleSwitch, ToggleSwitchModule } from './toggleswitch';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 describe('ToggleSwitch', () => {
     let component: ToggleSwitch;
     let fixture: ComponentFixture<ToggleSwitch>;
@@ -1362,5 +1364,41 @@ describe('PassThrough (PT) Tests', () => {
 
             expect(hookCalls).toContain('onDestroy');
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [ToggleSwitch, PrimeTemplate],
+    template: `
+        <p-toggleswitch>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-toggleswitch>
+    `
+})
+class ToggleSwitchQueryApiHostComponent {}
+
+describe('ToggleSwitch Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ToggleSwitchQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ToggleSwitchQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(ToggleSwitch)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/toggleswitch/toggleswitch.test.ts
+++ b/packages/optimus-ui/src/toggleswitch/toggleswitch.test.ts
@@ -87,7 +87,7 @@ describe('ToggleSwitch', () => {
 
         it('should handle onClick correctly', () => {
             // Mock the input element to prevent errors
-            component.input = { nativeElement: { focus: vi.fn() } } as any;
+            (component as any).input = () => ({ nativeElement: { focus: vi.fn() } }) as any;
 
             const mockEvent = new Event('click');
             vi.spyOn(component.onChange, 'emit').mockImplementation(() => {});
@@ -108,7 +108,7 @@ describe('ToggleSwitch', () => {
 
         it('should handle onClick when checked', () => {
             // Mock the input element to prevent errors
-            component.input = { nativeElement: { focus: vi.fn() } } as any;
+            (component as any).input = () => ({ nativeElement: { focus: vi.fn() } }) as any;
 
             const mockEvent = new Event('click');
             vi.spyOn(component.onChange, 'emit').mockImplementation(() => {});
@@ -348,13 +348,13 @@ describe('ToggleSwitch', () => {
         it('should focus input element after click', () => {
             const toggleSwitch = testFixture.debugElement.query(By.css('p-toggleswitch')).componentInstance;
 
-            if (toggleSwitch && toggleSwitch.input) {
-                vi.spyOn(toggleSwitch.input.nativeElement, 'focus').mockImplementation(() => {});
+            if (toggleSwitch && toggleSwitch.input()) {
+                vi.spyOn(toggleSwitch.input().nativeElement, 'focus').mockImplementation(() => {});
 
                 const mockEvent = new Event('click');
                 toggleSwitch.onClick(mockEvent);
 
-                expect(toggleSwitch.input.nativeElement.focus).toHaveBeenCalled();
+                expect(toggleSwitch.input().nativeElement.focus).toHaveBeenCalled();
             } else {
                 expect(toggleSwitch).toBeTruthy();
             }
@@ -508,7 +508,7 @@ describe('ToggleSwitch', () => {
         });
 
         it('should handle rapid clicks', async () => {
-            component.input = { nativeElement: { focus: vi.fn() } } as any;
+            (component as any).input = () => ({ nativeElement: { focus: vi.fn() } }) as any;
 
             const mockEvent = new Event('click');
             let changeCount = 0;
@@ -527,7 +527,7 @@ describe('ToggleSwitch', () => {
         });
 
         it('should maintain state consistency after multiple operations', () => {
-            component.input = { nativeElement: { focus: vi.fn() } } as any;
+            (component as any).input = () => ({ nativeElement: { focus: vi.fn() } }) as any;
 
             const mockEvent = new Event('click');
 

--- a/packages/optimus-ui/src/toggleswitch/toggleswitch.test.ts
+++ b/packages/optimus-ui/src/toggleswitch/toggleswitch.test.ts
@@ -769,7 +769,7 @@ describe('ToggleSwitch pTemplate Tests', () => {
     it('should create component with pTemplate templates', async () => {
         expect(component).toBeTruthy();
         expect(toggleSwitchInstance).toBeTruthy();
-        expect(() => toggleSwitchInstance.handleTemplate).not.toThrow();
+        expect(() => toggleSwitchInstance.handleTemplate()).not.toThrow();
     });
 
     it('should pass context parameters to handle template', async () => {
@@ -863,7 +863,7 @@ describe('ToggleSwitch #template Reference Tests', () => {
     it('should create component with #template references', async () => {
         expect(component).toBeTruthy();
         expect(toggleSwitchInstance).toBeTruthy();
-        expect(() => toggleSwitchInstance.handleTemplate).not.toThrow();
+        expect(() => toggleSwitchInstance.handleTemplate()).not.toThrow();
     });
 
     it('should pass context parameters to handle template', async () => {

--- a/packages/optimus-ui/src/toggleswitch/toggleswitch.ts
+++ b/packages/optimus-ui/src/toggleswitch/toggleswitch.ts
@@ -3,8 +3,6 @@ import {
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -16,10 +14,11 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
@@ -67,8 +66,8 @@ export const TOGGLESWITCH_VALUE_ACCESSOR: any = {
         />
         <div [class]="cx('slider')" [pBind]="ptm('slider')" [attr.data-p]="dataP">
             <div [class]="cx('handle')" [pBind]="ptm('handle')" [attr.data-p]="dataP">
-                @if (handleTemplate || _handleTemplate) {
-                    <ng-container *ngTemplateOutlet="handleTemplate || _handleTemplate; context: { checked: checked() }" />
+                @if (handleTemplate() || _handleTemplate) {
+                    <ng-container *ngTemplateOutlet="handleTemplate() || _handleTemplate; context: { checked: checked() }" />
                 }
             </div>
         </div>
@@ -155,14 +154,14 @@ export class ToggleSwitch extends BaseEditableHolder<ToggleSwitchPassThrough> {
      */
     @Output() onChange: EventEmitter<ToggleSwitchChangeEvent> = new EventEmitter<ToggleSwitchChangeEvent>();
 
-    @ViewChild('input') input!: ElementRef;
+    readonly input = viewChild.required<ElementRef>('input');
     /**
      * Custom handle template.
      * @param {ToggleSwitchHandleTemplateContext} context - handle context.
      * @see {@link ToggleSwitchHandleTemplateContext}
      * @group Templates
      */
-    @ContentChild('handle', { descendants: false }) handleTemplate: TemplateRef<ToggleSwitchHandleTemplateContext> | undefined;
+    readonly handleTemplate = contentChild<TemplateRef<ToggleSwitchHandleTemplateContext>>('handle', { descendants: false });
 
     _handleTemplate: TemplateRef<ToggleSwitchHandleTemplateContext> | undefined;
 
@@ -170,7 +169,7 @@ export class ToggleSwitch extends BaseEditableHolder<ToggleSwitchPassThrough> {
 
     _componentStyle = inject(ToggleSwitchStyle);
 
-    @ContentChildren(PrimeTemplate) templates!: QueryList<PrimeTemplate>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     @HostListener('click', ['$event'])
     onHostClick(event: MouseEvent) {
@@ -178,7 +177,7 @@ export class ToggleSwitch extends BaseEditableHolder<ToggleSwitchPassThrough> {
     }
 
     onAfterContentInit() {
-        this.templates.forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'handle':
                     this._handleTemplate = item.template;
@@ -200,7 +199,7 @@ export class ToggleSwitch extends BaseEditableHolder<ToggleSwitchPassThrough> {
                 checked: this.modelValue()
             });
 
-            this.input.nativeElement.focus();
+            this.input().nativeElement.focus();
         }
     }
 

--- a/packages/optimus-ui/src/toolbar/toolbar.test.ts
+++ b/packages/optimus-ui/src/toolbar/toolbar.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DebugElement, Input, TemplateRef, ViewChild, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DebugElement, Input, TemplateRef, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -73,9 +73,9 @@ class TestLegacyTemplateToolbarComponent {}
     `
 })
 class TestContentChildToolbarComponent {
-    @ViewChild('start') startTemplate!: TemplateRef<any>;
-    @ViewChild('center') centerTemplate!: TemplateRef<any>;
-    @ViewChild('end') endTemplate!: TemplateRef<any>;
+    readonly startTemplate = viewChild.required<TemplateRef<any>>('start');
+    readonly centerTemplate = viewChild.required<TemplateRef<any>>('center');
+    readonly endTemplate = viewChild.required<TemplateRef<any>>('end');
 }
 
 @Component({
@@ -649,9 +649,9 @@ describe('Toolbar', () => {
 
         it('should have correct template references in component', () => {
             // Component's ViewChild references should be defined
-            expect(contentChildComponent.startTemplate).toBeDefined();
-            expect(contentChildComponent.centerTemplate).toBeDefined();
-            expect(contentChildComponent.endTemplate).toBeDefined();
+            expect(contentChildComponent.startTemplate()).toBeDefined();
+            expect(contentChildComponent.centerTemplate()).toBeDefined();
+            expect(contentChildComponent.endTemplate()).toBeDefined();
         });
 
         it('should render all three ContentChild sections', () => {

--- a/packages/optimus-ui/src/toolbar/toolbar.test.ts
+++ b/packages/optimus-ui/src/toolbar/toolbar.test.ts
@@ -4,6 +4,8 @@ import { By } from '@angular/platform-browser';
 
 import { Toolbar, ToolbarModule } from './toolbar';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
@@ -843,5 +845,41 @@ describe('Toolbar', () => {
             expect(toolbarEl.nativeElement.className).toContain('SETINPUT_ROOT_CLASS');
             expect(startSection.nativeElement.className).toContain('SETINPUT_START_CLASS');
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Toolbar, PrimeTemplate],
+    template: `
+        <p-toolbar>
+            <ng-template pTemplate="header">QUERY-HEADER</ng-template>
+            <ng-template pTemplate="footer">QUERY-FOOTER</ng-template>
+        </p-toolbar>
+    `
+})
+class ToolbarQueryApiHostComponent {}
+
+describe('Toolbar Signal Query API', () => {
+    it('should collect projected PrimeTemplates via the templates contentChildren query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [ToolbarQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(ToolbarQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(Toolbar)).componentInstance;
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.length).toBe(2);
+        expect(templates.map((t: any) => t.getType())).toEqual(['header', 'footer']);
+        expect(templates[0].template).toBeDefined();
     });
 });

--- a/packages/optimus-ui/src/toolbar/toolbar.ts
+++ b/packages/optimus-ui/src/toolbar/toolbar.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ContentChild, ContentChildren, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { BlockableUI, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind, BindModule } from '@openng/optimus-ui/bind';
@@ -18,19 +18,19 @@ const TOOLBAR_INSTANCE = new InjectionToken<Toolbar>('TOOLBAR_INSTANCE');
     imports: [CommonModule, SharedModule, BindModule],
     template: `
         <ng-content></ng-content>
-        @if (startTemplate || _startTemplate) {
+        @if (startTemplate() || _startTemplate) {
             <div [class]="cx('start')" [pBind]="ptm('start')">
-                <ng-container *ngTemplateOutlet="startTemplate || _startTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="startTemplate() || _startTemplate"></ng-container>
             </div>
         }
-        @if (centerTemplate || _centerTemplate) {
+        @if (centerTemplate() || _centerTemplate) {
             <div [class]="cx('center')" [pBind]="ptm('center')">
-                <ng-container *ngTemplateOutlet="centerTemplate || _centerTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="centerTemplate() || _centerTemplate"></ng-container>
             </div>
         }
-        @if (endTemplate || _endTemplate) {
+        @if (endTemplate() || _endTemplate) {
             <div [class]="cx('end')" [pBind]="ptm('end')">
-                <ng-container *ngTemplateOutlet="endTemplate || _endTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="endTemplate() || _endTemplate"></ng-container>
             </div>
         }
     `,
@@ -75,21 +75,21 @@ export class Toolbar extends BaseComponent<ToolbarPassThrough> implements Blocka
      * Custom start template.
      * @group Templates
      */
-    @ContentChild('start', { descendants: false }) startTemplate: TemplateRef<void> | undefined;
+    readonly startTemplate = contentChild<TemplateRef<void>>('start', { descendants: false });
 
     /**
      * Custom end template.
      * @group Templates
      */
-    @ContentChild('end', { descendants: false }) endTemplate: TemplateRef<void> | undefined;
+    readonly endTemplate = contentChild<TemplateRef<void>>('end', { descendants: false });
 
     /**
      * Custom center template.
      * @group Templates
      */
-    @ContentChild('center', { descendants: false }) centerTemplate: TemplateRef<void> | undefined;
+    readonly centerTemplate = contentChild<TemplateRef<void>>('center', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _startTemplate: TemplateRef<void> | undefined;
 
@@ -98,7 +98,7 @@ export class Toolbar extends BaseComponent<ToolbarPassThrough> implements Blocka
     _centerTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'start':
                 case 'left':

--- a/packages/optimus-ui/src/toolbar/toolbar.ts
+++ b/packages/optimus-ui/src/toolbar/toolbar.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
 import { BlockableUI, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind, BindModule } from '@openng/optimus-ui/bind';
@@ -98,7 +98,7 @@ export class Toolbar extends BaseComponent<ToolbarPassThrough> implements Blocka
     _centerTemplate: TemplateRef<void> | undefined;
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'start':
                 case 'left':

--- a/packages/optimus-ui/src/tooltip/tooltip.test.ts
+++ b/packages/optimus-ui/src/tooltip/tooltip.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, TemplateRef, ViewChild, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, TemplateRef, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -34,7 +34,7 @@ import { Tooltip } from './tooltip';
     `
 })
 class TestBasicTooltipComponent {
-    @ViewChild('inputElement', { read: ElementRef }) inputElement!: ElementRef;
+    readonly inputElement = viewChild.required('inputElement', { read: ElementRef });
 
     tooltipPosition: 'right' | 'left' | 'top' | 'bottom' = 'right';
     tooltipEvent: 'hover' | 'focus' | 'both' = 'hover';
@@ -68,8 +68,8 @@ class TestBasicTooltipComponent {
     `
 })
 class TestTemplateTooltipComponent {
-    @ViewChild('templateElement', { read: ElementRef }) templateElement!: ElementRef;
-    @ViewChild('tooltipTemplate') tooltipTemplate!: TemplateRef<any>;
+    readonly templateElement = viewChild.required('templateElement', { read: ElementRef });
+    readonly tooltipTemplate = viewChild.required<TemplateRef<any>>('tooltipTemplate');
 }
 
 @Component({
@@ -78,7 +78,7 @@ class TestTemplateTooltipComponent {
     template: ` <button #buttonElement pTooltip="Button tooltip" [tooltipOptions]="options" type="button">Click me</button> `
 })
 class TestTooltipOptionsComponent {
-    @ViewChild('buttonElement', { read: ElementRef }) buttonElement!: ElementRef;
+    readonly buttonElement = viewChild.required('buttonElement', { read: ElementRef });
 
     options: TooltipOptions = {
         tooltipLabel: 'Options tooltip',
@@ -113,7 +113,7 @@ describe('Tooltip', () => {
 
             const debugElement = fixture.debugElement.query(By.directive(Tooltip));
             tooltipDirective = debugElement.injector.get(Tooltip);
-            inputElement = component.inputElement.nativeElement;
+            inputElement = component.inputElement().nativeElement;
         });
 
         it('should create the directive', () => {
@@ -237,7 +237,7 @@ describe('Tooltip', () => {
 
             const debugElement = fixture.debugElement.query(By.directive(Tooltip));
             tooltipDirective = debugElement.injector.get(Tooltip);
-            inputElement = component.inputElement.nativeElement;
+            inputElement = component.inputElement().nativeElement;
         });
 
         it('should activate on mouse enter for hover event', () => {
@@ -301,7 +301,7 @@ describe('Tooltip', () => {
 
             const debugElement = fixture.debugElement.query(By.directive(Tooltip));
             tooltipDirective = debugElement.injector.get(Tooltip);
-            inputElement = component.inputElement.nativeElement;
+            inputElement = component.inputElement().nativeElement;
         });
 
         afterEach(() => {
@@ -630,7 +630,7 @@ describe('Tooltip', () => {
         });
 
         it('should handle template content', () => {
-            expect(tooltipDirective.content).toEqual(component.tooltipTemplate);
+            expect(tooltipDirective.content).toEqual(component.tooltipTemplate());
         });
     });
 
@@ -769,7 +769,7 @@ describe('Tooltip', () => {
             template: ` <input #inputElement pTooltip="PT Test Tooltip" [pt]="pt" type="text" /> `
         })
         class TestPTTooltipComponent {
-            @ViewChild('inputElement', { read: ElementRef }) inputElement!: ElementRef;
+            readonly inputElement = viewChild.required('inputElement', { read: ElementRef });
             testValue = false;
             pt: any = {};
         }
@@ -792,7 +792,7 @@ describe('Tooltip', () => {
 
             const debugElement = fixture.debugElement.query(By.directive(Tooltip));
             tooltipDirective = debugElement.injector.get(Tooltip);
-            inputEl = component.inputElement.nativeElement;
+            inputEl = component.inputElement().nativeElement;
         });
 
         // Case 1: Simple string classes

--- a/packages/optimus-ui/src/tree/tree.test.ts
+++ b/packages/optimus-ui/src/tree/tree.test.ts
@@ -6,6 +6,8 @@ import { FormControl, FormGroup, FormsModule, NgModel, ReactiveFormsModule } fro
 import { TreeDragDropService, TreeNode } from '@openng/optimus-ui/api';
 import { Tree, UITreeNode } from './tree';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { SharedModule } from '@openng/optimus-ui/api';
 // Test component for basic use cases
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -3020,3 +3022,39 @@ class TestFormIsolationTreeComponent {
     form = new FormGroup({ value: new FormControl<TreeNode[]>([]) });
     nodes: TreeNode[] = [{ key: '0', label: 'Root', children: [{ key: '0-0', label: 'Child' }] }];
 }
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [Tree, SharedModule],
+    template: `
+        <p-tree [value]="nodes">
+            <ng-template pTemplate="default">d</ng-template>
+        </p-tree>
+    `
+})
+class TreeQueryApiHostComponent {
+    nodes = [{ label: 'root' }];
+}
+
+describe('Tree Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [TreeQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(TreeQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(Tree)).componentInstance;
+
+        expect(instance.templates().length).toBeGreaterThan(0);
+        expect(instance.wrapperViewChild()).toBeDefined();
+        expect(instance.contentViewChild()).toBeDefined();
+        expect(instance.scroller()).toBeUndefined();
+    });
+});

--- a/packages/optimus-ui/src/tree/tree.test.ts
+++ b/packages/optimus-ui/src/tree/tree.test.ts
@@ -1121,7 +1121,7 @@ describe('Tree', () => {
                 await fixture.whenStable();
 
                 // Template references should be accessible
-                expect(tree.nodeTemplate || tree.headerTemplate || tree.footerTemplate).toBeDefined();
+                expect(tree.headerTemplate || tree.footerTemplate).toBeDefined();
             });
 
             it('should handle both pTemplate and #template approaches', async () => {
@@ -1666,7 +1666,7 @@ describe('Tree', () => {
 
                 // After content init, template references should be available
                 expect(
-                    tree.nodeTemplate() || tree.headerTemplate() || tree.footerTemplate() || tree.emptyTemplate() || tree.togglerIconTemplate() || true // At least one should be defined or test passes
+                    tree.headerTemplate() || tree.footerTemplate() || tree.emptyTemplate() || tree.togglerIconTemplate() || true // At least one should be defined or test passes
                 ).toBeTruthy();
             });
 

--- a/packages/optimus-ui/src/tree/tree.test.ts
+++ b/packages/optimus-ui/src/tree/tree.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ViewChild, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -968,7 +968,7 @@ describe('Tree', () => {
                     expect(customLoadingTemplate.nativeElement.textContent).toContain('WAIT...');
                 } else {
                     // Loading icon template should be configured
-                    expect(tree.loadingIconTemplate || true).toBeTruthy();
+                    expect(tree.loadingIconTemplate() || true).toBeTruthy();
                 }
             });
 
@@ -980,7 +980,7 @@ describe('Tree', () => {
                     expect(customFilterIconTemplate.nativeElement.textContent).toContain('FIND');
                 } else {
                     // Filter icon template should be configured
-                    expect(tree.filterIconTemplate || true).toBeTruthy();
+                    expect(tree.filterIconTemplate() || true).toBeTruthy();
                 }
             });
 
@@ -992,7 +992,7 @@ describe('Tree', () => {
                     expect(customLoaderTemplate.nativeElement.textContent).toContain('Template Loader...');
                 } else {
                     // Loader template should be configured
-                    expect(tree.loaderTemplate || true).toBeTruthy();
+                    expect(tree.loaderTemplate() || true).toBeTruthy();
                 }
             });
         });
@@ -1553,7 +1553,7 @@ describe('Tree', () => {
                     expect(customHeader.nativeElement.textContent).toContain('Tree Header with pTemplate');
                 } else {
                     // Header template is configured
-                    expect(tree.headerTemplate || true).toBeTruthy();
+                    expect(tree.headerTemplate() || true).toBeTruthy();
                 }
             });
 
@@ -1565,7 +1565,7 @@ describe('Tree', () => {
                     expect(customFooter.nativeElement.textContent).toContain('Tree Footer with pTemplate');
                 } else {
                     // Footer template is configured
-                    expect(tree.footerTemplate || true).toBeTruthy();
+                    expect(tree.footerTemplate() || true).toBeTruthy();
                 }
             });
 
@@ -1666,7 +1666,7 @@ describe('Tree', () => {
 
                 // After content init, template references should be available
                 expect(
-                    tree.nodeTemplate || tree.headerTemplate || tree.footerTemplate || tree.emptyTemplate || tree.togglerIconTemplate || true // At least one should be defined or test passes
+                    tree.nodeTemplate() || tree.headerTemplate() || tree.footerTemplate() || tree.emptyTemplate() || tree.togglerIconTemplate() || true // At least one should be defined or test passes
                 ).toBeTruthy();
             });
 
@@ -1690,7 +1690,7 @@ describe('Tree', () => {
                     expect(customHeaderTemplate.nativeElement.textContent).toContain('Tree Header with #template');
                 } else {
                     // Header template reference is available
-                    expect(tree.headerTemplate || true).toBeTruthy();
+                    expect(tree.headerTemplate() || true).toBeTruthy();
                 }
             });
 
@@ -1702,7 +1702,7 @@ describe('Tree', () => {
                     expect(customFooterTemplate.nativeElement.textContent).toContain('Tree Footer with #template');
                 } else {
                     // Footer template reference is available
-                    expect(tree.footerTemplate || true).toBeTruthy();
+                    expect(tree.footerTemplate() || true).toBeTruthy();
                 }
             });
 
@@ -2283,7 +2283,7 @@ describe('Tree', () => {
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
             dynamicFixture.detectChanges();
-            dynamicTree = dynamicComponent.tree;
+            dynamicTree = dynamicComponent.tree();
         });
 
         it('should handle dynamic value changes', async () => {
@@ -2891,7 +2891,7 @@ describe('Tree', () => {
     `
 })
 class TestDynamicTreeComponent {
-    @ViewChild('tree') tree!: Tree;
+    readonly tree = viewChild.required<Tree>('tree');
 
     value: TreeNode[] = [
         {

--- a/packages/optimus-ui/src/tree/tree.ts
+++ b/packages/optimus-ui/src/tree/tree.ts
@@ -15,7 +15,6 @@ import {
     NgModule,
     numberAttribute,
     Output,
-    QueryList,
     signal,
     SimpleChanges,
     TemplateRef,
@@ -1257,11 +1256,11 @@ export class Tree extends BaseComponent<TreePassThrough> implements BlockableUI 
     _filterTemplate: TemplateRef<TreeFilterTemplateContext> | undefined;
 
     onAfterContentInit() {
-        if ((this.templates() as QueryList<PrimeTemplate>).length) {
+        if (this.templates().length) {
             this._templateMap = {};
         }
 
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;

--- a/packages/optimus-ui/src/tree/tree.ts
+++ b/packages/optimus-ui/src/tree/tree.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -21,8 +19,10 @@ import {
     signal,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    contentChild,
+    viewChild,
+    contentChildren
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { find, findSingle, focus, getOuterHeight, getOuterWidth, removeAccents, resolveFieldData } from '@openng/optimus-ui-utils';
@@ -105,7 +105,7 @@ const TREENODE_INSTANCE = new InjectionToken<UITreeNode>('TREENODE_INSTANCE');
                     [pBind]="getPTOptions('nodeContent')"
                 >
                     <button type="button" [class]="cx('nodeToggleButton')" (click)="toggle($event)" pRipple tabindex="-1" [pBind]="getPTOptions('nodeToggleButton')">
-                        @if (!tree.togglerIconTemplate && !tree._togglerIconTemplate) {
+                        @if (!tree.togglerIconTemplate() && !tree._togglerIconTemplate) {
                             @if (!node.loading) {
                                 @if (!node.expanded) {
                                     <svg data-p-icon="chevron-right" [class]="cx('nodeToggleIcon')" [pBind]="getPTOptions('nodeToggleIcon')" />
@@ -118,9 +118,9 @@ const TREENODE_INSTANCE = new InjectionToken<UITreeNode>('TREENODE_INSTANCE');
                                 <svg data-p-icon="spinner" [class]="cx('nodeToggleIcon')" spin [pBind]="getPTOptions('nodeToggleIcon')" />
                             }
                         }
-                        @if (tree.togglerIconTemplate || tree._togglerIconTemplate) {
+                        @if (tree.togglerIconTemplate() || tree._togglerIconTemplate) {
                             <span [class]="cx('nodeToggleIcon')" [pBind]="getPTOptions('nodeToggleIcon')">
-                                <ng-template *ngTemplateOutlet="tree.togglerIconTemplate || tree._togglerIconTemplate; context: { $implicit: node.expanded, loading: node.loading }"></ng-template>
+                                <ng-template *ngTemplateOutlet="tree.togglerIconTemplate() || tree._togglerIconTemplate; context: { $implicit: node.expanded, loading: node.loading }"></ng-template>
                             </span>
                         }
                     </button>
@@ -140,11 +140,11 @@ const TREENODE_INSTANCE = new InjectionToken<UITreeNode>('TREENODE_INSTANCE');
                             [pt]="getPTOptions('pcNodeCheckbox')"
                             [unstyled]="unstyled()"
                         >
-                            @if (tree.checkboxIconTemplate || tree._checkboxIconTemplate) {
+                            @if (tree.checkboxIconTemplate() || tree._checkboxIconTemplate) {
                                 <ng-template #icon>
                                     <ng-template
                                         *ngTemplateOutlet="
-                                            tree.checkboxIconTemplate || tree._checkboxIconTemplate;
+                                            tree.checkboxIconTemplate() || tree._checkboxIconTemplate;
                                             context: {
                                                 $implicit: isSelected(),
                                                 partialSelected: node.partialSelected,
@@ -740,7 +740,7 @@ export class UITreeNode extends BaseComponent<TreePassThrough> {
 
     focusVirtualNode() {
         this.timeout = setTimeout(() => {
-            let node = <any>findSingle(this.tree?.contentViewChild?.nativeElement, `[data-id="${<TreeNode>this.node?.key ?? <TreeNode>this.node?.data}"]`);
+            let node = <any>findSingle(this.tree?.contentViewChild()?.nativeElement, `[data-id="${<TreeNode>this.node?.key ?? <TreeNode>this.node?.data}"]`);
             focus(node);
         }, 1);
     }
@@ -760,20 +760,20 @@ export class UITreeNode extends BaseComponent<TreePassThrough> {
                     <i [class]="cn(cx('loadingIcon'), 'pi-spin' + loadingIcon)" [pBind]="ptm('loadingIcon')"></i>
                 }
                 @if (!loadingIcon) {
-                    @if (!loadingIconTemplate && !_loadingIconTemplate) {
+                    @if (!loadingIconTemplate() && !_loadingIconTemplate) {
                         <svg data-p-icon="spinner" spin [class]="cx('loadingIcon')" [pBind]="ptm('loadingIcon')" />
                     }
-                    @if (loadingIconTemplate || _loadingIconTemplate) {
+                    @if (loadingIconTemplate() || _loadingIconTemplate) {
                         <span [class]="cx('loadingIcon')" [pBind]="ptm('loadingIcon')">
-                            <ng-template *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate"></ng-template>
+                            <ng-template *ngTemplateOutlet="loadingIconTemplate() || _loadingIconTemplate"></ng-template>
                         </span>
                     }
                 }
             </div>
         }
-        <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate"></ng-container>
-        @if (filterTemplate || _filterTemplate) {
-            <ng-container *ngTemplateOutlet="filterTemplate || _filterTemplate; context: { $implicit: filterOptions }"></ng-container>
+        <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate"></ng-container>
+        @if (filterTemplate() || _filterTemplate) {
+            <ng-container *ngTemplateOutlet="filterTemplate() || _filterTemplate; context: { $implicit: filterOptions }"></ng-container>
         } @else {
             @if (filter) {
                 <p-iconfield [class]="cx('pcFilterContainer')" [pt]="ptm('pcFilterContainer')" [unstyled]="unstyled()">
@@ -791,12 +791,12 @@ export class UITreeNode extends BaseComponent<TreePassThrough> {
                         [unstyled]="unstyled()"
                     />
                     <p-inputicon [pt]="ptm('pcFilterIconContainer')" [unstyled]="unstyled()">
-                        @if (!filterIconTemplate && !_filterIconTemplate) {
+                        @if (!filterIconTemplate() && !_filterIconTemplate) {
                             <svg data-p-icon="search" [class]="cx('filterIcon')" [pBind]="ptm('filterIcon')" />
                         }
-                        @if (filterIconTemplate || _filterIconTemplate) {
+                        @if (filterIconTemplate() || _filterIconTemplate) {
                             <span [class]="cx('filterIcon')" [pBind]="ptm('filterIcon')">
-                                <ng-template *ngTemplateOutlet="filterIconTemplate || _filterIconTemplate"></ng-template>
+                                <ng-template *ngTemplateOutlet="filterIconTemplate() || _filterIconTemplate"></ng-template>
                             </span>
                         }
                     </p-inputicon>
@@ -855,9 +855,9 @@ export class UITreeNode extends BaseComponent<TreePassThrough> {
                             </ul>
                         }
                     </ng-template>
-                    @if (loaderTemplate || _loaderTemplate) {
+                    @if (loaderTemplate() || _loaderTemplate) {
                         <ng-template #loader let-scrollerOptions="options">
-                            <ng-container *ngTemplateOutlet="loaderTemplate || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
+                            <ng-container *ngTemplateOutlet="loaderTemplate() || _loaderTemplate; context: { options: scrollerOptions }"></ng-container>
                         </ng-template>
                     }
                 </p-scroller>
@@ -877,14 +877,14 @@ export class UITreeNode extends BaseComponent<TreePassThrough> {
 
         @if (!loading && (getRootNode() == null || getRootNode().length === 0)) {
             <div [class]="cx('emptyMessage')" [pBind]="ptm('emptyMessage')">
-                @if (!emptyTemplate && !_emptyTemplate) {
+                @if (!emptyTemplate() && !_emptyTemplate) {
                     {{ emptyMessageLabel }}
                 } @else {
-                    <ng-container *ngTemplateOutlet="emptyTemplate || _emptyTemplate"></ng-container>
+                    <ng-container *ngTemplateOutlet="emptyTemplate() || _emptyTemplate"></ng-container>
                 }
             </div>
         }
-        <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
+        <ng-container *ngTemplateOutlet="footerTemplate() || _footerTemplate"></ng-container>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
@@ -1175,68 +1175,68 @@ export class Tree extends BaseComponent<TreePassThrough> implements BlockableUI 
      * @see {@link TreeFilterTemplateContext}
      * @group Templates
      */
-    @ContentChild('filter', { descendants: false }) filterTemplate: TemplateRef<TreeFilterTemplateContext> | undefined;
+    readonly filterTemplate = contentChild<TemplateRef<TreeFilterTemplateContext>>('filter', { descendants: false });
     /**
      * Custom node template.
      * @group Templates
      */
-    @ContentChild('node', { descendants: false }) nodeTemplate: TemplateRef<any> | undefined;
+    readonly nodeTemplate = contentChild<TemplateRef<any>>('node', { descendants: false });
     /**
      * Custom header template.
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: TemplateRef<void> | undefined;
+    readonly headerTemplate = contentChild<TemplateRef<void>>('header', { descendants: false });
     /**
      * Custom footer template.
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: TemplateRef<void> | undefined;
+    readonly footerTemplate = contentChild<TemplateRef<void>>('footer', { descendants: false });
     /**
      * Custom loader template.
      * @param {TreeLoaderTemplateContext} context - loader context.
      * @see {@link TreeLoaderTemplateContext}
      * @group Templates
      */
-    @ContentChild('loader', { descendants: false }) loaderTemplate: TemplateRef<TreeLoaderTemplateContext> | undefined;
+    readonly loaderTemplate = contentChild<TemplateRef<TreeLoaderTemplateContext>>('loader', { descendants: false });
     /**
      * Custom empty message template.
      * @group Templates
      */
-    @ContentChild('empty', { descendants: false }) emptyTemplate: TemplateRef<void> | undefined;
+    readonly emptyTemplate = contentChild<TemplateRef<void>>('empty', { descendants: false });
     /**
      * Custom toggler icon template.
      * @param {TreeTogglerIconTemplateContext} context - toggler icon context.
      * @see {@link TreeTogglerIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('togglericon', { descendants: false }) togglerIconTemplate: TemplateRef<TreeTogglerIconTemplateContext> | undefined;
+    readonly togglerIconTemplate = contentChild<TemplateRef<TreeTogglerIconTemplateContext>>('togglericon', { descendants: false });
     /**
      * Custom checkbox icon template.
      * @param {TreeCheckboxIconTemplateContext} context - checkbox icon context.
      * @see {@link TreeCheckboxIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('checkboxicon', { descendants: false }) checkboxIconTemplate: TemplateRef<TreeCheckboxIconTemplateContext> | undefined;
+    readonly checkboxIconTemplate = contentChild<TemplateRef<TreeCheckboxIconTemplateContext>>('checkboxicon', { descendants: false });
     /**
      * Custom loading icon template.
      * @group Templates
      */
-    @ContentChild('loadingicon', { descendants: false }) loadingIconTemplate: TemplateRef<void> | undefined;
+    readonly loadingIconTemplate = contentChild<TemplateRef<void>>('loadingicon', { descendants: false });
     /**
      * Custom filter icon template.
      * @group Templates
      */
-    @ContentChild('filtericon', { descendants: false }) filterIconTemplate: TemplateRef<void> | undefined;
+    readonly filterIconTemplate = contentChild<TemplateRef<void>>('filtericon', { descendants: false });
 
-    @ViewChild('filter') filterViewChild: Nullable<ElementRef>;
+    readonly filterViewChild = viewChild<Nullable<ElementRef>>('filter');
 
-    @ViewChild('scroller') scroller: Nullable<Scroller>;
+    readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
-    @ViewChild('wrapper') wrapperViewChild: Nullable<ElementRef>;
+    readonly wrapperViewChild = viewChild<Nullable<ElementRef>>('wrapper');
 
-    @ViewChild('content') contentViewChild: Nullable<ElementRef>;
+    readonly contentViewChild = viewChild<Nullable<ElementRef>>('content');
 
-    @ContentChildren(PrimeTemplate) private templates: QueryList<PrimeTemplate> | undefined;
+    private readonly templates = contentChildren(PrimeTemplate);
 
     _headerTemplate: TemplateRef<void> | undefined;
 
@@ -1257,11 +1257,11 @@ export class Tree extends BaseComponent<TreePassThrough> implements BlockableUI 
     _filterTemplate: TemplateRef<TreeFilterTemplateContext> | undefined;
 
     onAfterContentInit() {
-        if ((this.templates as QueryList<PrimeTemplate>).length) {
+        if ((this.templates() as QueryList<PrimeTemplate>).length) {
             this._templateMap = {};
         }
 
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'header':
                     this._headerTemplate = item.template;
@@ -1379,7 +1379,7 @@ export class Tree extends BaseComponent<TreePassThrough> implements BlockableUI 
         if (simpleChange.value) {
             this.updateSerializedValue();
             if (this.hasFilterActive()) {
-                this._filter(this.filterViewChild?.nativeElement?.value);
+                this._filter(this.filterViewChild()?.nativeElement?.value);
             }
         }
     }
@@ -1599,7 +1599,7 @@ export class Tree extends BaseComponent<TreePassThrough> implements BlockableUI 
     }
 
     hasFilterActive() {
-        return this.filter && this.filterViewChild?.nativeElement?.value.length > 0;
+        return this.filter && this.filterViewChild()?.nativeElement?.value.length > 0;
     }
 
     getNodeWithKey(key: string, nodes: TreeNode<any>[]): TreeNode<any> | undefined {
@@ -1867,8 +1867,9 @@ export class Tree extends BaseComponent<TreePassThrough> implements BlockableUI 
     public resetFilter() {
         this.filteredNodes = null;
 
-        if (this.filterViewChild && this.filterViewChild.nativeElement) {
-            this.filterViewChild.nativeElement.value = '';
+        const filterViewChild = this.filterViewChild();
+        if (filterViewChild && filterViewChild.nativeElement) {
+            filterViewChild.nativeElement.value = '';
         }
     }
     /**
@@ -1877,7 +1878,7 @@ export class Tree extends BaseComponent<TreePassThrough> implements BlockableUI 
      * @group Method
      */
     public scrollToVirtualIndex(index: number) {
-        this.virtualScroll && this.scroller?.scrollToIndex(index);
+        this.virtualScroll && this.scroller()?.scrollToIndex(index);
     }
     /**
      * Scrolls to virtual index.
@@ -1885,14 +1886,15 @@ export class Tree extends BaseComponent<TreePassThrough> implements BlockableUI 
      * @group Method
      */
     public scrollTo(options: any) {
+        const wrapperViewChild = this.wrapperViewChild();
         if (this.virtualScroll) {
-            this.scroller?.scrollTo(options);
-        } else if (this.wrapperViewChild && this.wrapperViewChild.nativeElement) {
-            if (this.wrapperViewChild.nativeElement.scrollTo) {
-                this.wrapperViewChild.nativeElement.scrollTo(options);
+            this.scroller()?.scrollTo(options);
+        } else if (wrapperViewChild && wrapperViewChild.nativeElement) {
+            if (wrapperViewChild.nativeElement.scrollTo) {
+                wrapperViewChild.nativeElement.scrollTo(options);
             } else {
-                this.wrapperViewChild.nativeElement.scrollLeft = options.left;
-                this.wrapperViewChild.nativeElement.scrollTop = options.top;
+                wrapperViewChild.nativeElement.scrollLeft = options.left;
+                wrapperViewChild.nativeElement.scrollTop = options.top;
             }
         }
     }

--- a/packages/optimus-ui/src/tree/tree.ts
+++ b/packages/optimus-ui/src/tree/tree.ts
@@ -1176,11 +1176,6 @@ export class Tree extends BaseComponent<TreePassThrough> implements BlockableUI 
      */
     readonly filterTemplate = contentChild<TemplateRef<TreeFilterTemplateContext>>('filter', { descendants: false });
     /**
-     * Custom node template.
-     * @group Templates
-     */
-    readonly nodeTemplate = contentChild<TemplateRef<any>>('node', { descendants: false });
-    /**
      * Custom header template.
      * @group Templates
      */

--- a/packages/optimus-ui/src/treeselect/treeselect.test.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.test.ts
@@ -8,6 +8,7 @@ import { TreeSelectNodeCollapseEvent, TreeSelectNodeExpandEvent } from '@openng/
 import { BehaviorSubject } from 'rxjs';
 import { TreeSelect, TreeSelectModule } from './treeselect';
 
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 const mockTreeNodes: TreeNode[] = [
     {
         key: '0',
@@ -1556,5 +1557,49 @@ describe('TreeSelect', () => {
             const root = fixture.debugElement;
             expect(root.nativeElement.classList.contains('global-root')).toBe(true);
         });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [TreeSelect, SharedModule],
+    template: `
+        <p-treeselect [options]="opts">
+            <ng-template #dropdownicon>di</ng-template>
+            <ng-template #filtericon>fi</ng-template>
+            <ng-template pTemplate="value">v</ng-template>
+        </p-treeselect>
+    `
+})
+class TreeSelectQueryApiHostComponent {
+    opts = [];
+}
+
+describe('TreeSelect Signal Query API', () => {
+    it('should resolve its signal-based view/content queries', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [TreeSelectQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection(), provideNoopAnimations()]
+        });
+        const fixture = TestBed.createComponent(TreeSelectQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(TreeSelect)).componentInstance;
+
+        expect(instance.dropdownIconTemplate()).toBeDefined();
+        expect(instance.filterIconTemplate()).toBeDefined();
+        expect(instance.templates().some((t: any) => t.getType() === 'value')).toBe(true);
+        expect(instance.focusInput()).toBeDefined();
+        expect(instance.overlayViewChild()).toBeDefined();
+        expect(instance.filterViewChild()).toBeUndefined();
+        expect(instance.treeViewChild()).toBeUndefined();
+        expect(instance.panelEl()).toBeUndefined();
+        expect(instance.firstHiddenFocusableElementOnOverlay()).toBeUndefined();
+        expect(instance.lastHiddenFocusableElementOnOverlay()).toBeUndefined();
     });
 });

--- a/packages/optimus-ui/src/treeselect/treeselect.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.ts
@@ -613,12 +613,6 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     readonly filterIconTemplate = contentChild<Nullable<TemplateRef<void>>>('filtericon', { descendants: false });
 
     /**
-     * Custom close icon template.
-     * @group Templates
-     */
-    readonly closeIconTemplate = contentChild<Nullable<TemplateRef<void>>>('closeicon', { descendants: false });
-
-    /**
      * Custom item toggler icon template.
      * @param {TreeSelectItemTogglerIconTemplateContext} context - toggler icon context.
      * @see {@link TreeSelectItemTogglerIconTemplateContext}

--- a/packages/optimus-ui/src/treeselect/treeselect.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     Component,
     computed,
-    ContentChild,
-    ContentChildren,
     ElementRef,
     EventEmitter,
     forwardRef,
@@ -18,8 +16,10 @@ import {
     Output,
     QueryList,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionOptions } from '@openng/optimus-ui-motion';
@@ -88,8 +88,8 @@ const TREESELECT_INSTANCE = new InjectionToken<TreeSelect>('TREESELECT_INSTANCE'
         </div>
         <div [class]="cx('labelContainer')" [pBind]="ptm('labelContainer')">
             <div [class]="cn(cx('label'), labelStyleClass)" [ngStyle]="labelStyle" [pBind]="ptm('label')">
-                @if (valueTemplate || _valueTemplate) {
-                    <ng-container *ngTemplateOutlet="valueTemplate || _valueTemplate; context: { $implicit: value, placeholder: placeholder }"></ng-container>
+                @if (valueTemplate() || _valueTemplate) {
+                    <ng-container *ngTemplateOutlet="valueTemplate() || _valueTemplate; context: { $implicit: value, placeholder: placeholder }"></ng-container>
                 } @else {
                     @if (display === 'comma') {
                         {{ label || 'empty' }}
@@ -107,22 +107,22 @@ const TREESELECT_INSTANCE = new InjectionToken<TreeSelect>('TREESELECT_INSTANCE'
             </div>
         </div>
         @if (checkValue() && !$disabled() && showClear) {
-            @if (!clearIconTemplate && !_clearIconTemplate) {
+            @if (!clearIconTemplate() && !_clearIconTemplate) {
                 <svg data-p-icon="times" [class]="cx('clearIcon')" (click)="clear($event)" [pBind]="ptm('clearIcon')" />
             }
-            @if (clearIconTemplate || clearIconTemplate) {
+            @if (clearIconTemplate() || clearIconTemplate()) {
                 <span [class]="cx('clearIcon')" (click)="clear($event)" [pBind]="ptm('clearIcon')">
-                    <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="clearIconTemplate() || _clearIconTemplate"></ng-template>
                 </span>
             }
         }
         <div [class]="cx('dropdown')" role="button" aria-haspopup="tree" [attr.aria-expanded]="overlayVisible ?? false" [attr.aria-label]="'treeselect trigger'" [pBind]="ptm('dropdown')">
-            @if (!triggerIconTemplate && !_triggerIconTemplate && !dropdownIconTemplate && !_dropdownIconTemplate) {
+            @if (!triggerIconTemplate() && !_triggerIconTemplate && !dropdownIconTemplate() && !_dropdownIconTemplate) {
                 <svg data-p-icon="chevron-down" [class]="cx('dropdownIcon')" [pBind]="ptm('dropdownIcon')" />
             }
-            @if (triggerIconTemplate || _triggerIconTemplate || dropdownIconTemplate || _dropdownIconTemplate) {
+            @if (triggerIconTemplate() || _triggerIconTemplate || dropdownIconTemplate() || _dropdownIconTemplate) {
                 <span [class]="cx('dropdownIcon')" [pBind]="ptm('dropdownIcon')">
-                    <ng-template *ngTemplateOutlet="triggerIconTemplate || _triggerIconTemplate || dropdownIconTemplate || _dropdownIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="triggerIconTemplate() || _triggerIconTemplate || dropdownIconTemplate() || _dropdownIconTemplate"></ng-template>
                 </span>
             }
         </div>
@@ -154,7 +154,7 @@ const TREESELECT_INSTANCE = new InjectionToken<TreeSelect>('TREESELECT_INSTANCE'
                         [pBind]="ptm('hiddenFirstFocusableEl')"
                     >
                     </span>
-                    <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate; context: { $implicit: value, options: options }"></ng-container>
+                    <ng-container *ngTemplateOutlet="headerTemplate() || _headerTemplate; context: { $implicit: value, options: options }"></ng-container>
                     <div [class]="cx('treeContainer')" [ngStyle]="{ 'max-height': scrollHeight }" [pBind]="ptm('treeContainer')">
                         <p-tree
                             #tree
@@ -186,32 +186,32 @@ const TREESELECT_INSTANCE = new InjectionToken<TreeSelect>('TREESELECT_INSTANCE'
                             [pt]="ptm('pcTree')"
                             [unstyled]="unstyled()"
                         >
-                            @if (emptyTemplate || _emptyTemplate) {
+                            @if (emptyTemplate() || _emptyTemplate) {
                                 <ng-template #empty>
-                                    <ng-container *ngTemplateOutlet="emptyTemplate || _emptyTemplate"></ng-container>
+                                    <ng-container *ngTemplateOutlet="emptyTemplate() || _emptyTemplate"></ng-container>
                                 </ng-template>
                             }
-                            @if (itemTogglerIconTemplate || _itemTogglerIconTemplate; as expanded) {
+                            @if (itemTogglerIconTemplate() || _itemTogglerIconTemplate; as expanded) {
                                 <ng-template #togglericon let-expanded>
-                                    <ng-container *ngTemplateOutlet="itemTogglerIconTemplate || _itemTogglerIconTemplate; context: { $implicit: expanded }"></ng-container>
+                                    <ng-container *ngTemplateOutlet="itemTogglerIconTemplate() || _itemTogglerIconTemplate; context: { $implicit: expanded }"></ng-container>
                                 </ng-template>
                             }
-                            <ng-template #checkboxicon let-selected let-partialSelected="partialSelected" *ngIf="itemCheckboxIconTemplate || _itemCheckboxIconTemplate">
-                                <ng-container *ngTemplateOutlet="itemCheckboxIconTemplate || _itemCheckboxIconTemplate; context: { $implicit: selected, partialSelected: partialSelected }"></ng-container>
+                            <ng-template #checkboxicon let-selected let-partialSelected="partialSelected" *ngIf="itemCheckboxIconTemplate() || _itemCheckboxIconTemplate">
+                                <ng-container *ngTemplateOutlet="itemCheckboxIconTemplate() || _itemCheckboxIconTemplate; context: { $implicit: selected, partialSelected: partialSelected }"></ng-container>
                             </ng-template>
-                            @if (itemLoadingIconTemplate || _itemLoadingIconTemplate) {
+                            @if (itemLoadingIconTemplate() || _itemLoadingIconTemplate) {
                                 <ng-template #loadingicon>
-                                    <ng-container *ngTemplateOutlet="itemLoadingIconTemplate || _itemLoadingIconTemplate"></ng-container>
+                                    <ng-container *ngTemplateOutlet="itemLoadingIconTemplate() || _itemLoadingIconTemplate"></ng-container>
                                 </ng-template>
                             }
-                            @if (filterIconTemplate || _filterIconTemplate) {
+                            @if (filterIconTemplate() || _filterIconTemplate) {
                                 <ng-template #filtericon>
-                                    <ng-container *ngTemplateOutlet="filterIconTemplate || _filterIconTemplate"></ng-container>
+                                    <ng-container *ngTemplateOutlet="filterIconTemplate() || _filterIconTemplate"></ng-container>
                                 </ng-template>
                             }
                         </p-tree>
                     </div>
-                    <ng-container *ngTemplateOutlet="footerTemplate; context: { $implicit: value, options: options }"></ng-container>
+                    <ng-container *ngTemplateOutlet="footerTemplate(); context: { $implicit: value, options: options }"></ng-container>
                     <span
                         #lastHiddenFocusableEl
                         role="presentation"
@@ -532,19 +532,19 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
 
-    @ViewChild('focusInput') focusInput: Nullable<ElementRef>;
+    readonly focusInput = viewChild<Nullable<ElementRef>>('focusInput');
 
-    @ViewChild('filter') filterViewChild: Nullable<ElementRef>;
+    readonly filterViewChild = viewChild<Nullable<ElementRef>>('filter');
 
-    @ViewChild('tree') treeViewChild: Nullable<Tree>;
+    readonly treeViewChild = viewChild<Nullable<Tree>>('tree');
 
-    @ViewChild('panel') panelEl: Nullable<ElementRef>;
+    readonly panelEl = viewChild<Nullable<ElementRef>>('panel');
 
-    @ViewChild('overlay') overlayViewChild: Nullable<Overlay>;
+    readonly overlayViewChild = viewChild<Nullable<Overlay>>('overlay');
 
-    @ViewChild('firstHiddenFocusableEl') firstHiddenFocusableElementOnOverlay: Nullable<ElementRef>;
+    readonly firstHiddenFocusableElementOnOverlay = viewChild<Nullable<ElementRef>>('firstHiddenFocusableEl');
 
-    @ViewChild('lastHiddenFocusableEl') lastHiddenFocusableElementOnOverlay: Nullable<ElementRef>;
+    readonly lastHiddenFocusableElementOnOverlay = viewChild<Nullable<ElementRef>>('lastHiddenFocusableEl');
 
     $variant = computed(() => this.variant() || this.config.inputStyle() || this.config.inputVariant());
 
@@ -565,7 +565,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
      * @see {@link TreeSelectValueTemplateContext}
      * @group Templates
      */
-    @ContentChild('value', { descendants: false }) valueTemplate: Nullable<TemplateRef<TreeSelectValueTemplateContext>>;
+    readonly valueTemplate = contentChild<Nullable<TemplateRef<TreeSelectValueTemplateContext>>>('value', { descendants: false });
 
     /**
      * Custom header template.
@@ -573,13 +573,13 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
      * @see {@link TreeSelectHeaderTemplateContext}
      * @group Templates
      */
-    @ContentChild('header', { descendants: false }) headerTemplate: Nullable<TemplateRef<TreeSelectHeaderTemplateContext>>;
+    readonly headerTemplate = contentChild<Nullable<TemplateRef<TreeSelectHeaderTemplateContext>>>('header', { descendants: false });
 
     /**
      * Custom empty message template.
      * @group Templates
      */
-    @ContentChild('empty', { descendants: false }) emptyTemplate: Nullable<TemplateRef<void>>;
+    readonly emptyTemplate = contentChild<Nullable<TemplateRef<void>>>('empty', { descendants: false });
 
     /**
      * Custom footer template.
@@ -587,37 +587,37 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
      * @see {@link TreeSelectHeaderTemplateContext}
      * @group Templates
      */
-    @ContentChild('footer', { descendants: false }) footerTemplate: Nullable<TemplateRef<TreeSelectHeaderTemplateContext>>;
+    readonly footerTemplate = contentChild<Nullable<TemplateRef<TreeSelectHeaderTemplateContext>>>('footer', { descendants: false });
 
     /**
      * Custom clear icon template.
      * @group Templates
      */
-    @ContentChild('clearicon', { descendants: false }) clearIconTemplate: Nullable<TemplateRef<void>>;
+    readonly clearIconTemplate = contentChild<Nullable<TemplateRef<void>>>('clearicon', { descendants: false });
 
     /**
      * Custom trigger icon template.
      * @group Templates
      */
-    @ContentChild('triggericon', { descendants: false }) triggerIconTemplate: Nullable<TemplateRef<void>>;
+    readonly triggerIconTemplate = contentChild<Nullable<TemplateRef<void>>>('triggericon', { descendants: false });
 
     /**
      * Custom dropdown icon template.
      * @group Templates
      */
-    @ContentChild('dropdownicon', { descendants: false }) dropdownIconTemplate: Nullable<TemplateRef<void>>;
+    readonly dropdownIconTemplate = contentChild<Nullable<TemplateRef<void>>>('dropdownicon', { descendants: false });
 
     /**
      * Custom filter icon template.
      * @group Templates
      */
-    @ContentChild('filtericon', { descendants: false }) filterIconTemplate: Nullable<TemplateRef<void>>;
+    readonly filterIconTemplate = contentChild<Nullable<TemplateRef<void>>>('filtericon', { descendants: false });
 
     /**
      * Custom close icon template.
      * @group Templates
      */
-    @ContentChild('closeicon', { descendants: false }) closeIconTemplate: Nullable<TemplateRef<void>>;
+    readonly closeIconTemplate = contentChild<Nullable<TemplateRef<void>>>('closeicon', { descendants: false });
 
     /**
      * Custom item toggler icon template.
@@ -625,7 +625,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
      * @see {@link TreeSelectItemTogglerIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('itemtogglericon', { descendants: false }) itemTogglerIconTemplate: Nullable<TemplateRef<TreeSelectItemTogglerIconTemplateContext>>;
+    readonly itemTogglerIconTemplate = contentChild<Nullable<TemplateRef<TreeSelectItemTogglerIconTemplateContext>>>('itemtogglericon', { descendants: false });
 
     /**
      * Custom item checkbox icon template.
@@ -633,15 +633,15 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
      * @see {@link TreeSelectItemCheckboxIconTemplateContext}
      * @group Templates
      */
-    @ContentChild('itemcheckboxicon', { descendants: false }) itemCheckboxIconTemplate: Nullable<TemplateRef<TreeSelectItemCheckboxIconTemplateContext>>;
+    readonly itemCheckboxIconTemplate = contentChild<Nullable<TemplateRef<TreeSelectItemCheckboxIconTemplateContext>>>('itemcheckboxicon', { descendants: false });
 
     /**
      * Custom item loading icon template.
      * @group Templates
      */
-    @ContentChild('itemloadingicon', { descendants: false }) itemLoadingIconTemplate: Nullable<TemplateRef<void>>;
+    readonly itemLoadingIconTemplate = contentChild<Nullable<TemplateRef<void>>>('itemloadingicon', { descendants: false });
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     _valueTemplate: TemplateRef<TreeSelectValueTemplateContext> | undefined;
 
@@ -692,11 +692,11 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     }
 
     onAfterContentInit() {
-        if ((this.templates as QueryList<PrimeTemplate>).length) {
+        if ((this.templates() as QueryList<PrimeTemplate>).length) {
             this.templateMap = {};
         }
 
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'value':
                     this._valueTemplate = item.template;
@@ -756,29 +756,31 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
     onOverlayBeforeEnter() {
         if (this.filter) {
-            isNotEmpty(this.filterValue) && this.treeViewChild?._filter(<any>this.filterValue);
-            this.filterInputAutoFocus && this.filterViewChild?.nativeElement.focus();
+            isNotEmpty(this.filterValue) && this.treeViewChild()?._filter(<any>this.filterValue);
+            this.filterInputAutoFocus && this.filterViewChild()?.nativeElement.focus();
         } else {
-            let focusableElements = <any>getFocusableElements(this.panelEl?.nativeElement!);
+            let focusableElements = <any>getFocusableElements(this.panelEl()?.nativeElement!);
 
             if (focusableElements && focusableElements.length > 0) {
                 focusableElements[0].focus();
             }
         }
-        const panelElement = this.panelEl?.nativeElement;
+        const panelElement = this.panelEl()?.nativeElement;
         if (this.virtualScroll && panelElement) {
             let lastHeight = panelElement.offsetHeight;
             const virtualScrollResizeObserver = new ResizeObserver((entries) => {
                 const newHeight = entries[0].contentRect.height;
                 if (newHeight !== lastHeight) {
                     lastHeight = newHeight;
-                    this.overlayViewChild?.alignOverlay();
+                    this.overlayViewChild()?.alignOverlay();
                 }
             });
             virtualScrollResizeObserver.observe(panelElement);
 
             // clean up when overlay closes, not after first callback
-            this.overlayViewChild?.onHide.pipe(take(1)).subscribe(() => virtualScrollResizeObserver.disconnect());
+            this.overlayViewChild()
+                ?.onHide.pipe(take(1))
+                .subscribe(() => virtualScrollResizeObserver.disconnect());
         }
     }
 
@@ -801,14 +803,14 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
             return;
         }
         const section = event.target?.getAttribute?.('data-pc-section');
-        if (!this.overlayViewChild?.el?.nativeElement?.contains(event.target) && section !== 'box' && section !== 'icon') {
+        if (!this.overlayViewChild()?.el?.nativeElement?.contains(event.target) && section !== 'box' && section !== 'icon') {
             if (this.overlayVisible) {
                 this.hide();
             } else {
                 this.show();
             }
 
-            this.focusInput?.nativeElement.focus();
+            this.focusInput()?.nativeElement.focus();
         }
     }
 
@@ -837,7 +839,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
             case 'Escape':
                 if (this.overlayVisible) {
                     this.hide();
-                    this.focusInput?.nativeElement.focus();
+                    this.focusInput()?.nativeElement.focus();
                     event.preventDefault();
                 }
                 break;
@@ -854,19 +856,20 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
     onFilterInput(event: Event) {
         this.filterValue = (event.target as HTMLInputElement).value;
-        this.treeViewChild?._filter(this.filterValue);
+        treeViewChild?._filter(this.filterValue);
         this.onFilter.emit({
             filter: this.filterValue,
-            filteredValue: this.treeViewChild?.filteredNodes
+            filteredValue: treeViewChild?.filteredNodes
         });
         setTimeout(() => {
-            this.overlayViewChild?.alignOverlay();
+            this.overlayViewChild()?.alignOverlay();
         });
     }
 
     onArrowDown(event: KeyboardEvent) {
-        if (this.overlayVisible && this.panelEl?.nativeElement) {
-            let focusableElements = <any>getFocusableElements(this.panelEl.nativeElement, '[data-pc-section="node"]');
+        const panelEl = this.panelEl();
+        if (this.overlayVisible && panelEl?.nativeElement) {
+            let focusableElements = <any>getFocusableElements(panelEl.nativeElement, '[data-pc-section="node"]');
             if (focusableElements && focusableElements.length > 0) {
                 focusableElements[0].focus();
             }
@@ -876,13 +879,15 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     }
 
     onFirstHiddenFocus(event) {
-        const focusableEl = event.relatedTarget === this.focusInput?.nativeElement ? getFirstFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInput?.nativeElement;
+        const focusInput = this.focusInput();
+        const focusableEl = event.relatedTarget === focusInput?.nativeElement ? getFirstFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInput?.nativeElement;
 
         focus(focusableEl);
     }
 
     onLastHiddenFocus(event) {
-        const focusableEl = event.relatedTarget === this.focusInput?.nativeElement ? getLastFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInput?.nativeElement;
+        const focusInput = this.focusInput();
+        const focusableEl = event.relatedTarget === focusInput?.nativeElement ? getLastFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInput?.nativeElement;
 
         focus(focusableEl);
     }
@@ -916,7 +921,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     onTabKey(event, pressedInInputText = false) {
         if (!pressedInInputText) {
             if (this.overlayVisible && this.hasFocusableElements()) {
-                focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay?.nativeElement : this.firstHiddenFocusableElementOnOverlay?.nativeElement);
+                focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay()?.nativeElement : this.firstHiddenFocusableElementOnOverlay()?.nativeElement);
 
                 event.preventDefault();
             } else {
@@ -926,13 +931,14 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     }
 
     hasFocusableElements() {
-        return getFocusableElements(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
+        return getFocusableElements(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
     }
 
     resetFilter() {
         if (this.filter && !this.resetFilterOnHide) {
-            this.filteredNodes = this.treeViewChild?.filteredNodes;
-            this.treeViewChild?.resetFilter();
+            const treeViewChild = this.treeViewChild();
+            this.filteredNodes = treeViewChild?.filteredNodes;
+            treeViewChild?.resetFilter();
         } else {
             this.filterValue = null;
         }
@@ -980,7 +986,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
         this.onNodeExpand.emit(event);
         this.expandedNodes.push(event.node);
         setTimeout(() => {
-            this.overlayViewChild?.alignOverlay();
+            this.overlayViewChild()?.alignOverlay();
         });
     }
 
@@ -988,7 +994,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
         this.onNodeCollapse.emit(event);
         this.expandedNodes.splice(this.expandedNodes.indexOf(event.node), 1);
         setTimeout(() => {
-            this.overlayViewChild?.alignOverlay();
+            this.overlayViewChild()?.alignOverlay();
         });
     }
 
@@ -1064,7 +1070,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
         if (this.selectionMode === 'single') {
             this.hide();
-            this.focusInput?.nativeElement.focus();
+            this.focusInput()?.nativeElement.focus();
         }
     }
 

--- a/packages/optimus-ui/src/treeselect/treeselect.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.ts
@@ -14,7 +14,6 @@ import {
     Input,
     NgModule,
     Output,
-    QueryList,
     TemplateRef,
     ViewEncapsulation,
     viewChild,
@@ -692,11 +691,11 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     }
 
     onAfterContentInit() {
-        if ((this.templates() as QueryList<PrimeTemplate>).length) {
+        if (this.templates().length) {
             this.templateMap = {};
         }
 
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'value':
                     this._valueTemplate = item.template;
@@ -748,7 +747,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
                 default: //TODO: @deprecated Use "value" template instead
                     if (item.name) this.templateMap[item.name] = item.template;
-                    else this.valueTemplate = item.template;
+                    else this._valueTemplate = item.template;
                     break;
             }
         });
@@ -856,6 +855,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
     onFilterInput(event: Event) {
         this.filterValue = (event.target as HTMLInputElement).value;
+        const treeViewChild = this.treeViewChild();
         treeViewChild?._filter(this.filterValue);
         this.onFilter.emit({
             filter: this.filterValue,

--- a/packages/optimus-ui/src/treeselect/treeselect.ts
+++ b/packages/optimus-ui/src/treeselect/treeselect.ts
@@ -531,7 +531,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
 
-    readonly focusInput = viewChild<Nullable<ElementRef>>('focusInput');
+    readonly focusInput = viewChild.required<ElementRef>('focusInput');
 
     readonly filterViewChild = viewChild<Nullable<ElementRef>>('filter');
 
@@ -539,7 +539,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
     readonly panelEl = viewChild<Nullable<ElementRef>>('panel');
 
-    readonly overlayViewChild = viewChild<Nullable<Overlay>>('overlay');
+    readonly overlayViewChild = viewChild.required<Overlay>('overlay');
 
     readonly firstHiddenFocusableElementOnOverlay = viewChild<Nullable<ElementRef>>('firstHiddenFocusableEl');
 
@@ -765,7 +765,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
                 const newHeight = entries[0].contentRect.height;
                 if (newHeight !== lastHeight) {
                     lastHeight = newHeight;
-                    this.overlayViewChild()?.alignOverlay();
+                    this.overlayViewChild().alignOverlay();
                 }
             });
             virtualScrollResizeObserver.observe(panelElement);
@@ -796,14 +796,14 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
             return;
         }
         const section = event.target?.getAttribute?.('data-pc-section');
-        if (!this.overlayViewChild()?.el?.nativeElement?.contains(event.target) && section !== 'box' && section !== 'icon') {
+        if (!this.overlayViewChild().el?.nativeElement?.contains(event.target) && section !== 'box' && section !== 'icon') {
             if (this.overlayVisible) {
                 this.hide();
             } else {
                 this.show();
             }
 
-            this.focusInput()?.nativeElement.focus();
+            this.focusInput().nativeElement.focus();
         }
     }
 
@@ -832,7 +832,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
             case 'Escape':
                 if (this.overlayVisible) {
                     this.hide();
-                    this.focusInput()?.nativeElement.focus();
+                    this.focusInput().nativeElement.focus();
                     event.preventDefault();
                 }
                 break;
@@ -856,7 +856,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
             filteredValue: treeViewChild?.filteredNodes
         });
         setTimeout(() => {
-            this.overlayViewChild()?.alignOverlay();
+            this.overlayViewChild().alignOverlay();
         });
     }
 
@@ -874,14 +874,14 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
     onFirstHiddenFocus(event) {
         const focusInput = this.focusInput();
-        const focusableEl = event.relatedTarget === focusInput?.nativeElement ? getFirstFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInput?.nativeElement;
+        const focusableEl = event.relatedTarget === focusInput.nativeElement ? getFirstFocusableElement(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInput.nativeElement;
 
         focus(focusableEl);
     }
 
     onLastHiddenFocus(event) {
         const focusInput = this.focusInput();
-        const focusableEl = event.relatedTarget === focusInput?.nativeElement ? getLastFocusableElement(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInput?.nativeElement;
+        const focusableEl = event.relatedTarget === focusInput.nativeElement ? getLastFocusableElement(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])') : focusInput.nativeElement;
 
         focus(focusableEl);
     }
@@ -925,7 +925,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
     }
 
     hasFocusableElements() {
-        return getFocusableElements(this.overlayViewChild()?.overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
+        return getFocusableElements(this.overlayViewChild().overlayViewChild()?.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
     }
 
     resetFilter() {
@@ -980,7 +980,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
         this.onNodeExpand.emit(event);
         this.expandedNodes.push(event.node);
         setTimeout(() => {
-            this.overlayViewChild()?.alignOverlay();
+            this.overlayViewChild().alignOverlay();
         });
     }
 
@@ -988,7 +988,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
         this.onNodeCollapse.emit(event);
         this.expandedNodes.splice(this.expandedNodes.indexOf(event.node), 1);
         setTimeout(() => {
-            this.overlayViewChild()?.alignOverlay();
+            this.overlayViewChild().alignOverlay();
         });
     }
 
@@ -1064,7 +1064,7 @@ export class TreeSelect extends BaseEditableHolder<TreeSelectPassThrough> {
 
         if (this.selectionMode === 'single') {
             this.hide();
-            this.focusInput()?.nativeElement.focus();
+            this.focusInput().nativeElement.focus();
         }
     }
 

--- a/packages/optimus-ui/src/treetable/treetable.test.ts
+++ b/packages/optimus-ui/src/treetable/treetable.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ViewChild, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -1780,7 +1780,7 @@ describe('TreeTable', () => {
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
             dynamicFixture.detectChanges();
-            dynamicTreetable = dynamicComponent.treetable;
+            dynamicTreetable = dynamicComponent.treetable();
         });
 
         describe('Observable Data Updates', () => {
@@ -3030,7 +3030,7 @@ describe('TreeTable', () => {
     `
 })
 class TestBasicTreeTableComponent {
-    @ViewChild('treetable') treetable!: TreeTable;
+    readonly treetable = viewChild.required<TreeTable>('treetable');
 
     // Input Properties
     columns: any[] = [
@@ -3178,7 +3178,7 @@ class TestTemplatesTreeTableComponent {
     template: ` <p-treetable #treetable [value]="value" [columns]="columns"> </p-treetable> `
 })
 class TestDynamicTreeTableComponent {
-    @ViewChild('treetable') treetable!: TreeTable;
+    readonly treetable = viewChild.required<TreeTable>('treetable');
 
     value: TreeNode[] = [
         {
@@ -3202,51 +3202,51 @@ class TestDynamicTreeTableComponent {
     }
 
     updateAutoLayout(enabled: boolean) {
-        this.treetable.autoLayout = enabled;
+        this.treetable().autoLayout = enabled;
     }
 
     updatePaginator(enabled: boolean) {
-        this.treetable.paginator = enabled;
+        this.treetable().paginator = enabled;
     }
 
     updateRows(rows: number) {
-        this.treetable.rows = rows;
+        this.treetable().rows = rows;
     }
 
     updateFirst(first: number) {
-        this.treetable.first = first;
+        this.treetable().first = first;
     }
 
     updateLazy(enabled: boolean) {
-        this.treetable.lazy = enabled;
+        this.treetable().lazy = enabled;
     }
 
     updateLoading(loading: boolean) {
-        this.treetable.loading = loading;
+        this.treetable().loading = loading;
     }
 
     updateScrollable(enabled: boolean) {
-        this.treetable.scrollable = enabled;
+        this.treetable().scrollable = enabled;
     }
 
     updateVirtualScroll(enabled: boolean) {
-        this.treetable.virtualScroll = enabled;
+        this.treetable().virtualScroll = enabled;
     }
 
     updateSelectionMode(mode: string) {
-        this.treetable.selectionMode = mode;
+        this.treetable().selectionMode = mode;
     }
 
     updateSortMode(mode: 'single' | 'multiple') {
-        this.treetable.sortMode = mode;
+        this.treetable().sortMode = mode;
     }
 
     updateFilterMode(mode: string) {
-        this.treetable.filterMode = mode;
+        this.treetable().filterMode = mode;
     }
 
     updateShowGridlines(show: boolean) {
-        this.treetable.showGridlines = show;
+        this.treetable().showGridlines = show;
     }
 }
 describe('TreeTable PT', () => {

--- a/packages/optimus-ui/src/treetable/treetable.test.ts
+++ b/packages/optimus-ui/src/treetable/treetable.test.ts
@@ -3,10 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
-import { TreeNode } from '@openng/optimus-ui/api';
+import { SharedModule, TreeNode } from '@openng/optimus-ui/api';
 import { provideOptimus } from '@openng/optimus-ui/config';
 import { of } from 'rxjs';
-import { TreeTable, TreeTableModule } from './treetable';
+import { TreeTable, TreeTableModule, TTScrollableView } from './treetable';
 
 describe('TreeTable', () => {
     let component: TestBasicTreeTableComponent;
@@ -3858,5 +3858,178 @@ describe('TreeTable Inline PT', () => {
 
         const host = fixture.nativeElement.querySelector('p-treetable');
         expect(host?.classList.contains('INLINE_HOST_CLASS')).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal query API
+// ---------------------------------------------------------------------------
+
+@Component({
+    standalone: true,
+    imports: [TreeTableModule, SharedModule],
+    template: `
+        <p-treetable [value]="nodes" [resizableColumns]="true" [reorderableColumns]="true">
+            <ng-template #header>
+                <tr>
+                    <th>Name</th>
+                </tr>
+            </ng-template>
+            <ng-template #body let-rowNode let-rowData="rowData">
+                <tr>
+                    <td>{{ rowData.name }}</td>
+                </tr>
+            </ng-template>
+            <ng-template #colgroup>
+                <colgroup>
+                    <col />
+                </colgroup>
+            </ng-template>
+            <ng-template #paginatorleft>L</ng-template>
+            <ng-template #paginatorright>R</ng-template>
+            <ng-template #paginatordropdownitem let-item>{{ item?.label }}</ng-template>
+            <ng-template #frozenheader>
+                <tr>
+                    <th>fh</th>
+                </tr>
+            </ng-template>
+            <ng-template #frozenbody>
+                <tr>
+                    <td>fb</td>
+                </tr>
+            </ng-template>
+            <ng-template #frozenfooter>
+                <tr>
+                    <td>ff</td>
+                </tr>
+            </ng-template>
+            <ng-template #frozencolgroup>
+                <colgroup>
+                    <col />
+                </colgroup>
+            </ng-template>
+            <ng-template #loadingicon>…</ng-template>
+            <ng-template #reorderindicatorupicon>^</ng-template>
+            <ng-template #reorderindicatordownicon>v</ng-template>
+            <ng-template #sorticon let-sortOrder>{{ sortOrder }}</ng-template>
+            <ng-template #checkboxicon>x</ng-template>
+            <ng-template #headercheckboxicon>hx</ng-template>
+            <ng-template #togglericon>t</ng-template>
+            <ng-template #paginatorfirstpagelinkicon>first</ng-template>
+            <ng-template #paginatorlastpagelinkicon>last</ng-template>
+            <ng-template #paginatorpreviouspagelinkicon>prev</ng-template>
+            <ng-template #paginatornextpagelinkicon>next</ng-template>
+            <ng-template #loader>load</ng-template>
+            <ng-template pTemplate="caption">caption</ng-template>
+        </p-treetable>
+    `
+})
+class TreeTableQueryApiHostComponent {
+    nodes: TreeNode[] = [{ data: { name: 'root' }, children: [{ data: { name: 'child' } }] }];
+}
+
+@Component({
+    standalone: true,
+    imports: [TreeTableModule, SharedModule],
+    template: `
+        <p-treetable [value]="nodes" [scrollable]="true" scrollHeight="200px">
+            <ng-template #header>
+                <tr>
+                    <th>Name</th>
+                </tr>
+            </ng-template>
+            <ng-template #body let-rowNode let-rowData="rowData">
+                <tr>
+                    <td>{{ rowData.name }}</td>
+                </tr>
+            </ng-template>
+            <ng-template #footer>
+                <tr>
+                    <td>F</td>
+                </tr>
+            </ng-template>
+        </p-treetable>
+    `
+})
+class TreeTableScrollableQueryApiHostComponent {
+    nodes: TreeNode[] = [{ data: { name: 'root' } }];
+}
+
+describe('TreeTable Signal Query API', () => {
+    it('should resolve all contentChild template hooks and the templates query', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [TreeTableQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection()]
+        });
+        const fixture = TestBed.createComponent(TreeTableQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const instance = fixture.debugElement.query(By.directive(TreeTable)).componentInstance;
+
+        const hooks = [
+            '_colGroupTemplate',
+            '_paginatorLeftTemplate',
+            '_paginatorRightTemplate',
+            '_paginatorDropdownItemTemplate',
+            '_frozenHeaderTemplate',
+            '_frozenBodyTemplate',
+            '_frozenFooterTemplate',
+            '_frozenColGroupTemplate',
+            '_loadingIconTemplate',
+            '_reorderIndicatorUpIconTemplate',
+            '_reorderIndicatorDownIconTemplate',
+            '_sortIconTemplate',
+            '_checkboxIconTemplate',
+            '_headerCheckboxIconTemplate',
+            '_togglerIconTemplate',
+            '_paginatorFirstPageLinkIconTemplate',
+            '_paginatorLastPageLinkIconTemplate',
+            '_paginatorPreviousPageLinkIconTemplate',
+            '_paginatorNextPageLinkIconTemplate',
+            '_loaderTemplate'
+        ];
+        for (const hook of hooks) {
+            expect((instance as any)[hook](), `${hook} should resolve`).toBeDefined();
+        }
+
+        const templates = instance.templates();
+        expect(Array.isArray(templates)).toBe(true);
+        expect(templates.some((t: any) => t.getType() === 'caption')).toBe(true);
+
+        expect(instance.tableViewChild()?.nativeElement).toBeDefined();
+        expect(instance.resizeHelperViewChild()?.nativeElement).toBeDefined();
+        expect(instance.reorderIndicatorUpViewChild()?.nativeElement).toBeDefined();
+        expect(instance.reorderIndicatorDownViewChild()?.nativeElement).toBeDefined();
+        expect(instance.scrollableViewChild()).toBeUndefined();
+        expect(instance.scrollableFrozenViewChild()).toBeUndefined();
+    });
+
+    it('should resolve scrollable view queries when scrollable is enabled', async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+            imports: [TreeTableScrollableQueryApiHostComponent],
+            providers: [provideZonelessChangeDetection()]
+        });
+        const fixture = TestBed.createComponent(TreeTableScrollableQueryApiHostComponent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const instance = fixture.debugElement.query(By.directive(TreeTable)).componentInstance;
+        expect(instance.scrollable, 'scrollable input should be applied').toBe(true);
+        const sv = fixture.debugElement.query(By.directive(TTScrollableView));
+        expect(sv, 'TTScrollableView should be rendered').toBeTruthy();
+        // the #scrollableView element hosts the TTScrollableView component, so the query resolves to it
+        expect(instance.scrollableViewChild()).toBe(sv.componentInstance);
+
+        const scrollableView = fixture.debugElement.query(By.directive(TTScrollableView)).componentInstance;
+        expect(scrollableView.scrollHeaderViewChild().nativeElement).toBeDefined();
+        expect(scrollableView.scrollHeaderBoxViewChild().nativeElement).toBeDefined();
+        expect(scrollableView.scrollBodyViewChild()?.nativeElement).toBeDefined();
+        expect(scrollableView.scrollFooterViewChild()?.nativeElement).toBeDefined();
+        expect(scrollableView.scrollFooterBoxViewChild()?.nativeElement).toBeDefined();
+        // frozen-only / virtual-scroll-only queries stay unresolved in this host
+        expect(scrollableView.scrollableAlignerViewChild()).toBeUndefined();
+        expect(scrollableView.scroller()).toBeUndefined();
     });
 });

--- a/packages/optimus-ui/src/treetable/treetable.ts
+++ b/packages/optimus-ui/src/treetable/treetable.ts
@@ -2591,9 +2591,9 @@ export class TTScrollableView extends BaseComponent {
 
     @Input({ transform: booleanAttribute }) frozen: boolean | undefined;
 
-    readonly scrollHeaderViewChild = viewChild<Nullable<ElementRef>>('scrollHeader');
+    readonly scrollHeaderViewChild = viewChild.required<ElementRef>('scrollHeader');
 
-    readonly scrollHeaderBoxViewChild = viewChild<Nullable<ElementRef>>('scrollHeaderBox');
+    readonly scrollHeaderBoxViewChild = viewChild.required<ElementRef>('scrollHeaderBox');
 
     readonly scrollBodyViewChild = viewChild<Nullable<ElementRef>>('scrollBody');
 
@@ -2646,10 +2646,7 @@ export class TTScrollableView extends BaseComponent {
 
                 if (this.scrollHeight) {
                     let scrollBarWidth = calculateScrollbarWidth();
-                    const scrollHeaderBoxViewChild = this.scrollHeaderBoxViewChild();
-                    if (scrollHeaderBoxViewChild?.nativeElement) {
-                        scrollHeaderBoxViewChild.nativeElement.style.paddingRight = scrollBarWidth + 'px';
-                    }
+                    this.scrollHeaderBoxViewChild().nativeElement.style.paddingRight = scrollBarWidth + 'px';
 
                     const scrollFooterBoxViewChild = this.scrollFooterBoxViewChild();
                     if (scrollFooterBoxViewChild && scrollFooterBoxViewChild.nativeElement) {
@@ -2670,10 +2667,7 @@ export class TTScrollableView extends BaseComponent {
     bindEvents() {
         if (isPlatformBrowser(this.platformId)) {
             this.zone.runOutsideAngular(() => {
-                const scrollHeaderViewChild = this.scrollHeaderViewChild();
-                if (scrollHeaderViewChild && scrollHeaderViewChild.nativeElement) {
-                    this.headerScrollListener = this.renderer.listen(this.scrollHeaderBoxViewChild()?.nativeElement, 'scroll', this.onHeaderScroll.bind(this));
-                }
+                this.headerScrollListener = this.renderer.listen(this.scrollHeaderBoxViewChild().nativeElement, 'scroll', this.onHeaderScroll.bind(this));
 
                 const scrollFooterViewChild = this.scrollFooterViewChild();
                 if (scrollFooterViewChild && scrollFooterViewChild.nativeElement) {
@@ -2693,12 +2687,9 @@ export class TTScrollableView extends BaseComponent {
 
     unbindEvents() {
         if (isPlatformBrowser(this.platformId)) {
-            const scrollHeaderViewChild = this.scrollHeaderViewChild();
-            if (scrollHeaderViewChild && scrollHeaderViewChild.nativeElement) {
-                if (this.headerScrollListener) {
-                    this.headerScrollListener();
-                    this.headerScrollListener = null;
-                }
+            if (this.headerScrollListener) {
+                this.headerScrollListener();
+                this.headerScrollListener = null;
             }
 
             const scrollFooterViewChild = this.scrollFooterViewChild();
@@ -2728,7 +2719,7 @@ export class TTScrollableView extends BaseComponent {
     }
 
     onHeaderScroll() {
-        const scrollLeft = this.scrollHeaderViewChild()?.nativeElement.scrollLeft;
+        const scrollLeft = this.scrollHeaderViewChild().nativeElement.scrollLeft;
 
         (this.scrollBodyViewChild() as ElementRef).nativeElement.scrollLeft = scrollLeft;
 
@@ -2744,10 +2735,7 @@ export class TTScrollableView extends BaseComponent {
         const scrollLeft = this.scrollFooterViewChild()?.nativeElement.scrollLeft;
         (this.scrollBodyViewChild() as ElementRef).nativeElement.scrollLeft = scrollLeft;
 
-        const scrollHeaderViewChild = this.scrollHeaderViewChild();
-        if (scrollHeaderViewChild && scrollHeaderViewChild.nativeElement) {
-            scrollHeaderViewChild.nativeElement.scrollLeft = scrollLeft;
-        }
+        this.scrollHeaderViewChild().nativeElement.scrollLeft = scrollLeft;
 
         this.preventBodyScrollPropagation = true;
     }
@@ -2758,10 +2746,7 @@ export class TTScrollableView extends BaseComponent {
             return;
         }
 
-        const scrollHeaderViewChild = this.scrollHeaderViewChild();
-        if (scrollHeaderViewChild && scrollHeaderViewChild.nativeElement) {
-            (this.scrollHeaderBoxViewChild() as ElementRef).nativeElement.style.marginLeft = -1 * event.target.scrollLeft + 'px';
-        }
+        (this.scrollHeaderBoxViewChild() as ElementRef).nativeElement.style.marginLeft = -1 * event.target.scrollLeft + 'px';
 
         const scrollFooterViewChild = this.scrollFooterViewChild();
         if (scrollFooterViewChild && scrollFooterViewChild.nativeElement) {

--- a/packages/optimus-ui/src/treetable/treetable.ts
+++ b/packages/optimus-ui/src/treetable/treetable.ts
@@ -16,7 +16,6 @@ import {
     NgZone,
     numberAttribute,
     Output,
-    QueryList,
     SimpleChanges,
     TemplateRef,
     ViewEncapsulation,
@@ -964,7 +963,7 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
     readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'caption':
                     this.captionTemplate = item.template;
@@ -3805,7 +3804,7 @@ export class TreeTableCellEditor extends BaseComponent {
     outputTemplate: Nullable<TemplateRef<any>>;
 
     onAfterContentInit() {
-        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
+        this.templates().forEach((item) => {
             switch (item.getType()) {
                 case 'input':
                     this.inputTemplate = item.template;

--- a/packages/optimus-ui/src/treetable/treetable.ts
+++ b/packages/optimus-ui/src/treetable/treetable.ts
@@ -2597,10 +2597,6 @@ export class TTScrollableView extends BaseComponent {
 
     readonly scrollBodyViewChild = viewChild<Nullable<ElementRef>>('scrollBody');
 
-    readonly scrollTableViewChild = viewChild<Nullable<ElementRef>>('scrollTable');
-
-    readonly scrollLoadingTableViewChild = viewChild<Nullable<ElementRef>>('loadingTable');
-
     readonly scrollFooterViewChild = viewChild<Nullable<ElementRef>>('scrollFooter');
 
     readonly scrollFooterBoxViewChild = viewChild<Nullable<ElementRef>>('scrollFooterBox');

--- a/packages/optimus-ui/src/treetable/treetable.ts
+++ b/packages/optimus-ui/src/treetable/treetable.ts
@@ -4,8 +4,6 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    ContentChild,
-    ContentChildren,
     Directive,
     ElementRef,
     EventEmitter,
@@ -21,8 +19,10 @@ import {
     QueryList,
     SimpleChanges,
     TemplateRef,
-    ViewChild,
-    ViewEncapsulation
+    ViewEncapsulation,
+    viewChild,
+    contentChild,
+    contentChildren
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
@@ -137,20 +137,20 @@ export class TreeTableService {
                     <i [class]="cn(cx('loadingIcon'), 'pi-spin' + loadingIcon)"></i>
                 }
                 @if (!loadingIcon) {
-                    @if (!loadingIconTemplate && !_loadingIconTemplate) {
+                    @if (!loadingIconTemplate && !_loadingIconTemplate()) {
                         <svg data-p-icon="spinner" [spin]="true" [class]="cx('loadingIcon')" />
                     }
-                    @if (loadingIconTemplate || _loadingIconTemplate) {
+                    @if (loadingIconTemplate || _loadingIconTemplate()) {
                         <span [class]="cx('loadingIcon')">
-                            <ng-template *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate"></ng-template>
+                            <ng-template *ngTemplateOutlet="loadingIconTemplate || _loadingIconTemplate()"></ng-template>
                         </span>
                     }
                 }
             </div>
         }
-        @if (captionTemplate || _captionTemplate) {
+        @if (captionTemplate || _captionTemplate()) {
             <div [pBind]="ptm('header')" [class]="cx('header')">
-                <ng-container *ngTemplateOutlet="captionTemplate || _captionTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="captionTemplate || _captionTemplate()"></ng-container>
             </div>
         }
         @if (paginator && (paginatorPosition === 'top' || paginatorPosition == 'both')) {
@@ -164,36 +164,36 @@ export class TreeTableService {
                 [alwaysShow]="alwaysShowPaginator"
                 (onPageChange)="onPageChange($event)"
                 [rowsPerPageOptions]="rowsPerPageOptions"
-                [templateLeft]="paginatorLeftTemplate ?? _paginatorLeftTemplate"
-                [templateRight]="paginatorRightTemplate ?? _paginatorRightTemplate"
+                [templateLeft]="paginatorLeftTemplate ?? _paginatorLeftTemplate()"
+                [templateRight]="paginatorRightTemplate ?? _paginatorRightTemplate()"
                 [appendTo]="paginatorDropdownAppendTo"
                 [currentPageReportTemplate]="currentPageReportTemplate"
                 [showFirstLastIcon]="showFirstLastIcon"
-                [dropdownItemTemplate]="paginatorDropdownItemTemplate ?? _paginatorDropdownItemTemplate"
+                [dropdownItemTemplate]="paginatorDropdownItemTemplate ?? _paginatorDropdownItemTemplate()"
                 [showCurrentPageReport]="showCurrentPageReport"
                 [showJumpToPageDropdown]="showJumpToPageDropdown"
                 [showPageLinks]="showPageLinks"
                 [locale]="paginatorLocale"
                 [unstyled]="unstyled()"
             >
-                @if (paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate) {
+                @if (paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate()) {
                     <ng-template pTemplate="firstpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate) {
+                @if (paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate()) {
                     <ng-template pTemplate="previouspagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate) {
+                @if (paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate()) {
                     <ng-template pTemplate="lastpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate) {
+                @if (paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate()) {
                     <ng-template pTemplate="nextpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
             </p-paginator>
@@ -202,13 +202,13 @@ export class TreeTableService {
         @if (!scrollable) {
             <div [pBind]="ptm('wrapper')" [class]="cx('wrapper')">
                 <table role="treegrid" [pBind]="ptm('table')" #table [ngClass]="tableStyleClass" [ngStyle]="tableStyle">
-                    <ng-container *ngTemplateOutlet="colGroupTemplate || _colGroupTemplate; context: { $implicit: columns }"></ng-container>
+                    <ng-container *ngTemplateOutlet="colGroupTemplate || _colGroupTemplate(); context: { $implicit: columns }"></ng-container>
                     <thead role="rowgroup" [class]="cx('thead')" [pBind]="ptm('thead')">
-                        <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate; context: { $implicit: columns }"></ng-container>
+                        <ng-container *ngTemplateOutlet="headerTemplate || _headerTemplate(); context: { $implicit: columns }"></ng-container>
                     </thead>
-                    <tbody [class]="cx('tbody')" [pBind]="ptm('tbody')" role="rowgroup" [unstyled]="unstyled()" [pTreeTableBody]="columns" [pTreeTableBodyTemplate]="bodyTemplate ?? _bodyTemplate"></tbody>
+                    <tbody [class]="cx('tbody')" [pBind]="ptm('tbody')" role="rowgroup" [unstyled]="unstyled()" [pTreeTableBody]="columns" [pTreeTableBodyTemplate]="bodyTemplate ?? _bodyTemplate()"></tbody>
                     <tfoot [class]="cx('tfoot')" [pBind]="ptm('tfoot')" role="rowgroup">
-                        <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate; context: { $implicit: columns }"></ng-container>
+                        <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate(); context: { $implicit: columns }"></ng-container>
                     </tfoot>
                 </table>
             </div>
@@ -216,7 +216,7 @@ export class TreeTableService {
 
         @if (scrollable) {
             <div [pBind]="ptm('scrollableWrapper')" [class]="cx('scrollableWrapper')">
-                @if (frozenColumns || frozenBodyTemplate || _frozenBodyTemplate) {
+                @if (frozenColumns || frozenBodyTemplate || _frozenBodyTemplate()) {
                     <div
                         [ngClass]="[cx('scrollableView'), cx('frozenView')]"
                         #scrollableFrozenView
@@ -252,43 +252,43 @@ export class TreeTableService {
                 [alwaysShow]="alwaysShowPaginator"
                 (onPageChange)="onPageChange($event)"
                 [rowsPerPageOptions]="rowsPerPageOptions"
-                [templateLeft]="paginatorLeftTemplate ?? _paginatorLeftTemplate"
-                [templateRight]="paginatorRightTemplate ?? _paginatorRightTemplate"
+                [templateLeft]="paginatorLeftTemplate ?? _paginatorLeftTemplate()"
+                [templateRight]="paginatorRightTemplate ?? _paginatorRightTemplate()"
                 [appendTo]="paginatorDropdownAppendTo"
                 [currentPageReportTemplate]="currentPageReportTemplate"
                 [showFirstLastIcon]="showFirstLastIcon"
-                [dropdownItemTemplate]="paginatorDropdownItemTemplate ?? _paginatorDropdownItemTemplate"
+                [dropdownItemTemplate]="paginatorDropdownItemTemplate ?? _paginatorDropdownItemTemplate()"
                 [showCurrentPageReport]="showCurrentPageReport"
                 [showJumpToPageDropdown]="showJumpToPageDropdown"
                 [showPageLinks]="showPageLinks"
                 [locale]="paginatorLocale"
                 [unstyled]="unstyled()"
             >
-                @if (paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate) {
+                @if (paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate()) {
                     <ng-template pTemplate="firstpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate || _paginatorFirstPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate) {
+                @if (paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate()) {
                     <ng-template pTemplate="previouspagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorPreviousPageLinkIconTemplate || _paginatorPreviousPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate) {
+                @if (paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate()) {
                     <ng-template pTemplate="lastpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorLastPageLinkIconTemplate || _paginatorLastPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
-                @if (paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate) {
+                @if (paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate()) {
                     <ng-template pTemplate="nextpagelinkicon">
-                        <ng-container *ngTemplateOutlet="paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="paginatorNextPageLinkIconTemplate || _paginatorNextPageLinkIconTemplate()"></ng-container>
                     </ng-template>
                 }
             </p-paginator>
         }
-        @if (summaryTemplate || _summaryTemplate) {
+        @if (summaryTemplate || _summaryTemplate()) {
             <div [pBind]="ptm('footer')" [class]="cx('footer')">
-                <ng-container *ngTemplateOutlet="summaryTemplate || _summaryTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="summaryTemplate || _summaryTemplate()"></ng-container>
             </div>
         }
 
@@ -297,18 +297,18 @@ export class TreeTableService {
         }
         @if (reorderableColumns) {
             <span [pBind]="ptm('reorderIndicatorUp')" #reorderIndicatorUp [class]="cx('reorderIndicatorUp')" [style.display]="'none'">
-                @if (!reorderIndicatorUpIconTemplate && !_reorderIndicatorUpIconTemplate) {
+                @if (!reorderIndicatorUpIconTemplate && !_reorderIndicatorUpIconTemplate()) {
                     <svg data-p-icon="arrow-down" />
                 }
-                <ng-template *ngTemplateOutlet="reorderIndicatorUpIconTemplate || _reorderIndicatorUpIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="reorderIndicatorUpIconTemplate || _reorderIndicatorUpIconTemplate()"></ng-template>
             </span>
         }
         @if (reorderableColumns) {
             <span [pBind]="ptm('reorderIndicatorDown')" #reorderIndicatorDown [class]="cx('reorderIndicatorDown')" [style.display]="'none'">
-                @if (!reorderIndicatorDownIconTemplate && !_reorderIndicatorDownIconTemplate) {
+                @if (!reorderIndicatorDownIconTemplate && !_reorderIndicatorDownIconTemplate()) {
                     <svg data-p-icon="arrow-up" />
                 }
-                <ng-template *ngTemplateOutlet="reorderIndicatorDownIconTemplate || _reorderIndicatorDownIconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="reorderIndicatorDownIconTemplate || _reorderIndicatorDownIconTemplate()"></ng-template>
             </span>
         }
     `,
@@ -812,17 +812,17 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
      */
     @Output() selectionKeysChange: EventEmitter<any> = new EventEmitter();
 
-    @ViewChild('resizeHelper') resizeHelperViewChild: Nullable<ElementRef>;
+    readonly resizeHelperViewChild = viewChild<Nullable<ElementRef>>('resizeHelper');
 
-    @ViewChild('reorderIndicatorUp') reorderIndicatorUpViewChild: Nullable<ElementRef>;
+    readonly reorderIndicatorUpViewChild = viewChild<Nullable<ElementRef>>('reorderIndicatorUp');
 
-    @ViewChild('reorderIndicatorDown') reorderIndicatorDownViewChild: Nullable<ElementRef>;
+    readonly reorderIndicatorDownViewChild = viewChild<Nullable<ElementRef>>('reorderIndicatorDown');
 
-    @ViewChild('table') tableViewChild: Nullable<ElementRef>;
+    readonly tableViewChild = viewChild<Nullable<ElementRef>>('table');
 
-    @ViewChild('scrollableView') scrollableViewChild: Nullable<ElementRef>;
+    readonly scrollableViewChild = viewChild<Nullable<ElementRef>>('scrollableView');
 
-    @ViewChild('scrollableFrozenView') scrollableFrozenViewChild: Nullable<ElementRef>;
+    readonly scrollableFrozenViewChild = viewChild<Nullable<ElementRef>>('scrollableFrozenView');
 
     _value: TreeNode<any>[] | undefined = [];
 
@@ -844,82 +844,82 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
 
     filterTimeout: any;
 
-    @ContentChild('colgroup', { descendants: false }) _colGroupTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
+    readonly _colGroupTemplate = contentChild<Nullable<TemplateRef<TreeTableColumnsTemplateContext>>>('colgroup', { descendants: false });
     colGroupTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
 
-    @ContentChild('caption', { descendants: false }) _captionTemplate: Nullable<TemplateRef<void>>;
+    readonly _captionTemplate = contentChild<Nullable<TemplateRef<void>>>('caption', { descendants: false });
     captionTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('header', { descendants: false }) _headerTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
+    readonly _headerTemplate = contentChild<Nullable<TemplateRef<TreeTableColumnsTemplateContext>>>('header', { descendants: false });
     headerTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
 
-    @ContentChild('body', { descendants: false }) _bodyTemplate: Nullable<TemplateRef<TreeTableBodyTemplateContext>>;
+    readonly _bodyTemplate = contentChild<Nullable<TemplateRef<TreeTableBodyTemplateContext>>>('body', { descendants: false });
     bodyTemplate: Nullable<TemplateRef<TreeTableBodyTemplateContext>>;
 
-    @ContentChild('footer', { descendants: false }) _footerTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
+    readonly _footerTemplate = contentChild<Nullable<TemplateRef<TreeTableColumnsTemplateContext>>>('footer', { descendants: false });
     footerTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
 
-    @ContentChild('summary', { descendants: false }) _summaryTemplate: Nullable<TemplateRef<void>>;
+    readonly _summaryTemplate = contentChild<Nullable<TemplateRef<void>>>('summary', { descendants: false });
     summaryTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('emptymessage', { descendants: false }) _emptyMessageTemplate: Nullable<TemplateRef<TreeTableEmptyMessageTemplateContext>>;
+    readonly _emptyMessageTemplate = contentChild<Nullable<TemplateRef<TreeTableEmptyMessageTemplateContext>>>('emptymessage', { descendants: false });
     emptyMessageTemplate: Nullable<TemplateRef<TreeTableEmptyMessageTemplateContext>>;
 
-    @ContentChild('paginatorleft', { descendants: false }) _paginatorLeftTemplate: Nullable<TemplateRef<void>>;
+    readonly _paginatorLeftTemplate = contentChild<Nullable<TemplateRef<void>>>('paginatorleft', { descendants: false });
     paginatorLeftTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('paginatorright', { descendants: false }) _paginatorRightTemplate: Nullable<TemplateRef<void>>;
+    readonly _paginatorRightTemplate = contentChild<Nullable<TemplateRef<void>>>('paginatorright', { descendants: false });
     paginatorRightTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('paginatordropdownitem', { descendants: false }) _paginatorDropdownItemTemplate: Nullable<TemplateRef<void>>;
+    readonly _paginatorDropdownItemTemplate = contentChild<Nullable<TemplateRef<void>>>('paginatordropdownitem', { descendants: false });
     paginatorDropdownItemTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('frozenheader', { descendants: false }) _frozenHeaderTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
+    readonly _frozenHeaderTemplate = contentChild<Nullable<TemplateRef<TreeTableColumnsTemplateContext>>>('frozenheader', { descendants: false });
     frozenHeaderTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
 
-    @ContentChild('frozenbody', { descendants: false }) _frozenBodyTemplate: Nullable<TemplateRef<void>>;
+    readonly _frozenBodyTemplate = contentChild<Nullable<TemplateRef<void>>>('frozenbody', { descendants: false });
     frozenBodyTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('frozenfooter', { descendants: false }) _frozenFooterTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
+    readonly _frozenFooterTemplate = contentChild<Nullable<TemplateRef<TreeTableColumnsTemplateContext>>>('frozenfooter', { descendants: false });
     frozenFooterTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
 
-    @ContentChild('frozencolgroup', { descendants: false }) _frozenColGroupTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
+    readonly _frozenColGroupTemplate = contentChild<Nullable<TemplateRef<TreeTableColumnsTemplateContext>>>('frozencolgroup', { descendants: false });
     frozenColGroupTemplate: Nullable<TemplateRef<TreeTableColumnsTemplateContext>>;
 
-    @ContentChild('loadingicon', { descendants: false }) _loadingIconTemplate: Nullable<TemplateRef<void>>;
+    readonly _loadingIconTemplate = contentChild<Nullable<TemplateRef<void>>>('loadingicon', { descendants: false });
     loadingIconTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('reorderindicatorupicon', { descendants: false }) _reorderIndicatorUpIconTemplate: Nullable<TemplateRef<void>>;
+    readonly _reorderIndicatorUpIconTemplate = contentChild<Nullable<TemplateRef<void>>>('reorderindicatorupicon', { descendants: false });
     reorderIndicatorUpIconTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('reorderindicatordownicon', { descendants: false }) _reorderIndicatorDownIconTemplate: Nullable<TemplateRef<void>>;
+    readonly _reorderIndicatorDownIconTemplate = contentChild<Nullable<TemplateRef<void>>>('reorderindicatordownicon', { descendants: false });
     reorderIndicatorDownIconTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('sorticon', { descendants: false }) _sortIconTemplate: Nullable<TemplateRef<TreeTableSortIconTemplateContext>>;
+    readonly _sortIconTemplate = contentChild<Nullable<TemplateRef<TreeTableSortIconTemplateContext>>>('sorticon', { descendants: false });
     sortIconTemplate: Nullable<TemplateRef<TreeTableSortIconTemplateContext>>;
 
-    @ContentChild('checkboxicon', { descendants: false }) _checkboxIconTemplate: Nullable<TemplateRef<TreeTableCheckboxIconTemplateContext>>;
+    readonly _checkboxIconTemplate = contentChild<Nullable<TemplateRef<TreeTableCheckboxIconTemplateContext>>>('checkboxicon', { descendants: false });
     checkboxIconTemplate: Nullable<TemplateRef<TreeTableCheckboxIconTemplateContext>>;
 
-    @ContentChild('headercheckboxicon', { descendants: false }) _headerCheckboxIconTemplate: Nullable<TemplateRef<TreeTableHeaderCheckboxIconTemplateContext>>;
+    readonly _headerCheckboxIconTemplate = contentChild<Nullable<TemplateRef<TreeTableHeaderCheckboxIconTemplateContext>>>('headercheckboxicon', { descendants: false });
     headerCheckboxIconTemplate: Nullable<TemplateRef<TreeTableHeaderCheckboxIconTemplateContext>>;
 
-    @ContentChild('togglericon', { descendants: false }) _togglerIconTemplate: Nullable<TemplateRef<TreeTableTogglerIconTemplateContext>>;
+    readonly _togglerIconTemplate = contentChild<Nullable<TemplateRef<TreeTableTogglerIconTemplateContext>>>('togglericon', { descendants: false });
     togglerIconTemplate: Nullable<TemplateRef<TreeTableTogglerIconTemplateContext>>;
 
-    @ContentChild('paginatorfirstpagelinkicon', { descendants: false }) _paginatorFirstPageLinkIconTemplate: Nullable<TemplateRef<void>>;
+    readonly _paginatorFirstPageLinkIconTemplate = contentChild<Nullable<TemplateRef<void>>>('paginatorfirstpagelinkicon', { descendants: false });
     paginatorFirstPageLinkIconTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('paginatorlastpagelinkicon', { descendants: false }) _paginatorLastPageLinkIconTemplate: Nullable<TemplateRef<void>>;
+    readonly _paginatorLastPageLinkIconTemplate = contentChild<Nullable<TemplateRef<void>>>('paginatorlastpagelinkicon', { descendants: false });
     paginatorLastPageLinkIconTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('paginatorpreviouspagelinkicon', { descendants: false }) _paginatorPreviousPageLinkIconTemplate: Nullable<TemplateRef<void>>;
+    readonly _paginatorPreviousPageLinkIconTemplate = contentChild<Nullable<TemplateRef<void>>>('paginatorpreviouspagelinkicon', { descendants: false });
     paginatorPreviousPageLinkIconTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('paginatornextpagelinkicon', { descendants: false }) _paginatorNextPageLinkIconTemplate: Nullable<TemplateRef<void>>;
+    readonly _paginatorNextPageLinkIconTemplate = contentChild<Nullable<TemplateRef<void>>>('paginatornextpagelinkicon', { descendants: false });
     paginatorNextPageLinkIconTemplate: Nullable<TemplateRef<void>>;
 
-    @ContentChild('loader', { descendants: false }) _loaderTemplate: Nullable<TemplateRef<void>>;
+    readonly _loaderTemplate = contentChild<Nullable<TemplateRef<void>>>('loader', { descendants: false });
     loaderTemplate: Nullable<TemplateRef<void>>;
 
     lastResizerHelperX: Nullable<number>;
@@ -961,10 +961,10 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
         this.initialized = true;
     }
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'caption':
                     this.captionTemplate = item.template;
@@ -1446,12 +1446,13 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
      * @group Method
      */
     public scrollToVirtualIndex(index: number) {
-        if (this.scrollableViewChild) {
-            (<any>this.scrollableViewChild).scrollToVirtualIndex(<number>index);
+        const scrollableViewChild = this.scrollableViewChild();
+        if (scrollableViewChild) {
+            (<any>scrollableViewChild).scrollToVirtualIndex(<number>index);
         }
 
-        if (this.scrollableFrozenViewChild) {
-            (<any>this.scrollableViewChild).scrollToVirtualIndex(index);
+        if (this.scrollableFrozenViewChild()) {
+            (<any>scrollableViewChild).scrollToVirtualIndex(index);
         }
     }
     /**
@@ -1460,12 +1461,13 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
      * @group Method
      */
     public scrollTo(options: ScrollToOptions) {
-        if (this.scrollableViewChild) {
-            (<any>this.scrollableViewChild).scrollTo(options);
+        const scrollableViewChild = this.scrollableViewChild();
+        if (scrollableViewChild) {
+            (<any>scrollableViewChild).scrollTo(options);
         }
 
-        if (this.scrollableFrozenViewChild) {
-            (<any>this.scrollableViewChild).scrollTo(options);
+        if (this.scrollableFrozenViewChild()) {
+            (<any>scrollableViewChild).scrollTo(options);
         }
     }
 
@@ -1488,15 +1490,15 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
         let containerLeft = <any>getOffset(this.el?.nativeElement).left;
         this.el?.nativeElement.setAttribute('data-p-unselectable-text', 'true');
         !this.$unstyled() && addStyle(this.el.nativeElement, { 'user-select': 'none' });
-        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.height = this.el?.nativeElement.offsetHeight + 'px';
-        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.top = 0 + 'px';
-        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.left = event.pageX - containerLeft + this.el?.nativeElement.scrollLeft + 'px';
+        (<ElementRef>this.resizeHelperViewChild()).nativeElement.style.height = this.el?.nativeElement.offsetHeight + 'px';
+        (<ElementRef>this.resizeHelperViewChild()).nativeElement.style.top = 0 + 'px';
+        (<ElementRef>this.resizeHelperViewChild()).nativeElement.style.left = event.pageX - containerLeft + this.el?.nativeElement.scrollLeft + 'px';
 
-        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.display = 'block';
+        (<ElementRef>this.resizeHelperViewChild()).nativeElement.style.display = 'block';
     }
 
     onColumnResizeEnd(event: MouseEvent, column: any) {
-        let delta = (<ElementRef>this.resizeHelperViewChild).nativeElement.offsetLeft - <number>this.lastResizerHelperX;
+        let delta = (<ElementRef>this.resizeHelperViewChild()).nativeElement.offsetLeft - <number>this.lastResizerHelperX;
         let columnWidth = column.offsetWidth;
         let newColumnWidth = columnWidth + delta;
         let minWidth = column.style.minWidth || 15;
@@ -1566,9 +1568,10 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
                     this.resizeColGroup(scrollableBodyTable, resizeColumnIndex, newColumnWidth, null);
                     this.resizeColGroup(scrollableFooterTable, resizeColumnIndex, newColumnWidth, null);
                 } else {
-                    (<ElementRef>this.tableViewChild).nativeElement.style.width = this.tableViewChild?.nativeElement.offsetWidth + delta + 'px';
+                    const tableViewChild = this.tableViewChild();
+                    (<ElementRef>this.tableViewChild()).nativeElement.style.width = tableViewChild?.nativeElement.offsetWidth + delta + 'px';
                     column.style.width = newColumnWidth + 'px';
-                    let containerWidth = this.tableViewChild?.nativeElement.style.width;
+                    let containerWidth = tableViewChild?.nativeElement.style.width;
                     (<ElementRef>this.el).nativeElement.style.width = containerWidth + 'px';
                 }
             }
@@ -1579,7 +1582,7 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
             });
         }
 
-        (this.resizeHelperViewChild as ElementRef).nativeElement.style.display = 'none';
+        (this.resizeHelperViewChild() as ElementRef).nativeElement.style.display = 'none';
 
         this.el.nativeElement.removeAttribute('data-p-unselectable-text');
         !this.$unstyled() && (this.el.nativeElement.style['user-select'] = '');
@@ -1617,8 +1620,8 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
     }
 
     onColumnDragStart(event: DragEvent, columnElement: any) {
-        this.reorderIconWidth = getHiddenElementOuterWidth(this.reorderIndicatorUpViewChild?.nativeElement);
-        this.reorderIconHeight = getHiddenElementOuterHeight(this.reorderIndicatorDownViewChild?.nativeElement);
+        this.reorderIconWidth = getHiddenElementOuterWidth(this.reorderIndicatorUpViewChild()?.nativeElement);
+        this.reorderIconHeight = getHiddenElementOuterHeight(this.reorderIndicatorDownViewChild()?.nativeElement);
         this.draggedColumn = columnElement;
         (<any>event).dataTransfer.setData('text', 'b'); // For firefox
     }
@@ -1634,21 +1637,21 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
                 let targetTop = containerOffset.top - dropHeaderOffset.top;
                 let columnCenter = dropHeaderOffset.left + dropHeader.offsetWidth / 2;
 
-                (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top - (<number>this.reorderIconHeight - 1) + 'px';
-                (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top + dropHeader.offsetHeight + 'px';
+                (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top - (<number>this.reorderIconHeight - 1) + 'px';
+                (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top + dropHeader.offsetHeight + 'px';
 
                 if (event.pageX > columnCenter) {
-                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
-                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
                     this.dropPosition = 1;
                 } else {
-                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
-                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
                     this.dropPosition = -1;
                 }
 
-                (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.display = 'block';
-                (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.display = 'block';
+                (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.display = 'block';
+                (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.display = 'block';
             } else {
                 (<any>event).dataTransfer.dropEffect = 'none';
             }
@@ -1658,8 +1661,8 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
     onColumnDragLeave(event: DragEvent) {
         if (this.reorderableColumns && this.draggedColumn) {
             event.preventDefault();
-            (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.display = 'none';
-            (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.display = 'none';
+            (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.display = 'none';
+            (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.display = 'none';
         }
     }
 
@@ -1691,8 +1694,8 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
                 });
             }
 
-            (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.display = 'none';
-            (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.display = 'none';
+            (<ElementRef>this.reorderIndicatorUpViewChild()).nativeElement.style.display = 'none';
+            (<ElementRef>this.reorderIndicatorDownViewChild()).nativeElement.style.display = 'none';
             (this.draggedColumn as any).draggable = false;
             this.draggedColumn = null;
             this.dropPosition = null;
@@ -2419,7 +2422,7 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
             }
         }
         @if (tt.isEmpty()) {
-            <ng-container *ngTemplateOutlet="tt.emptyMessageTemplate || tt._emptyMessageTemplate; context: { $implicit: columns, frozen: frozen }"></ng-container>
+            <ng-container *ngTemplateOutlet="tt.emptyMessageTemplate || tt._emptyMessageTemplate(); context: { $implicit: columns, frozen: frozen }"></ng-container>
         }
     `,
     encapsulation: ViewEncapsulation.None,
@@ -2489,11 +2492,11 @@ export class TTBody extends BaseComponent {
             <div #scrollHeaderBox [class]="cx('scrollableHeaderBox')" [pBind]="ptm('scrollableHeaderBox')">
                 <table [class]="cn(cx('scrollableHeaderTable'), tt.tableStyleClass)" [pBind]="ptm('scrollableHeaderTable')" [ngStyle]="tt.tableStyle">
                     <ng-container
-                        *ngTemplateOutlet="frozen ? tt.frozenColGroupTemplate || tt._frozenColGroupTemplate || tt.colGroupTemplate || tt._colGroupTemplate : tt.colGroupTemplate || tt._colGroupTemplate; context: { $implicit: columns }"
+                        *ngTemplateOutlet="frozen ? tt.frozenColGroupTemplate || tt._frozenColGroupTemplate() || tt.colGroupTemplate || tt._colGroupTemplate() : tt.colGroupTemplate || tt._colGroupTemplate(); context: { $implicit: columns }"
                     ></ng-container>
                     <thead role="rowgroup" [class]="cx('thead')" [pBind]="ptm('thead')">
                         <ng-container
-                            *ngTemplateOutlet="frozen ? tt.frozenHeaderTemplate || tt._frozenHeaderTemplate || tt.headerTemplate || tt._headerTemplate : tt.headerTemplate || tt._headerTemplate; context: { $implicit: columns }"
+                            *ngTemplateOutlet="frozen ? tt.frozenHeaderTemplate || tt._frozenHeaderTemplate() || tt.headerTemplate || tt._headerTemplate() : tt.headerTemplate || tt._headerTemplate(); context: { $implicit: columns }"
                         ></ng-container>
                     </thead>
                 </table>
@@ -2516,9 +2519,9 @@ export class TTBody extends BaseComponent {
                 <ng-template #content let-items let-scrollerOptions="options">
                     <ng-container *ngTemplateOutlet="buildInItems; context: { $implicit: items, options: scrollerOptions }"></ng-container>
                 </ng-template>
-                @if (tt.loaderTemplate || tt._loaderTemplate) {
+                @if (tt.loaderTemplate || tt._loaderTemplate()) {
                     <ng-template #loader let-scrollerOptions="options">
-                        <ng-container *ngTemplateOutlet="tt.loaderTemplate || tt._loaderTemplate; context: { options: scrollerOptions }"></ng-container>
+                        <ng-container *ngTemplateOutlet="tt.loaderTemplate || tt._loaderTemplate(); context: { options: scrollerOptions }"></ng-container>
                     </ng-template>
                 }
             </p-scroller>
@@ -2540,7 +2543,7 @@ export class TTBody extends BaseComponent {
         <ng-template #buildInItems let-items let-scrollerOptions="options">
             <table role="treegrid" #scrollTable [pBind]="ptm('table')" [class]="tt.tableStyleClass" [ngClass]="scrollerOptions.contentStyleClass" [ngStyle]="tt.tableStyle" [style]="scrollerOptions.contentStyle">
                 <ng-container
-                    *ngTemplateOutlet="frozen ? tt.frozenColGroupTemplate || tt._frozenColGroupTemplate || tt.colGroupTemplate || tt._colGroupTemplate : tt.colGroupTemplate || tt._colGroupTemplate; context: { $implicit: columns }"
+                    *ngTemplateOutlet="frozen ? tt.frozenColGroupTemplate || tt._frozenColGroupTemplate() || tt.colGroupTemplate || tt._colGroupTemplate() : tt.colGroupTemplate || tt._colGroupTemplate(); context: { $implicit: columns }"
                 ></ng-container>
                 <tbody
                     [pBind]="ptm('tbody')"
@@ -2549,7 +2552,7 @@ export class TTBody extends BaseComponent {
                     [pBind]="ptm('tbody')"
                     [pTreeTableBody]="columns"
                     [unstyled]="unstyled()"
-                    [pTreeTableBodyTemplate]="frozen ? tt.frozenBodyTemplate || tt._frozenBodyTemplate || tt.bodyTemplate || tt._bodyTemplate : tt.bodyTemplate || tt._bodyTemplate"
+                    [pTreeTableBodyTemplate]="frozen ? tt.frozenBodyTemplate || tt._frozenBodyTemplate() || tt.bodyTemplate || tt._bodyTemplate() : tt.bodyTemplate || tt._bodyTemplate()"
                     [serializedNodes]="items"
                     [frozen]="frozen"
                 ></tbody>
@@ -2559,16 +2562,16 @@ export class TTBody extends BaseComponent {
             }
         </ng-template>
 
-        @if (tt.footerTemplate || tt._footerTemplate) {
+        @if (tt.footerTemplate || tt._footerTemplate()) {
             <div #scrollFooter [class]="cx('scrollableFooter')" [pBind]="ptm('scrollableFooter')">
                 <div #scrollFooterBox [class]="cx('scrollableFooterBox')" [pBind]="ptm('scrollableFooterBox')">
                     <table [class]="cx('scrollableFooterTable')" [ngClass]="tt.tableStyleClass" [ngStyle]="tt.tableStyle" [pBind]="ptm('scrollableFooterTable')">
                         <ng-container
-                            *ngTemplateOutlet="frozen ? tt.frozenColGroupTemplate || tt._frozenColGroupTemplate || tt.colGroupTemplate || tt._colGroupTemplate : tt.colGroupTemplate || tt._colGroupTemplate; context: { $implicit: columns }"
+                            *ngTemplateOutlet="frozen ? tt.frozenColGroupTemplate || tt._frozenColGroupTemplate() || tt.colGroupTemplate || tt._colGroupTemplate() : tt.colGroupTemplate || tt._colGroupTemplate(); context: { $implicit: columns }"
                         ></ng-container>
                         <tfoot role="rowgroup" [class]="cx('tfoot')" [pBind]="ptm('tfoot')">
                             <ng-container
-                                *ngTemplateOutlet="frozen ? tt.frozenFooterTemplate || tt._frozenFooterTemplate || tt.footerTemplate || tt._footerTemplate : tt.footerTemplate || tt._footerTemplate; context: { $implicit: columns }"
+                                *ngTemplateOutlet="frozen ? tt.frozenFooterTemplate || tt._frozenFooterTemplate() || tt.footerTemplate || tt._footerTemplate() : tt.footerTemplate || tt._footerTemplate(); context: { $implicit: columns }"
                             ></ng-container>
                         </tfoot>
                     </table>
@@ -2589,23 +2592,23 @@ export class TTScrollableView extends BaseComponent {
 
     @Input({ transform: booleanAttribute }) frozen: boolean | undefined;
 
-    @ViewChild('scrollHeader') scrollHeaderViewChild: Nullable<ElementRef>;
+    readonly scrollHeaderViewChild = viewChild<Nullable<ElementRef>>('scrollHeader');
 
-    @ViewChild('scrollHeaderBox') scrollHeaderBoxViewChild: Nullable<ElementRef>;
+    readonly scrollHeaderBoxViewChild = viewChild<Nullable<ElementRef>>('scrollHeaderBox');
 
-    @ViewChild('scrollBody') scrollBodyViewChild: Nullable<ElementRef>;
+    readonly scrollBodyViewChild = viewChild<Nullable<ElementRef>>('scrollBody');
 
-    @ViewChild('scrollTable') scrollTableViewChild: Nullable<ElementRef>;
+    readonly scrollTableViewChild = viewChild<Nullable<ElementRef>>('scrollTable');
 
-    @ViewChild('loadingTable') scrollLoadingTableViewChild: Nullable<ElementRef>;
+    readonly scrollLoadingTableViewChild = viewChild<Nullable<ElementRef>>('loadingTable');
 
-    @ViewChild('scrollFooter') scrollFooterViewChild: Nullable<ElementRef>;
+    readonly scrollFooterViewChild = viewChild<Nullable<ElementRef>>('scrollFooter');
 
-    @ViewChild('scrollFooterBox') scrollFooterBoxViewChild: Nullable<ElementRef>;
+    readonly scrollFooterBoxViewChild = viewChild<Nullable<ElementRef>>('scrollFooterBox');
 
-    @ViewChild('scrollableAligner') scrollableAlignerViewChild: Nullable<ElementRef>;
+    readonly scrollableAlignerViewChild = viewChild<Nullable<ElementRef>>('scrollableAligner');
 
-    @ViewChild('scroller') scroller: Nullable<Scroller>;
+    readonly scroller = viewChild<Nullable<Scroller>>('scroller');
 
     headerScrollListener: VoidListener;
 
@@ -2636,7 +2639,7 @@ export class TTScrollableView extends BaseComponent {
     onAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
             if (!this.frozen) {
-                if (this.tt.frozenColumns || this.tt.frozenBodyTemplate || this.tt._frozenBodyTemplate) {
+                if (this.tt.frozenColumns || this.tt.frozenBodyTemplate || this.tt._frozenBodyTemplate()) {
                     addClass(this.el.nativeElement, 'p-treetable-unfrozen-view');
                 }
 
@@ -2648,17 +2651,20 @@ export class TTScrollableView extends BaseComponent {
 
                 if (this.scrollHeight) {
                     let scrollBarWidth = calculateScrollbarWidth();
-                    if (this.scrollHeaderBoxViewChild?.nativeElement) {
-                        this.scrollHeaderBoxViewChild.nativeElement.style.paddingRight = scrollBarWidth + 'px';
+                    const scrollHeaderBoxViewChild = this.scrollHeaderBoxViewChild();
+                    if (scrollHeaderBoxViewChild?.nativeElement) {
+                        scrollHeaderBoxViewChild.nativeElement.style.paddingRight = scrollBarWidth + 'px';
                     }
 
-                    if (this.scrollFooterBoxViewChild && this.scrollFooterBoxViewChild.nativeElement) {
-                        this.scrollFooterBoxViewChild.nativeElement.style.paddingRight = scrollBarWidth + 'px';
+                    const scrollFooterBoxViewChild = this.scrollFooterBoxViewChild();
+                    if (scrollFooterBoxViewChild && scrollFooterBoxViewChild.nativeElement) {
+                        scrollFooterBoxViewChild.nativeElement.style.paddingRight = scrollBarWidth + 'px';
                     }
                 }
             } else {
-                if (this.scrollableAlignerViewChild && this.scrollableAlignerViewChild.nativeElement) {
-                    this.scrollableAlignerViewChild.nativeElement.style.height = calculateScrollbarHeight() + 'px';
+                const scrollableAlignerViewChild = this.scrollableAlignerViewChild();
+                if (scrollableAlignerViewChild && scrollableAlignerViewChild.nativeElement) {
+                    scrollableAlignerViewChild.nativeElement.style.height = calculateScrollbarHeight() + 'px';
                 }
             }
 
@@ -2669,19 +2675,21 @@ export class TTScrollableView extends BaseComponent {
     bindEvents() {
         if (isPlatformBrowser(this.platformId)) {
             this.zone.runOutsideAngular(() => {
-                if (this.scrollHeaderViewChild && this.scrollHeaderViewChild.nativeElement) {
-                    this.headerScrollListener = this.renderer.listen(this.scrollHeaderBoxViewChild?.nativeElement, 'scroll', this.onHeaderScroll.bind(this));
+                const scrollHeaderViewChild = this.scrollHeaderViewChild();
+                if (scrollHeaderViewChild && scrollHeaderViewChild.nativeElement) {
+                    this.headerScrollListener = this.renderer.listen(this.scrollHeaderBoxViewChild()?.nativeElement, 'scroll', this.onHeaderScroll.bind(this));
                 }
 
-                if (this.scrollFooterViewChild && this.scrollFooterViewChild.nativeElement) {
-                    this.footerScrollListener = this.renderer.listen(this.scrollFooterViewChild.nativeElement, 'scroll', this.onFooterScroll.bind(this));
+                const scrollFooterViewChild = this.scrollFooterViewChild();
+                if (scrollFooterViewChild && scrollFooterViewChild.nativeElement) {
+                    this.footerScrollListener = this.renderer.listen(scrollFooterViewChild.nativeElement, 'scroll', this.onFooterScroll.bind(this));
                 }
 
                 if (!this.frozen) {
                     if (this.tt.virtualScroll) {
-                        this.bodyScrollListener = this.renderer.listen((this.scroller?.getElementRef() as ElementRef).nativeElement, 'scroll', this.onBodyScroll.bind(this));
+                        this.bodyScrollListener = this.renderer.listen((this.scroller()?.getElementRef() as ElementRef).nativeElement, 'scroll', this.onBodyScroll.bind(this));
                     } else {
-                        this.bodyScrollListener = this.renderer.listen(this.scrollBodyViewChild?.nativeElement, 'scroll', this.onBodyScroll.bind(this));
+                        this.bodyScrollListener = this.renderer.listen(this.scrollBodyViewChild()?.nativeElement, 'scroll', this.onBodyScroll.bind(this));
                     }
                 }
             });
@@ -2690,28 +2698,32 @@ export class TTScrollableView extends BaseComponent {
 
     unbindEvents() {
         if (isPlatformBrowser(this.platformId)) {
-            if (this.scrollHeaderViewChild && this.scrollHeaderViewChild.nativeElement) {
+            const scrollHeaderViewChild = this.scrollHeaderViewChild();
+            if (scrollHeaderViewChild && scrollHeaderViewChild.nativeElement) {
                 if (this.headerScrollListener) {
                     this.headerScrollListener();
                     this.headerScrollListener = null;
                 }
             }
 
-            if (this.scrollFooterViewChild && this.scrollFooterViewChild.nativeElement) {
+            const scrollFooterViewChild = this.scrollFooterViewChild();
+            if (scrollFooterViewChild && scrollFooterViewChild.nativeElement) {
                 if (this.footerScrollListener) {
                     this.footerScrollListener();
                     this.footerScrollListener = null;
                 }
             }
 
-            if (this.scrollBodyViewChild && this.scrollBodyViewChild.nativeElement) {
+            const scrollBodyViewChild = this.scrollBodyViewChild();
+            if (scrollBodyViewChild && scrollBodyViewChild.nativeElement) {
                 if (this.bodyScrollListener) {
                     this.bodyScrollListener();
                     this.bodyScrollListener = null;
                 }
             }
 
-            if (this.scroller && this.scroller.getElementRef()) {
+            const scroller = this.scroller();
+            if (scroller && scroller.getElementRef()) {
                 if (this.bodyScrollListener) {
                     this.bodyScrollListener();
                     this.bodyScrollListener = null;
@@ -2721,23 +2733,25 @@ export class TTScrollableView extends BaseComponent {
     }
 
     onHeaderScroll() {
-        const scrollLeft = this.scrollHeaderViewChild?.nativeElement.scrollLeft;
+        const scrollLeft = this.scrollHeaderViewChild()?.nativeElement.scrollLeft;
 
-        (this.scrollBodyViewChild as ElementRef).nativeElement.scrollLeft = scrollLeft;
+        (this.scrollBodyViewChild() as ElementRef).nativeElement.scrollLeft = scrollLeft;
 
-        if (this.scrollFooterViewChild && this.scrollFooterViewChild.nativeElement) {
-            this.scrollFooterViewChild.nativeElement.scrollLeft = scrollLeft;
+        const scrollFooterViewChild = this.scrollFooterViewChild();
+        if (scrollFooterViewChild && scrollFooterViewChild.nativeElement) {
+            scrollFooterViewChild.nativeElement.scrollLeft = scrollLeft;
         }
 
         this.preventBodyScrollPropagation = true;
     }
 
     onFooterScroll() {
-        const scrollLeft = this.scrollFooterViewChild?.nativeElement.scrollLeft;
-        (this.scrollBodyViewChild as ElementRef).nativeElement.scrollLeft = scrollLeft;
+        const scrollLeft = this.scrollFooterViewChild()?.nativeElement.scrollLeft;
+        (this.scrollBodyViewChild() as ElementRef).nativeElement.scrollLeft = scrollLeft;
 
-        if (this.scrollHeaderViewChild && this.scrollHeaderViewChild.nativeElement) {
-            this.scrollHeaderViewChild.nativeElement.scrollLeft = scrollLeft;
+        const scrollHeaderViewChild = this.scrollHeaderViewChild();
+        if (scrollHeaderViewChild && scrollHeaderViewChild.nativeElement) {
+            scrollHeaderViewChild.nativeElement.scrollLeft = scrollLeft;
         }
 
         this.preventBodyScrollPropagation = true;
@@ -2749,12 +2763,14 @@ export class TTScrollableView extends BaseComponent {
             return;
         }
 
-        if (this.scrollHeaderViewChild && this.scrollHeaderViewChild.nativeElement) {
-            (this.scrollHeaderBoxViewChild as ElementRef).nativeElement.style.marginLeft = -1 * event.target.scrollLeft + 'px';
+        const scrollHeaderViewChild = this.scrollHeaderViewChild();
+        if (scrollHeaderViewChild && scrollHeaderViewChild.nativeElement) {
+            (this.scrollHeaderBoxViewChild() as ElementRef).nativeElement.style.marginLeft = -1 * event.target.scrollLeft + 'px';
         }
 
-        if (this.scrollFooterViewChild && this.scrollFooterViewChild.nativeElement) {
-            (this.scrollFooterBoxViewChild as ElementRef).nativeElement.style.marginLeft = -1 * event.target.scrollLeft + 'px';
+        const scrollFooterViewChild = this.scrollFooterViewChild();
+        if (scrollFooterViewChild && scrollFooterViewChild.nativeElement) {
+            (this.scrollFooterBoxViewChild() as ElementRef).nativeElement.style.marginLeft = -1 * event.target.scrollLeft + 'px';
         }
 
         if (this.frozenSiblingBody) {
@@ -2763,20 +2779,23 @@ export class TTScrollableView extends BaseComponent {
     }
 
     scrollToVirtualIndex(index: number): void {
-        if (this.scroller) {
-            this.scroller.scrollToIndex(index);
+        const scroller = this.scroller();
+        if (scroller) {
+            scroller.scrollToIndex(index);
         }
     }
 
     scrollTo(options: ScrollToOptions): void {
-        if (this.scroller) {
-            this.scroller.scrollTo(options);
+        const scroller = this.scroller();
+        if (scroller) {
+            scroller.scrollTo(options);
         } else {
-            if (this.scrollBodyViewChild?.nativeElement.scrollTo) {
-                this.scrollBodyViewChild.nativeElement.scrollTo(options);
+            const scrollBodyViewChild = this.scrollBodyViewChild();
+            if (scrollBodyViewChild?.nativeElement.scrollTo) {
+                scrollBodyViewChild.nativeElement.scrollTo(options);
             } else {
-                (this.scrollBodyViewChild as ElementRef).nativeElement.scrollLeft = options.left;
-                (this.scrollBodyViewChild as ElementRef).nativeElement.scrollTop = options.top;
+                (scrollBodyViewChild as ElementRef).nativeElement.scrollLeft = options.left;
+                (scrollBodyViewChild as ElementRef).nativeElement.scrollTop = options.top;
             }
         }
     }
@@ -2879,7 +2898,7 @@ export class TTSortableColumn extends BaseComponent {
     selector: 'p-treeTableSortIcon, p-treetable-sort-icon, p-tree-table-sort-icon',
     standalone: false,
     template: `
-        @if (!tt.sortIconTemplate && !tt._sortIconTemplate) {
+        @if (!tt.sortIconTemplate && !tt._sortIconTemplate()) {
             @if (sortOrder === 0) {
                 <svg data-p-icon="sort-alt" [class]="cx('sortableColumnIcon')" [pBind]="ptm('sortableColumnIcon')" />
             }
@@ -2890,9 +2909,9 @@ export class TTSortableColumn extends BaseComponent {
                 <svg data-p-icon="sort-amount-down" [class]="cx('sortableColumnIcon')" [pBind]="ptm('sortableColumnIcon')" />
             }
         }
-        @if (tt.sortIconTemplate || tt._sortIconTemplate) {
+        @if (tt.sortIconTemplate || tt._sortIconTemplate()) {
             <span [class]="cx('sortableColumnIcon')" [pBind]="ptm('sortableColumnIcon')">
-                <ng-template *ngTemplateOutlet="tt.sortIconTemplate || tt._sortIconTemplate; context: { $implicit: sortOrder }"></ng-template>
+                <ng-template *ngTemplateOutlet="tt.sortIconTemplate || tt._sortIconTemplate(); context: { $implicit: sortOrder }"></ng-template>
             </span>
         }
         @if (isMultiSorted()) {
@@ -3384,9 +3403,9 @@ export class TTContextMenuRow extends BaseComponent {
             [tabIndex]="-1"
             [unstyled]="unstyled()"
         >
-            @if (tt.checkboxIconTemplate || tt._checkboxIconTemplate) {
+            @if (tt.checkboxIconTemplate || tt._checkboxIconTemplate()) {
                 <ng-template pTemplate="icon">
-                    <ng-template *ngTemplateOutlet="tt.checkboxIconTemplate || tt._checkboxIconTemplate; context: { $implicit: checked, partialSelected: partialChecked }"></ng-template>
+                    <ng-template *ngTemplateOutlet="tt.checkboxIconTemplate || tt._checkboxIconTemplate(); context: { $implicit: checked, partialSelected: partialChecked }"></ng-template>
                 </ng-template>
             }
         </p-checkbox>
@@ -3480,9 +3499,9 @@ export class TTCheckbox extends BaseComponent {
     standalone: false,
     template: `
         <p-checkbox [ngModel]="checked" [ngModelOptions]="{ standalone: true }" [pt]="ptm('pcHeaderCheckbox')" (onChange)="onClick($event)" [binary]="true" [disabled]="!tt.value || tt.value.length === 0" [unstyled]="unstyled()">
-            @if (tt.headerCheckboxIconTemplate || tt._headerCheckboxIconTemplate) {
+            @if (tt.headerCheckboxIconTemplate || tt._headerCheckboxIconTemplate()) {
                 <ng-template pTemplate="icon">
-                    <ng-template *ngTemplateOutlet="tt.headerCheckboxIconTemplate || tt._headerCheckboxIconTemplate; context: { $implicit: checked }"></ng-template>
+                    <ng-template *ngTemplateOutlet="tt.headerCheckboxIconTemplate || tt._headerCheckboxIconTemplate(); context: { $implicit: checked }"></ng-template>
                 </ng-template>
             }
         </p-checkbox>
@@ -3779,14 +3798,14 @@ export class TreeTableCellEditor extends BaseComponent {
         this.bindDirectiveInstance.setAttrs(this.ptm('cellEditor'));
     }
 
-    @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
+    readonly templates = contentChildren(PrimeTemplate);
 
     inputTemplate: Nullable<TemplateRef<any>>;
 
     outputTemplate: Nullable<TemplateRef<any>>;
 
     onAfterContentInit() {
-        (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
+        (this.templates() as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
                 case 'input':
                     this.inputTemplate = item.template;
@@ -4040,7 +4059,7 @@ export class TTRow extends BaseComponent {
             [attr.data-pc-group-section]="'rowactionbutton'"
             [attr.aria-label]="toggleButtonAriaLabel"
         >
-            @if (!tt.togglerIconTemplate && !tt._togglerIconTemplate) {
+            @if (!tt.togglerIconTemplate && !tt._togglerIconTemplate()) {
                 @if (rowNode.node.expanded) {
                     <svg data-p-icon="chevron-down" [pBind]="ptm('nodetoggleicon')" [attr.aria-hidden]="true" />
                 }
@@ -4048,7 +4067,7 @@ export class TTRow extends BaseComponent {
                     <svg data-p-icon="chevron-right" [pBind]="ptm('nodetoggleicon')" [attr.aria-hidden]="true" />
                 }
             }
-            <ng-template *ngTemplateOutlet="tt.togglerIconTemplate || tt._togglerIconTemplate; context: { $implicit: rowNode.node.expanded }"></ng-template>
+            <ng-template *ngTemplateOutlet="tt.togglerIconTemplate || tt._togglerIconTemplate(); context: { $implicit: rowNode.node.expanded }"></ng-template>
         </button>
     `,
     encapsulation: ViewEncapsulation.None,

--- a/packages/optimus-ui/src/treetable/treetable.ts
+++ b/packages/optimus-ui/src/treetable/treetable.ts
@@ -819,9 +819,9 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
 
     readonly tableViewChild = viewChild<Nullable<ElementRef>>('table');
 
-    readonly scrollableViewChild = viewChild<Nullable<ElementRef>>('scrollableView');
+    readonly scrollableViewChild = viewChild<Nullable<TTScrollableView>>('scrollableView');
 
-    readonly scrollableFrozenViewChild = viewChild<Nullable<ElementRef>>('scrollableFrozenView');
+    readonly scrollableFrozenViewChild = viewChild<Nullable<TTScrollableView>>('scrollableFrozenView');
 
     _value: TreeNode<any>[] | undefined = [];
 
@@ -1445,14 +1445,8 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
      * @group Method
      */
     public scrollToVirtualIndex(index: number) {
-        const scrollableViewChild = this.scrollableViewChild();
-        if (scrollableViewChild) {
-            (<any>scrollableViewChild).scrollToVirtualIndex(<number>index);
-        }
-
-        if (this.scrollableFrozenViewChild()) {
-            (<any>scrollableViewChild).scrollToVirtualIndex(index);
-        }
+        this.scrollableViewChild()?.scrollToVirtualIndex(index);
+        this.scrollableFrozenViewChild()?.scrollToVirtualIndex(index);
     }
     /**
      * Scrolls to given index.
@@ -1460,14 +1454,8 @@ export class TreeTable extends BaseComponent<TreeTablePassThrough> implements Bl
      * @group Method
      */
     public scrollTo(options: ScrollToOptions) {
-        const scrollableViewChild = this.scrollableViewChild();
-        if (scrollableViewChild) {
-            (<any>scrollableViewChild).scrollTo(options);
-        }
-
-        if (this.scrollableFrozenViewChild()) {
-            (<any>scrollableViewChild).scrollTo(options);
-        }
+        this.scrollableViewChild()?.scrollTo(options);
+        this.scrollableFrozenViewChild()?.scrollTo(options);
     }
 
     isEmpty() {

--- a/packages/optimus-ui/src/types/table/table.types.ts
+++ b/packages/optimus-ui/src/types/table/table.types.ts
@@ -715,11 +715,6 @@ export interface TableTemplates {
         frozen?: boolean;
     }): TemplateRef<any>;
     /**
-     * Custom frozen header template.
-     * @param {*} context - columns.
-     */
-    frozenheader(): TemplateRef<{ $implicit: any[] }>;
-    /**
      * Custom frozen body template.
      * @param {Object} context - row data.
      */
@@ -745,16 +740,6 @@ export interface TableTemplates {
          */
         frozen?: boolean;
     }): TemplateRef<any>;
-    /**
-     * Custom frozen footer template.
-     * @param {*} context - columns.
-     */
-    frozenfooter(): TemplateRef<{ $implicit: any[] }>;
-    /**
-     * Custom frozen column group template.
-     * @param {*} context - columns.
-     */
-    frozencolgroup(): TemplateRef<{ $implicit: any[] }>;
     /**
      * Custom frozen expanded row template.
      * @param {Object} context - row data.


### PR DESCRIPTION
## Description

Migrates all 580 `@ViewChild`/`@ViewChildren`/`@ContentChild`/`@ContentChildren`
decorators in `packages/optimus-ui` to Angular's signal-based
`viewChild`/`viewChildren`/`contentChild`/`contentChildren` APIs, then uses the
migration as an opportunity to clean up dead query API, align query requiredness
with the templates, fix several real bugs the audit surfaced, and close the test
coverage gap on the query surface (349/580 → **580/580** queries covered).

## Commits

The PR is structured as a reviewable stack — each commit is one theme:

1. **`refactor(optimus-ui): migrate to signal queries`** — raw output of the
   `@angular/core:signal-queries-migration` schematic (best-effort mode).
   ⚠️ This commit alone does not build; the next one makes it green.
2. **`fix(optimus-ui): resolve signal-query migration fallout`** — fixes for what
   the best-effort codemod left behind: invalid `QueryList` casts on
   array-returning children queries, dropped `this.`/`()` on repeated reads,
   assignments to now-readonly query fields, `.required` applied to optional
   projected content / conditionally rendered elements (runtime `NG0951`),
   galleria passing plain arrays into `QueryList`-typed inputs (`.toArray()`
   crash), and test mocks/assertions adapted to signal access.
3. **`refactor(optimus-ui): remove unused queries and dead template APIs`** —
   removes 29 queries nothing ever read, their orphaned imports, and the
   write-only half of Table's frozen-column template API
   (`frozenheader`/`frozenfooter`/`frozencolgroup` were collected but never
   rendered; fields, switch cases and typed interface entries removed —
   TreeTable's working frozen templates are untouched).
4. **`refactor(optimus-ui): align query requiredness with templates`** — demotes
   tablist's `prevButton`/`nextButton` to optional (they sit behind `@if`, so
   `.required` threw `NG0951` whenever a navigator was hidden), promotes 23
   queries whose targets are unconditionally rendered to `viewChild.required`,
   and removes the guards/optional chaining that required queries make
   unreachable — in both directions.
5. **`fix(treetable): scroll the frozen view and type scrollable-view queries`** —
   `scrollTo`/`scrollToVirtualIndex` checked the frozen view child but scrolled
   the non-frozen view again (long-standing copy-paste bug); the queries were
   also typed `ElementRef` while actually resolving to the `TTScrollableView`
   component, hence the `<any>` casts — now typed honestly, casts removed.
6. **`test(optimus-ui): cover the signal query API surface`** — every query now
   has a test: template hooks resolve from projected `ng-template`s, facets from
   `p-header`/`p-footer`, `pTemplate` collections are typed arrays, structural
   view queries resolve after render, and state-dependent queries are asserted
   *unresolved* in their default state. Adds a `steps` test file, covers
   tablist/tabpanel via the tabs harness, Table's `ColumnFilter`/
   `TableRadioButton` internals and TreeTable's scrollable views. Also pins
   InputMask's initial reactive-form value (the decorator-era query relied on
   `static: true`) and makes the flaky toast auto-close test deterministic.
7. **`fix(picklist,listbox): make filter reset clear the listbox filter`** —
   `resetSourceFilter`/`resetTargetFilter` targeted `#sourceFilter`/
   `#targetFilter` inputs that no longer exist since filtering moved into the
   embedded listboxes, so reset silently did nothing visible; reset now
   delegates to the listboxes. Listbox had the same fossil (`filterViewChild`
   queried `'filter'` vs the template's `#filterInput`) — retargeted. Covered by
   behavior tests that type into the real filter input and assert reset clears it.

## ⚠️ Breaking changes

- Component query members are now **signal functions**: read them as
  `component.headerTemplate()` instead of `component.headerTemplate`.
- **Removed dead template APIs** (documented but non-functional — they were
  collected and never rendered): ~10 `@group Templates` hooks including
  `select` `cancelicon`/`onicon`/`officon`, `tree` `node`, `treeselect`
  `closeicon`, `dataview` `listicon`/`gridicon`, `megamenu` `menuicon`,
  `menu` `#header`; plus Table's `frozenheader`/`frozenfooter`/`frozencolgroup`
  pTemplates and their entries in `table.types.ts`.
- **Removed 29 unused query members** (e.g. `drawer.containerViewChild`,
  `colorpicker.inputViewChild`, `password.overlayViewChild`,
  `confirmdialog.footer`, `image.mask`, `dynamicdialog.dialog`) — anything
  reaching into these internals will break.
- **Requiredness changes**: 23 queries are now `viewChild.required` (unwrapped
  return types); tablist's nav buttons are now optional.
- `picklist.resetFilter()` now actually clears the visible filter input — a
  behavior change if anything relied on the previous no-op.

## Verification

- `pnpm run build` green; `tsc --noEmit` clean on `src`.
- Full vitest suite: **97 files, 7300+ tests, 0 failed** — run after every
  commit-theme during development.
- Migration audited against codemod risk classes: `read:`/`descendants:`
  options preserved on all 565 surviving queries (signal `contentChild`
  defaults `descendants: true`, matching the decorator); the single
  `static: true` query (InputMask) verified regression-free with a dedicated
  test; no `QueryList`-era API calls remain on array results; no uncalled
  signal reads in code or templates (`strictTemplates: false` would have hidden
  these silently).