### PR TITLE
refactor(basecomponent): unwrap signal hostName in the $hostName shim

### DIFF
--- a/packages/optimus-ui/src/basecomponent/basecomponent.ts
+++ b/packages/optimus-ui/src/basecomponent/basecomponent.ts
@@ -28,11 +28,41 @@ export class BaseComponent<PT = any> implements Lifecycle {
 
     public config: Optimus = inject(Optimus);
 
-    public $parentInstance: BaseComponent | undefined = inject(PARENT_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
-
     public baseComponentStyle: BaseComponentStyle = inject(BaseComponentStyle);
 
     public baseStyle: BaseStyle = inject(BaseStyle);
+
+    /******************** Inputs ********************/
+
+    /**
+     * Defines scoped design tokens of the component.
+     * @defaultValue undefined
+     * @group Props
+     */
+    dt = input<Object | undefined>();
+
+    /**
+     * Indicates whether the component should be rendered without styles.
+     * @defaultValue undefined
+     * @group Props
+     */
+    unstyled = input<boolean | undefined>();
+
+    /**
+     * Used to pass attributes to DOM elements inside the component.
+     * @defaultValue undefined
+     * @group Props
+     */
+    pt = input<PT | undefined>();
+
+    /**
+     * Used to configure passthrough(pt) options of the component.
+     * @group Props
+     * @defaultValue undefined
+     */
+    ptOptions = input<PassThroughOptions | undefined>();
+
+    public $parentInstance: BaseComponent | undefined = inject(PARENT_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
 
     public scopedStyleEl: any;
 
@@ -44,33 +74,6 @@ export class BaseComponent<PT = any> implements Lifecycle {
 
     private themeChangeListenerMap: Map<string, any> = new Map();
 
-    /******************** Inputs ********************/
-
-    /**
-     * Defines scoped design tokens of the component.
-     * @defaultValue undefined
-     * @group Props
-     */
-    dt = input<Object | undefined>();
-    /**
-     * Indicates whether the component should be rendered without styles.
-     * @defaultValue undefined
-     * @group Props
-     */
-    unstyled = input<boolean | undefined>();
-    /**
-     * Used to pass attributes to DOM elements inside the component.
-     * @defaultValue undefined
-     * @group Props
-     */
-    pt = input<PT | undefined>();
-    /**
-     * Used to configure passthrough(pt) options of the component.
-     * @group Props
-     * @defaultValue undefined
-     */
-    ptOptions = input<PassThroughOptions | undefined>();
-
     /******************** Computed ********************/
 
     $attrSelector = uuid('pc');
@@ -80,7 +83,10 @@ export class BaseComponent<PT = any> implements Lifecycle {
     }
 
     private get $hostName() {
-        return this['hostName'];
+        const hostName = this['hostName'];
+        // `hostName` is a signal input on migrated components and a plain string on legacy ones —
+        // unwrap both shapes (interim shim until every component is signal-based).
+        return typeof hostName === 'function' ? hostName() : hostName;
     }
 
     get $el() {
@@ -126,40 +132,6 @@ export class BaseComponent<PT = any> implements Lifecycle {
         };
     }
 
-    /******************** Lifecycle Hooks ********************/
-
-    onInit() {
-        // NOOP - to be implemented by subclasses
-    }
-
-    onChanges(changes: SimpleChanges) {
-        // NOOP - to be implemented by subclasses
-    }
-
-    onDoCheck() {
-        // NOOP - to be implemented by subclasses
-    }
-
-    onAfterContentInit() {
-        // NOOP - to be implemented by subclasses
-    }
-
-    onAfterContentChecked() {
-        // NOOP - to be implemented by subclasses
-    }
-
-    onAfterViewInit() {
-        // NOOP - to be implemented by subclasses
-    }
-
-    onAfterViewChecked() {
-        // NOOP - to be implemented by subclasses
-    }
-
-    onDestroy() {
-        // NOOP - to be implemented by subclasses
-    }
-
     /******************** Angular Lifecycle Hooks ********************/
 
     constructor() {
@@ -195,6 +167,40 @@ export class BaseComponent<PT = any> implements Lifecycle {
         });
 
         this._hook('onBeforeInit');
+    }
+
+    /******************** Lifecycle Hooks ********************/
+
+    onInit() {
+        // NOOP - to be implemented by subclasses
+    }
+
+    onChanges(changes: SimpleChanges) {
+        // NOOP - to be implemented by subclasses
+    }
+
+    onDoCheck() {
+        // NOOP - to be implemented by subclasses
+    }
+
+    onAfterContentInit() {
+        // NOOP - to be implemented by subclasses
+    }
+
+    onAfterContentChecked() {
+        // NOOP - to be implemented by subclasses
+    }
+
+    onAfterViewInit() {
+        // NOOP - to be implemented by subclasses
+    }
+
+    onAfterViewChecked() {
+        // NOOP - to be implemented by subclasses
+    }
+
+    onDestroy() {
+        // NOOP - to be implemented by subclasses
     }
 
     /**

--- a/packages/optimus-ui/src/icons/baseicon/baseicon.ts
+++ b/packages/optimus-ui/src/icons/baseicon/baseicon.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, Input, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
 import { cn } from '@openng/optimus-ui-utils';
 import { BaseComponent } from '@openng/optimus-ui/basecomponent';
 import { BaseIconStyle } from './style/baseiconstyle';
@@ -19,13 +19,13 @@ import { BaseIconStyle } from './style/baseiconstyle';
     }
 })
 export class BaseIcon extends BaseComponent {
-    @Input({ transform: booleanAttribute }) spin: boolean = false;
-
     _componentStyle = inject(BaseIconStyle);
+
+    readonly spin = input<boolean, unknown>(false, { transform: booleanAttribute });
 
     getClassNames() {
         return cn('p-icon', {
-            'p-icon-spin': this.spin
+            'p-icon-spin': this.spin()
         });
     }
 }


### PR DESCRIPTION
Makes BaseComponent.$hostName unwrap both shapes of hostName - a signal
input on migrated components and a plain string on legacy ones - and
migrates BaseIcon (spin to input()). Backward compatible with every
unmigrated component; merge this branch FIRST: the components that
declare hostName as a signal input rely on this shim for PT resolution.

**Merge this PR first.** The migrated components that declare `hostName` as a signal input rely on the `$hostName` shim in this PR for correct PT resolution at runtime.

---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5