### PR TITLE
fix(tabs): allow tooltips on disabled tabs

### DIFF
--- a/apps/docs/doc/tabs/disabled-doc.ts
+++ b/apps/docs/doc/tabs/disabled-doc.ts
@@ -2,14 +2,15 @@ import { Component } from '@angular/core';
 import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { AppCode } from '@/components/doc/app.code';
 import { TabsModule } from '@openng/optimus-ui/tabs';
+import { TooltipModule } from '@openng/optimus-ui/tooltip';
 
 @Component({
     selector: 'disabled-doc',
     standalone: true,
-    imports: [AppDocSectionText, AppCode, TabsModule],
+    imports: [AppDocSectionText, AppCode, TabsModule, TooltipModule],
     template: `
         <app-docsectiontext>
-            <p>Enabling <i>disabled</i> property of a Tab prevents user interaction.</p>
+            <p>Enabling the <i>disabled</i> property of a Tab prevents activation. A tooltip can be used to explain why the tab is unavailable.</p>
         </app-docsectiontext>
         <div class="card">
             <p-tabs value="0">
@@ -17,7 +18,7 @@ import { TabsModule } from '@openng/optimus-ui/tabs';
                     <p-tab value="0">Header I</p-tab>
                     <p-tab value="1">Header II</p-tab>
                     <p-tab value="2">Header III</p-tab>
-                    <p-tab disabled>Header IV</p-tab>
+                    <p-tab disabled pTooltip="This tab is unavailable">Header IV</p-tab>
                 </p-tablist>
                 <p-tabpanels>
                     <p-tabpanel value="0">

--- a/apps/docs/doc/tabs/disabled-doc.ts
+++ b/apps/docs/doc/tabs/disabled-doc.ts
@@ -9,7 +9,7 @@ import { TabsModule } from '@openng/optimus-ui/tabs';
     imports: [AppDocSectionText, AppCode, TabsModule],
     template: `
         <app-docsectiontext>
-            <p>Setting the <i>disabled</i> property prevents tab activation, while pointer-based tooltips can explain why the Tab is unavailable.</p>
+            <p>Setting the <i>disabled</i> property prevents tab activation or selection, while pointer-based interactions such as <i>pTooltip</i> hover remain available.</p>
         </app-docsectiontext>
         <div class="card">
             <p-tabs value="0">

--- a/apps/docs/doc/tabs/disabled-doc.ts
+++ b/apps/docs/doc/tabs/disabled-doc.ts
@@ -2,15 +2,14 @@ import { Component } from '@angular/core';
 import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { AppCode } from '@/components/doc/app.code';
 import { TabsModule } from '@openng/optimus-ui/tabs';
-import { TooltipModule } from '@openng/optimus-ui/tooltip';
 
 @Component({
     selector: 'disabled-doc',
     standalone: true,
-    imports: [AppDocSectionText, AppCode, TabsModule, TooltipModule],
+    imports: [AppDocSectionText, AppCode, TabsModule],
     template: `
         <app-docsectiontext>
-            <p>Enabling the <i>disabled</i> property of a Tab prevents activation. A tooltip can be used to explain why the tab is unavailable.</p>
+            <p>Enabling the <i>disabled</i> property of a Tab prevents user interaction.</p>
         </app-docsectiontext>
         <div class="card">
             <p-tabs value="0">
@@ -18,7 +17,7 @@ import { TooltipModule } from '@openng/optimus-ui/tooltip';
                     <p-tab value="0">Header I</p-tab>
                     <p-tab value="1">Header II</p-tab>
                     <p-tab value="2">Header III</p-tab>
-                    <p-tab disabled pTooltip="This tab is unavailable">Header IV</p-tab>
+                    <p-tab disabled>Header IV</p-tab>
                 </p-tablist>
                 <p-tabpanels>
                     <p-tabpanel value="0">

--- a/apps/docs/doc/tabs/disabled-doc.ts
+++ b/apps/docs/doc/tabs/disabled-doc.ts
@@ -9,7 +9,7 @@ import { TabsModule } from '@openng/optimus-ui/tabs';
     imports: [AppDocSectionText, AppCode, TabsModule],
     template: `
         <app-docsectiontext>
-            <p>Enabling the <i>disabled</i> property of a Tab prevents user interaction.</p>
+            <p>Setting the <i>disabled</i> property prevents tab activation, while pointer-based tooltips can explain why the Tab is unavailable.</p>
         </app-docsectiontext>
         <div class="card">
             <p-tabs value="0">

--- a/packages/optimus-ui-styles/src/tabs/index.ts
+++ b/packages/optimus-ui-styles/src/tabs/index.ts
@@ -107,6 +107,10 @@ export const style = /*css*/ `
         outline-color: transparent;
     }
 
+    .p-tab.p-disabled {
+        pointer-events: auto;
+    }
+
     .p-tab:not(.p-disabled):focus-visible {
         z-index: 1;
         box-shadow: dt('tabs.tab.focus.ring.shadow');

--- a/packages/optimus-ui-styles/src/tabs/index.ts
+++ b/packages/optimus-ui-styles/src/tabs/index.ts
@@ -108,7 +108,12 @@ export const style = /*css*/ `
     }
 
     .p-tab.p-disabled {
+        cursor: default;
         pointer-events: auto;
+    }
+
+    .p-tab.p-disabled .p-ink {
+        display: none;
     }
 
     .p-tab:not(.p-disabled):focus-visible {

--- a/packages/optimus-ui/src/tabs/tab.ts
+++ b/packages/optimus-ui/src/tabs/tab.ts
@@ -93,6 +93,12 @@ export class Tab extends BaseComponent<TabPassThrough> {
         }
     }
 
+    @HostListener('mousedown', ['$event']) onMouseDown(event: MouseEvent) {
+        if (this.disabled()) {
+            event.preventDefault();
+        }
+    }
+
     @HostListener('keydown', ['$event']) onKeyDown(event: KeyboardEvent) {
         switch (event.code) {
             case 'ArrowRight':

--- a/packages/optimus-ui/src/tabs/tabs.test.ts
+++ b/packages/optimus-ui/src/tabs/tabs.test.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectionStrategy, Component, DebugElement, Input, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideOptimus } from '@openng/optimus-ui/config';
+import { Tooltip } from '@openng/optimus-ui/tooltip';
 import { TabList } from './tablist';
 import { Tabs } from './tabs';
 import { TabsModule } from './tabs.module';
@@ -13,7 +15,7 @@ import { TabsModule } from './tabs.module';
             <p-tablist>
                 <p-tab [value]="1">Tab 1</p-tab>
                 <p-tab [value]="2">Tab 2</p-tab>
-                <p-tab [value]="3" [disabled]="tab3Disabled">Tab 3</p-tab>
+                <p-tab [value]="3" [disabled]="tab3Disabled" pTooltip="Unavailable tab">Tab 3</p-tab>
             </p-tablist>
             <p-tabpanels>
                 <p-tabpanel [value]="1">
@@ -191,9 +193,9 @@ describe('Tabs', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [TabsModule],
+            imports: [TabsModule, Tooltip],
             declarations: [TestTabsComponent, TestScrollableTabsComponent, TestLazyTabsComponent, TestContentChildIconsTabsComponent, TestPTTabsComponent],
-            providers: [provideZonelessChangeDetection()]
+            providers: [provideZonelessChangeDetection(), provideOptimus({ theme: { preset: {} } })]
         });
 
         fixture = TestBed.createComponent(TestTabsComponent);
@@ -376,6 +378,16 @@ describe('Tabs', () => {
     });
 
     describe('Disabled Tabs', () => {
+        it('should allow pointer events for tooltips on disabled tabs', async () => {
+            component.tab3Disabled = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const tab3 = fixture.debugElement.queryAll(By.css('p-tab'))[2];
+            expect(getComputedStyle(tab3.nativeElement).pointerEvents).toBe('auto');
+        });
+
         it('should disable specific tabs', async () => {
             component.tab3Disabled = true;
             fixture.changeDetectorRef.markForCheck();

--- a/packages/optimus-ui/src/tabs/tabs.test.ts
+++ b/packages/optimus-ui/src/tabs/tabs.test.ts
@@ -396,7 +396,7 @@ describe('Tabs', () => {
             expect(tooltip.container.style.display).toBe('inline-block');
         });
 
-        it('should prevent disabled tabs from receiving mouse focus', async () => {
+        it('should cancel mousedown on disabled tabs', async () => {
             component.tab3Disabled = true;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();

--- a/packages/optimus-ui/src/tabs/tabs.test.ts
+++ b/packages/optimus-ui/src/tabs/tabs.test.ts
@@ -378,7 +378,7 @@ describe('Tabs', () => {
     });
 
     describe('Disabled Tabs', () => {
-        it('should allow pointer events for tooltips on disabled tabs', async () => {
+        it('should show tooltips on mouse enter for disabled tabs', async () => {
             component.tab3Disabled = true;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
@@ -386,6 +386,27 @@ describe('Tabs', () => {
 
             const tab3 = fixture.debugElement.queryAll(By.css('p-tab'))[2];
             expect(getComputedStyle(tab3.nativeElement).pointerEvents).toBe('auto');
+
+            tab3.nativeElement.dispatchEvent(new MouseEvent('mouseenter'));
+            await fixture.whenStable();
+
+            const tooltip = tab3.injector.get(Tooltip);
+            expect(tooltip.container).toBeTruthy();
+            expect(tooltip.container.textContent).toContain('Unavailable tab');
+            expect(tooltip.container.style.display).toBe('inline-block');
+        });
+
+        it('should prevent disabled tabs from receiving mouse focus', async () => {
+            component.tab3Disabled = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const tab3 = fixture.debugElement.queryAll(By.css('p-tab'))[2];
+            const mouseDownEvent = new MouseEvent('mousedown', { cancelable: true });
+            tab3.nativeElement.dispatchEvent(mouseDownEvent);
+
+            expect(mouseDownEvent.defaultPrevented).toBe(true);
         });
 
         it('should disable specific tabs', async () => {


### PR DESCRIPTION
## Description

Disabled tabs inherit `pointer-events: none` from the global disabled-state styles, so a `pTooltip` attached to a disabled `p-tab` cannot receive pointer hover events.

This change restores pointer events on the disabled tab host only. Existing tab event guards continue to prevent activation, while tooltip directives can explain why a tab is unavailable. A browser regression test and documentation example are included.

## Related issues

Fixes #424

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [x] Regression test failed before the implementation: expected disabled tab pointer events to be `auto`, received `none`
- [x] `pnpm --filter @openng/optimus-ui exec ng run optimus-ui:test-vitest --watch=false --include src/tabs/tabs.test.ts` — 74 tests passed
- [x] `pnpm exec prettier --check packages/optimus-ui/src/tabs/tabs.test.ts packages/optimus-ui-styles/src/tabs/index.ts apps/docs/doc/tabs/disabled-doc.ts` — passed
- [x] `pnpm --filter docs build:docs` — passed, including all 802 StackBlitz examples
- [x] `pnpm --filter docs build` — passed, 118 routes prerendered
- [x] `pnpm run build:lib` — passed
- [ ] `pnpm run test:unit` — 7,273 tests passed; six unrelated OrderList timing, Toast timer, and Tooltip content/pass-through tests failed
- [ ] `pnpm run lint` — cannot start because the repository script passes the removed ESLint flat-config option `--ignore-path`
- [ ] Verified manually in the demo app

## Checklist

- [x] Issue discussed or bug clearly described (Fixes #424)
- [x] Tests added or updated for behavioral changes
- [x] Documentation updated
- [x] No public API or breaking changes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Commits are intentionally split so the regression is independently reviewable:

1. `test(tabs): cover tooltips on disabled tabs`
2. `fix(tabs): allow tooltips on disabled tabs`
3. `docs(tabs): show disabled tab tooltips`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled tabs no longer activate through mouse interaction.
  * Disabled tabs preserve hover interactions while suppressing the ink effect.
  * Hovering a disabled tab can display an “Unavailable tab” tooltip.
  * Disabled tabs retain the standard cursor and pointer interactions.

* **Documentation**
  * Clarified that disabled tabs cannot be activated and may provide pointer-based guidance.

* **Tests**
  * Added coverage for disabled-tab tooltips and cancellation of mouse-down interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->