### PR TITLE
fix(menu): hide items of a submenu whose visible is false

### DIFF
--- a/packages/optimus-ui/src/menu/menu.test.ts
+++ b/packages/optimus-ui/src/menu/menu.test.ts
@@ -588,6 +588,70 @@ describe('Menu', () => {
             const separators = submenuFixture.debugElement.queryAll(By.css('li[data-pc-section="separator"]'));
             expect(separators.length).toBe(0);
         });
+
+        it('should not render items of a hidden submenu even when item.visible is true', async () => {
+            const submenuFixture = TestBed.createComponent(TestSubmenuMenuComponent);
+            submenuFixture.componentInstance.submenuModel = [
+                {
+                    label: 'Hidden Group',
+                    visible: false,
+                    items: [{ label: 'Forced Visible Item', visible: true }, { label: 'Normally Hidden Item' }]
+                },
+                {
+                    label: 'Visible Group',
+                    items: [{ label: 'Shown Item' }]
+                }
+            ];
+            submenuFixture.detectChanges();
+            await submenuFixture.whenStable();
+
+            const items = submenuFixture.debugElement.queryAll(By.css('li[role="menuitem"]'));
+            expect(items.length).toBe(1);
+            expect(items[0].nativeElement.getAttribute('aria-label')).toBe('Shown Item');
+
+            const submenuHeaders = submenuFixture.debugElement.queryAll(By.css('li[data-pc-section="submenulabel"]'));
+            expect(submenuHeaders.length).toBe(1);
+            expect(submenuHeaders[0].nativeElement.textContent.trim()).toBe('Visible Group');
+        });
+
+        it('should not render separators of a hidden submenu', async () => {
+            const submenuFixture = TestBed.createComponent(TestSubmenuMenuComponent);
+            submenuFixture.componentInstance.submenuModel = [
+                {
+                    label: 'Hidden Group',
+                    visible: false,
+                    items: [{ label: 'First' }, { separator: true }, { label: 'Second' }]
+                },
+                {
+                    label: 'Visible Group',
+                    items: [{ label: 'Shown Item' }]
+                }
+            ];
+            submenuFixture.detectChanges();
+            await submenuFixture.whenStable();
+
+            const separators = submenuFixture.debugElement.queryAll(By.css('li[data-pc-section="separator"]'));
+            expect(separators.length).toBe(0);
+        });
+
+        it('should render a force-shown item when its submenu is visible', async () => {
+            const submenuFixture = TestBed.createComponent(TestSubmenuMenuComponent);
+            submenuFixture.componentInstance.submenuModel = [
+                {
+                    label: 'Visible Group',
+                    items: [
+                        { label: 'Explicitly Visible Item', visible: true },
+                        { label: 'Hidden Item', visible: false }
+                    ]
+                }
+            ];
+            submenuFixture.detectChanges();
+            await submenuFixture.whenStable();
+
+            const items = submenuFixture.debugElement.queryAll(By.css('li[role="menuitem"]'));
+            expect(items.length).toBe(1);
+            expect(items[0].nativeElement.getAttribute('aria-label')).toBe('Explicitly Visible Item');
+        });
     });
 
     describe('Item Interaction Tests', () => {

--- a/packages/optimus-ui/src/menu/menu.ts
+++ b/packages/optimus-ui/src/menu/menu.ts
@@ -240,32 +240,32 @@ export class MenuItemContent extends BaseComponent {
                                         }
                                     </li>
                                 }
-                            }
-                            @for (item of submenu.items; track item; let j = $index) {
-                                @if (item.separator && (item.visible !== false || submenu.visible !== false)) {
-                                    <li [class]="cx('separator')" [pBind]="ptm('separator')" role="separator" [attr.data-pc-section]="'separator'"></li>
-                                }
-                                @if (!item.separator && item.visible !== false && (item.visible !== undefined || submenu.visible !== false)) {
-                                    <li
-                                        [class]="cn(cx('item', { item, id: menuitemId(item, id, i, j) }), item?.styleClass)"
-                                        [pBind]="ptm('item')"
-                                        [pMenuItemContent]="item"
-                                        [itemTemplate]="itemTemplate ?? _itemTemplate"
-                                        [idx]="j"
-                                        [menuitemId]="menuitemId(item, id, i, j)"
-                                        [style]="item.style"
-                                        (onMenuItemClick)="itemClick($event, menuitemId(item, id, i, j))"
-                                        pTooltip
-                                        [tooltipOptions]="item.tooltipOptions"
-                                        [pTooltipUnstyled]="unstyled()"
-                                        [unstyled]="unstyled()"
-                                        role="menuitem"
-                                        [attr.aria-label]="label(item.label)"
-                                        [attr.data-p-focused]="isItemFocused(menuitemId(item, id, i, j))"
-                                        [attr.data-p-disabled]="disabled(item.disabled)"
-                                        [attr.aria-disabled]="disabled(item.disabled)"
-                                        [attr.id]="menuitemId(item, id, i, j)"
-                                    ></li>
+                                @for (item of submenu.items; track item; let j = $index) {
+                                    @if (item.separator && item.visible !== false) {
+                                        <li [class]="cx('separator')" [pBind]="ptm('separator')" role="separator" [attr.data-pc-section]="'separator'"></li>
+                                    }
+                                    @if (!item.separator && item.visible !== false) {
+                                        <li
+                                            [class]="cn(cx('item', { item, id: menuitemId(item, id, i, j) }), item?.styleClass)"
+                                            [pBind]="ptm('item')"
+                                            [pMenuItemContent]="item"
+                                            [itemTemplate]="itemTemplate ?? _itemTemplate"
+                                            [idx]="j"
+                                            [menuitemId]="menuitemId(item, id, i, j)"
+                                            [style]="item.style"
+                                            (onMenuItemClick)="itemClick($event, menuitemId(item, id, i, j))"
+                                            pTooltip
+                                            [tooltipOptions]="item.tooltipOptions"
+                                            [pTooltipUnstyled]="unstyled()"
+                                            [unstyled]="unstyled()"
+                                            role="menuitem"
+                                            [attr.aria-label]="label(item.label)"
+                                            [attr.data-p-focused]="isItemFocused(menuitemId(item, id, i, j))"
+                                            [attr.data-p-disabled]="disabled(item.disabled)"
+                                            [attr.aria-disabled]="disabled(item.disabled)"
+                                            [attr.id]="menuitemId(item, id, i, j)"
+                                        ></li>
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes #1648

## Problem

A child item that set `visible: true` rendered even when its parent submenu had `visible: false`:

```
@if (!item.separator && item.visible !== false && (item.visible !== undefined || submenu.visible !== false))
```

The `item.visible !== undefined` clause force-shows any child that declares `visible`. The group header (`li[data-pc-section="submenulabel"]`) is gated on `submenu.visible !== false` alone, so it does not render — the force-shown item is left with no group label at all, which is the a11y gap reported in #1648.

The sibling separator guard had a related bug, an `||` where it needs `&&`:

```
@if (item.separator && (item.visible !== false || submenu.visible !== false))
```

With a hidden group and a separator that leaves `visible` undefined, `item.visible !== false` is `true`, so separators rendered inside a hidden group.

## Fix

Move the child loop inside the `@if (submenu.visible !== false)` wrapper added in #1632 and drop the parent checks from the inner conditions. A hidden group now hides its header, its separators and its items alike, and the grouped branch reads exactly like the non-grouped one.

The item `li` bindings, `menuitemId()` ids, `data-pc-section` values and PT hooks are unchanged. `git log -S` traces the escape hatch back to the pre-fork PrimeNG rename (`0c463b7410`) — it is undocumented and was never a deliberate feature here.

**Behavior change worth a look:** `item.visible: true` no longer overrides a hidden parent group. Anyone relying on the force-show loses those items.

## Tests

Three cases added next to the ones from #1632:

- hidden group with a `visible: true` child renders no items and no orphan (fails before the fix: `expected 2 to be 1`)
- hidden group containing a separator renders no separators (fails before the fix: `expected 1 to be +0`)
- a `visible: true` child of a *visible* group still renders, so the fix does not overreach

Menu suite: 131 passed. Full `optimus-ui` suite: 7281 passed, 90 skipped, 0 failed.

## Verified in the docs app

Group demo temporarily patched with the issue's repro model (`Documents` group `visible: false`, child `Forced Visible Item` `visible: true`), reverted afterwards.

Before: `Forced Visible Item` renders on its own, no `Documents` header above it.
After: the entire hidden group is gone, only the `Profile` group remains.

## Follow-up

`isItemHidden()` (`menu.ts:942`) is dead code and carries its own inverted separator logic. Left untouched here; happy to remove it separately if you want it gone.

---

Co-authored by Claude. (The trailer is in the description rather than the commit because commitlint's `no-ai-co-author` rule rejects it in the message.)