### PR TITLE
feat(optimus-ui): add ng-update migrations for 3.0 input removals and renames

### DIFF
--- a/packages/optimus-ui/schematics/migrations.json
+++ b/packages/optimus-ui/schematics/migrations.json
@@ -5,6 +5,21 @@
             "version": "3.0.0",
             "factory": "./migrations/remove-dead-outputs/migration",
             "description": "Remove usages of outputs removed in this version that had already stopped firing: Overlay's onAnimationStart/onAnimationDone (and OverlayOptions config callbacks), and MenubarSub's menuFocus/menuBlur/menuKeydown."
+        },
+        "styleclass-to-class": {
+            "version": "3.0.0",
+            "factory": "./migrations/styleclass-to-class/migration",
+            "description": "Rewrite the removed styleClass input to the plain class attribute on components migrated to signals in 3.0.0 (p-tag, avatar-group, input-group(-addon), input-icon, icon-field, progress-spinner, divider, skeleton, ...)."
+        },
+        "renamed-inputs": {
+            "version": "3.0.0",
+            "factory": "./migrations/renamed-inputs/migration",
+            "description": "Rewrite usages of inputs renamed in 3.0.0 (deprecated aliases removed with the signal migration), e.g. OverlayBadge's size \u2192 badgeSize."
+        },
+        "remove-dead-inputs": {
+            "version": "3.0.0",
+            "factory": "./migrations/remove-dead-inputs/migration",
+            "description": "Remove template bindings for inputs removed in 3.0.0 that had already stopped doing anything, e.g. CascadeSelect's never-read inputLabel."
         }
     }
 }

--- a/packages/optimus-ui/schematics/migrations/remove-dead-inputs/migration.ts
+++ b/packages/optimus-ui/schematics/migrations/remove-dead-inputs/migration.ts
@@ -1,0 +1,140 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { SKIP_DIRS } from '../../utils/package-json';
+import { removeDeadInputs, removeDeadInputsInTypeScript } from '../../utils/removed-inputs';
+
+/**
+ * A set of inputs removed together in this version. Each group names the component selectors the
+ * inputs lived on — the same input name may still exist on other components, so removal is always
+ * selector-scoped.
+ */
+interface RemovedInputGroup {
+    /** Human-readable label used in the summary log line. */
+    label: string;
+    /** The component's element selectors, e.g. ['p-cascadeSelect', 'p-cascadeselect']. */
+    selectors: readonly string[];
+    /** Input property names in this group. */
+    names: readonly string[];
+}
+
+const REMOVED_INPUT_GROUPS: readonly RemovedInputGroup[] = [
+    {
+        label: 'CascadeSelect inputLabel',
+        selectors: ['p-cascadeSelect', 'p-cascadeselect', 'p-cascade-select'],
+        // `inputLabel` was declared but never read anywhere in the component — the binding had no
+        // effect. Use `ariaLabel`/`inputId` + a <label> for accessible labeling.
+        names: ['inputLabel']
+    },
+    {
+        label: 'Tree togglerAriaLabel',
+        selectors: ['p-tree'],
+        // `togglerAriaLabel` was declared but never applied to any element — the binding had no
+        // effect on the rendered output.
+        names: ['togglerAriaLabel']
+    },
+    {
+        label: 'TreeNode rowNode/root/firstChild/lastChild',
+        selectors: ['p-treeNode', 'p-treenode', 'p-tree-node'],
+        // These inputs were declared on the internal `p-treeNode` component but never read — the
+        // bindings had no effect.
+        names: ['rowNode', 'root', 'firstChild', 'lastChild']
+    },
+    {
+        label: 'AutoComplete autoZIndex/baseZIndex/showTransitionOptions/hideTransitionOptions',
+        selectors: ['p-autoComplete', 'p-autocomplete', 'p-auto-complete'],
+        // Layering is managed by the overlay (`overlayOptions`), and the transition options were
+        // superseded by `motionOptions` — none of these inputs were read anywhere.
+        names: ['autoZIndex', 'baseZIndex', 'showTransitionOptions', 'hideTransitionOptions']
+    },
+    {
+        label: 'SelectItem visible/itemSize',
+        selectors: ['p-selectItem', 'p-selectitem', 'p-select-item'],
+        // These inputs were declared on the internal `p-selectItem` component but never read —
+        // item height comes from `scrollerOptions`.
+        names: ['visible', 'itemSize']
+    },
+    {
+        label: 'DatePicker showTransitionOptions/hideTransitionOptions',
+        selectors: ['p-datePicker', 'p-datepicker', 'p-date-picker'],
+        // Superseded by `motionOptions` — neither input was read anywhere.
+        names: ['showTransitionOptions', 'hideTransitionOptions']
+    },
+    {
+        label: 'TreeTableSortIcon ariaLabelDesc/ariaLabelAsc',
+        selectors: ['p-treeTableSortIcon', 'p-treetable-sort-icon', 'p-tree-table-sort-icon'],
+        // These inputs were declared on the internal sort icon component but never read — the
+        // bindings had no effect on the rendered output.
+        names: ['ariaLabelDesc', 'ariaLabelAsc']
+    }
+];
+
+/**
+ * Removes template bindings for inputs deleted in 3.0.0 that had already stopped doing anything:
+ *
+ * - CascadeSelect.inputLabel: declared but never read — the binding never had an effect.
+ * - Tree.togglerAriaLabel: declared but never applied to any element.
+ * - UITreeNode (`p-treeNode`) rowNode/root/firstChild/lastChild: declared but never read.
+ * - AutoComplete autoZIndex/baseZIndex/showTransitionOptions/hideTransitionOptions: never read.
+ * - SelectItem (`p-selectItem`) visible/itemSize: declared but never read.
+ * - TreeTableSortIcon (`p-treeTableSortIcon`) ariaLabelDesc/ariaLabelAsc: declared but never read.
+ * - DatePicker showTransitionOptions/hideTransitionOptions: superseded by `motionOptions`, never read.
+ *
+ * Both `[name]="expr"` bindings and `name="value"` static attributes are removed, only on the
+ * component's own selectors. Programmatic access on component instances is not rewritten.
+ */
+export default function (): Rule {
+    return (tree: Tree, context: SchematicContext) => {
+        let filesChanged = 0;
+        let bindingsRemoved = 0;
+
+        tree.visit((path) => {
+            if (SKIP_DIRS.test(path)) {
+                return;
+            }
+            if (path.endsWith('.html')) {
+                const original = tree.read(path)?.toString();
+                if (original === undefined) {
+                    return;
+                }
+                let text = original;
+                let removedInFile = 0;
+                for (const group of REMOVED_INPUT_GROUPS) {
+                    const result = removeDeadInputs(text, group.selectors, group.names);
+                    text = result.text;
+                    removedInFile += result.removed;
+                }
+                if (removedInFile > 0) {
+                    tree.overwrite(path, text);
+                    filesChanged++;
+                    bindingsRemoved += removedInFile;
+                    context.logger.info(`${path}: removed ${removedInFile} dead input binding(s)`);
+                }
+            } else if (path.endsWith('.ts') || path.endsWith('.mts')) {
+                const original = tree.read(path)?.toString();
+                if (original === undefined) {
+                    return;
+                }
+                let text = original;
+                let removedInFile = 0;
+                for (const group of REMOVED_INPUT_GROUPS) {
+                    const result = removeDeadInputsInTypeScript(path, text, group.selectors, group.names);
+                    text = result.text;
+                    removedInFile += result.removed;
+                }
+                if (removedInFile > 0) {
+                    tree.overwrite(path, text);
+                    filesChanged++;
+                    bindingsRemoved += removedInFile;
+                    context.logger.info(`${path}: removed ${removedInFile} dead input binding(s) from inline template`);
+                }
+            }
+        });
+
+        if (bindingsRemoved > 0) {
+            context.logger.info(`Removed ${bindingsRemoved} dead input binding(s) across ${filesChanged} file(s) for: ${REMOVED_INPUT_GROUPS.map((g) => g.label).join(', ')}.`);
+        } else {
+            context.logger.info('No bindings for the removed inputs were found to remove.');
+        }
+
+        return tree;
+    };
+}

--- a/packages/optimus-ui/schematics/migrations/renamed-inputs/migration.ts
+++ b/packages/optimus-ui/schematics/migrations/renamed-inputs/migration.ts
@@ -1,0 +1,105 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { SKIP_DIRS } from '../../utils/package-json';
+import { renameInput, renameInputInTypeScript, RenameInputSpec } from '../../utils/rename-input';
+
+/**
+ * Inputs renamed (their deprecated aliases removed) in 3.0.0 as part of the signal migration.
+ * Extend this table as components are migrated.
+ */
+const RENAMED_INPUTS: readonly RenameInputSpec[] = [
+    // OverlayBadge: the deprecated `size` input (a no-op alias that only logged a warning) was
+    // removed — `badgeSize` is the input actually forwarded to the badge.
+    { selectors: ['p-overlayBadge', 'p-overlay-badge', 'p-overlaybadge'], from: 'size', to: 'badgeSize' },
+    // TreeSelect: the deprecated container styling inputs were removed — the standard `class` and
+    // `style` attributes land on the same host element.
+    { selectors: ['p-treeSelect', 'p-treeselect', 'p-tree-select'], from: 'containerStyleClass', to: 'class' },
+    { selectors: ['p-treeSelect', 'p-treeselect', 'p-tree-select'], from: 'containerStyle', to: 'style' },
+    // AutoComplete: the deprecated `minLength` alias was removed — `minQueryLength` is the input
+    // that has been read since v20.
+    { selectors: ['p-autoComplete', 'p-autocomplete', 'p-auto-complete'], from: 'minLength', to: 'minQueryLength' }
+];
+
+/**
+ * Rewrites usages of inputs that were renamed in 3.0.0:
+ *
+ * - `from="x"`   → `to="x"`
+ * - `[from]="e"` → `[to]="e"`
+ *
+ * A tag carrying both the old and the new input keeps the old attribute and is reported for
+ * manual review — the new input's value is assumed to be the one the author wants to keep.
+ */
+export default function (): Rule {
+    return (tree: Tree, context: SchematicContext) => {
+        let filesChanged = 0;
+        let renamed = 0;
+        const conflicts: string[] = [];
+
+        tree.visit((path) => {
+            if (SKIP_DIRS.test(path)) {
+                return;
+            }
+            if (path.endsWith('.html')) {
+                const original = tree.read(path)?.toString();
+                if (original === undefined) {
+                    return;
+                }
+                let text = original;
+                let changed = false;
+                for (const spec of RENAMED_INPUTS) {
+                    const result = renameInput(text, spec);
+                    if (result.changed) {
+                        text = result.text;
+                        changed = true;
+                        renamed += result.renamed;
+                        context.logger.info(`${path}: renamed ${result.renamed} ${spec.from} usage(s) to ${spec.to}`);
+                    }
+                    for (const _ of result.conflicts) {
+                        conflicts.push(`${path} (${spec.from} → ${spec.to})`);
+                    }
+                }
+                if (changed) {
+                    tree.overwrite(path, text);
+                    filesChanged++;
+                }
+            } else if (path.endsWith('.ts') || path.endsWith('.mts')) {
+                const original = tree.read(path)?.toString();
+                if (original === undefined) {
+                    return;
+                }
+                let text = original;
+                let changed = false;
+                for (const spec of RENAMED_INPUTS) {
+                    const result = renameInputInTypeScript(path, text, spec);
+                    if (result.changed) {
+                        text = result.text;
+                        changed = true;
+                        renamed += result.renamed;
+                        context.logger.info(`${path}: renamed ${result.renamed} ${spec.from} usage(s) to ${spec.to} in inline template`);
+                    }
+                    for (const _ of result.conflicts) {
+                        conflicts.push(`${path} (${spec.from} → ${spec.to})`);
+                    }
+                }
+                if (changed) {
+                    tree.overwrite(path, text);
+                    filesChanged++;
+                }
+            }
+        });
+
+        if (renamed > 0) {
+            context.logger.info(`Renamed ${renamed} input usage(s) across ${filesChanged} file(s).`);
+        } else {
+            context.logger.info('No renamed-input usages found.');
+        }
+
+        if (conflicts.length > 0) {
+            context.logger.warn(`Found ${conflicts.length} element(s) carrying both the old and the new input — remove the old one manually:`);
+            for (const entry of conflicts) {
+                context.logger.warn(`  ${entry}`);
+            }
+        }
+
+        return tree;
+    };
+}

--- a/packages/optimus-ui/schematics/migrations/styleclass-to-class/migration.ts
+++ b/packages/optimus-ui/schematics/migrations/styleclass-to-class/migration.ts
@@ -1,0 +1,239 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { SKIP_DIRS } from '../../utils/package-json';
+import { migrateStyleClass, migrateStyleClassInTypeScript } from '../../utils/styleclass';
+
+/**
+ * Selectors of the components whose deprecated `styleClass` input was removed in 3.0.0 as part of
+ * their signal migration. Extend this list as each component is migrated — the rewrite is the same
+ * for all of them: `styleClass` becomes the plain `class` attribute, which the component host has
+ * always merged.
+ */
+const MIGRATED_SELECTORS: readonly string[] = [
+    'p-tag',
+    // AvatarGroup
+    'p-avatargroup',
+    'p-avatarGroup',
+    'p-avatar-group',
+    // InputGroup
+    'p-inputgroup',
+    'p-inputGroup',
+    'p-input-group',
+    // InputGroupAddon
+    'p-inputgroup-addon',
+    'p-inputGroupAddon',
+    // InputIcon
+    'p-inputicon',
+    'p-inputIcon',
+    // IconField
+    'p-iconfield',
+    'p-iconField',
+    'p-icon-field',
+    // ProgressSpinner
+    'p-progressSpinner',
+    'p-progress-spinner',
+    'p-progressspinner',
+    // Divider
+    'p-divider',
+    // Skeleton
+    'p-skeleton',
+    // Avatar
+    'p-avatar',
+    // Toolbar
+    'p-toolbar',
+    // Timeline
+    'p-timeline',
+    // Terminal
+    'p-terminal',
+    // BlockUI
+    'p-blockUI',
+    'p-blockui',
+    'p-block-ui',
+    // Card
+    'p-card',
+    // Inplace
+    'p-inplace',
+    // Chip (the chipProps.styleClass property still works)
+    'p-chip',
+    // ToggleSwitch
+    'p-toggleswitch',
+    'p-toggleSwitch',
+    'p-toggle-switch',
+    // RadioButton
+    'p-radioButton',
+    'p-radiobutton',
+    'p-radio-button',
+    // ToggleButton
+    'p-toggleButton',
+    'p-togglebutton',
+    'p-toggle-button',
+    // Badge
+    'p-badge',
+    // Checkbox
+    'p-checkbox',
+    'p-checkBox',
+    'p-check-box',
+    // Panel
+    'p-panel',
+    // OrganizationChart
+    'p-organizationChart',
+    'p-organization-chart',
+    'p-organizationchart',
+    // Knob
+    'p-knob',
+    // SplitButton
+    'p-splitbutton',
+    'p-splitButton',
+    'p-split-button',
+    // Dock
+    'p-dock',
+    // Editor
+    'p-editor',
+    // ScrollPanel
+    'p-scroll-panel',
+    'p-scrollPanel',
+    'p-scrollpanel',
+    // DataView
+    'p-dataView',
+    'p-dataview',
+    'p-data-view',
+    // Splitter
+    'p-splitter',
+    // Accordion
+    'p-accordion',
+    // Image
+    'p-image',
+    // Toast
+    'p-toast',
+    // Slider
+    'p-slider',
+    // Paginator
+    'p-paginator',
+    // ColorPicker
+    'p-colorPicker',
+    'p-colorpicker',
+    'p-color-picker',
+    // Password
+    'p-password',
+    // Carousel
+    'p-carousel',
+    // PanelMenu
+    'p-panelMenu',
+    'p-panelmenu',
+    'p-panel-menu',
+    // Menubar
+    'p-menubar',
+    // MegaMenu
+    'p-megaMenu',
+    'p-megamenu',
+    'p-mega-menu',
+    // InputNumber
+    'p-inputNumber',
+    'p-inputnumber',
+    'p-input-number',
+    // CascadeSelect
+    'p-cascadeSelect',
+    'p-cascadeselect',
+    'p-cascade-select',
+    // Listbox
+    'p-listbox',
+    'p-listBox',
+    'p-list-box',
+    // OrderList
+    'p-orderList',
+    'p-orderlist',
+    'p-order-list',
+    // Tree
+    'p-tree',
+    // AutoComplete
+    'p-autoComplete',
+    'p-autocomplete',
+    'p-auto-complete',
+    // Select
+    'p-select',
+    // MultiSelect
+    'p-multiSelect',
+    'p-multiselect',
+    'p-multi-select',
+    // DatePicker
+    'p-datePicker',
+    'p-datepicker',
+    'p-date-picker',
+    // TreeTable
+    'p-treeTable',
+    'p-treetable',
+    'p-tree-table',
+    // Table
+    'p-table'
+];
+
+/**
+ * Rewrites usages of the removed `styleClass` input to the standard `class` attribute on the
+ * components migrated in 3.0.0:
+ *
+ * - `styleClass="x"`   → `class="x"` (merged into an existing static `class` attribute if any)
+ * - `[styleClass]="e"` → `[class]="e"`
+ *
+ * A tag carrying both `[styleClass]` and `[class]` is reported for manual review instead of being
+ * rewritten (two `[class]` bindings would compete). Programmatic access to `.styleClass` on
+ * component instances is not rewritten — `styleClass` still exists on the components that are not
+ * yet migrated, so a blind rename would produce false positives.
+ */
+export default function (): Rule {
+    return (tree: Tree, context: SchematicContext) => {
+        let filesChanged = 0;
+        let renamed = 0;
+        const conflicts: string[] = [];
+
+        tree.visit((path) => {
+            if (SKIP_DIRS.test(path)) {
+                return;
+            }
+            if (path.endsWith('.html')) {
+                const original = tree.read(path)?.toString();
+                if (original === undefined) {
+                    return;
+                }
+                const result = migrateStyleClass(original, MIGRATED_SELECTORS);
+                if (result.changed) {
+                    tree.overwrite(path, result.text);
+                    filesChanged++;
+                    renamed += result.renamed;
+                    context.logger.info(`${path}: rewrote ${result.renamed} styleClass usage(s) to class`);
+                }
+                for (const _ of result.conflicts) {
+                    conflicts.push(path);
+                }
+            } else if (path.endsWith('.ts') || path.endsWith('.mts')) {
+                const original = tree.read(path)?.toString();
+                if (original === undefined) {
+                    return;
+                }
+                const result = migrateStyleClassInTypeScript(path, original, MIGRATED_SELECTORS);
+                if (result.changed) {
+                    tree.overwrite(path, result.text);
+                    filesChanged++;
+                    renamed += result.renamed;
+                    context.logger.info(`${path}: rewrote ${result.renamed} styleClass usage(s) to class in inline template`);
+                }
+                for (const _ of result.conflicts) {
+                    conflicts.push(path);
+                }
+            }
+        });
+
+        if (renamed > 0) {
+            context.logger.info(`Rewrote ${renamed} styleClass usage(s) to class across ${filesChanged} file(s) for: ${MIGRATED_SELECTORS.join(', ')}.`);
+        } else {
+            context.logger.info(`No styleClass usages found on: ${MIGRATED_SELECTORS.join(', ')}.`);
+        }
+
+        if (conflicts.length > 0) {
+            context.logger.warn(`Found ${conflicts.length} element(s) carrying both [styleClass] and [class] — merge them into the single [class] binding manually:`);
+            for (const path of conflicts) {
+                context.logger.warn(`  ${path}`);
+            }
+        }
+
+        return tree;
+    };
+}

--- a/packages/optimus-ui/schematics/test/remove-dead-inputs.spec.ts
+++ b/packages/optimus-ui/schematics/test/remove-dead-inputs.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { createAppTree, createMigrationRunner } from './helpers';
+
+describe('remove-dead-inputs', () => {
+    describe('CascadeSelect inputLabel', () => {
+        it('removes an [inputLabel] binding from a standalone template file', async () => {
+            const runner = createMigrationRunner();
+            const tree = createAppTree({
+                '/src/app/app.html': `<p-cascadeselect [options]="countries" [inputLabel]="label" optionLabel="name"></p-cascadeselect>\n`
+            });
+            const result = await runner.runSchematic('remove-dead-inputs', {}, tree);
+            const html = result.readContent('/src/app/app.html');
+            expect(html).not.toContain('inputLabel');
+            expect(html).toContain('<p-cascadeselect [options]="countries" optionLabel="name"></p-cascadeselect>');
+        });
+
+        it('removes a static inputLabel attribute, single- or double-quoted', async () => {
+            const runner = createMigrationRunner();
+            const tree = createAppTree({
+                '/src/app/app.html': `<p-cascade-select inputLabel='City' [options]="cities"></p-cascade-select>\n`
+            });
+            const result = await runner.runSchematic('remove-dead-inputs', {}, tree);
+            expect(result.readContent('/src/app/app.html')).toBe(`<p-cascade-select [options]="cities"></p-cascade-select>\n`);
+        });
+
+        it('removes the binding inside an inline component template (camelCase selector)', async () => {
+            const runner = createMigrationRunner();
+            const tree = createAppTree({
+                '/src/app/picker.component.ts':
+                    `import { Component } from '@angular/core';\n` +
+                    '@Component({\n' +
+                    "    selector: 'app-picker',\n" +
+                    '    template: `<p-cascadeSelect [inputLabel]="label" [options]="options"></p-cascadeSelect>`\n' +
+                    '})\n' +
+                    `export class PickerComponent {\n` +
+                    `    label = 'Pick one';\n` +
+                    `    options = [];\n` +
+                    `}\n`
+            });
+            const result = await runner.runSchematic('remove-dead-inputs', {}, tree);
+            const ts = result.readContent('/src/app/picker.component.ts');
+            expect(ts).not.toContain('[inputLabel]');
+            expect(ts).toContain('<p-cascadeSelect [options]="options"></p-cascadeSelect>');
+            // The (now-orphaned) component property is left in place.
+            expect(ts).toContain(`label = 'Pick one';`);
+        });
+
+        it('does not touch inputLabel on other elements', async () => {
+            const runner = createMigrationRunner();
+            const content = `<my-widget [inputLabel]="label"></my-widget>\n<p-select [inputLabel]="label"></p-select>\n`;
+            const tree = createAppTree({ '/src/app/app.html': content });
+            const result = await runner.runSchematic('remove-dead-inputs', {}, tree);
+            expect(result.readContent('/src/app/app.html')).toBe(content);
+        });
+
+        it('does not rewrite non-template string literals in TypeScript', async () => {
+            const runner = createMigrationRunner();
+            const content = `export const example = '<p-cascadeselect [inputLabel]="x"></p-cascadeselect>';\n`;
+            const tree = createAppTree({ '/src/app/config.ts': content });
+            const result = await runner.runSchematic('remove-dead-inputs', {}, tree);
+            expect(result.readContent('/src/app/config.ts')).toBe(content);
+        });
+    });
+
+    it('does not touch node_modules or dist', async () => {
+        const runner = createMigrationRunner();
+        const content = `<p-cascadeselect [inputLabel]="x"></p-cascadeselect>\n`;
+        const tree = createAppTree({
+            '/node_modules/pkg/tpl.html': content,
+            '/dist/app/tpl.html': content
+        });
+        const result = await runner.runSchematic('remove-dead-inputs', {}, tree);
+        expect(result.readContent('/node_modules/pkg/tpl.html')).toBe(content);
+        expect(result.readContent('/dist/app/tpl.html')).toBe(content);
+    });
+
+    it('reports nothing on a workspace with no usage of the removed inputs', async () => {
+        const runner = createMigrationRunner();
+        const infos: string[] = [];
+        runner.logger.subscribe((entry) => {
+            if (entry.level === 'info') {
+                infos.push(entry.message);
+            }
+        });
+        await runner.runSchematic('remove-dead-inputs', {}, createAppTree());
+        expect(infos.join('\n')).toContain('No bindings for the removed inputs were found to remove.');
+    });
+});

--- a/packages/optimus-ui/schematics/test/renamed-inputs.spec.ts
+++ b/packages/optimus-ui/schematics/test/renamed-inputs.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { createAppTree, createMigrationRunner } from './helpers';
+
+describe('renamed-inputs', () => {
+    it('renames a static size attribute on p-overlayBadge to badgeSize', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-overlayBadge severity="danger" size="small" value="2"></p-overlayBadge>\n`
+        });
+        const result = await runner.runSchematic('renamed-inputs', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-overlayBadge severity="danger" badgeSize="small" value="2"></p-overlayBadge>\n`);
+    });
+
+    it('renames a [size] binding on all selector variants', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-overlay-badge [size]="s"></p-overlay-badge><p-overlaybadge [size]="s"></p-overlaybadge>\n`
+        });
+        const result = await runner.runSchematic('renamed-inputs', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-overlay-badge [badgeSize]="s"></p-overlay-badge><p-overlaybadge [badgeSize]="s"></p-overlaybadge>\n`);
+    });
+
+    it('renames containerStyleClass and containerStyle on p-treeSelect to class and style', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-treeSelect [options]="nodes" containerStyleClass="w-full" [containerStyle]="{ width: '300px' }"></p-treeSelect>\n`
+        });
+        const result = await runner.runSchematic('renamed-inputs', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-treeSelect [options]="nodes" class="w-full" [style]="{ width: '300px' }"></p-treeSelect>\n`);
+    });
+
+    it('does not rename containerStyle on other components', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-galleria [containerStyle]="{ 'max-width': '640px' }"></p-galleria>\n`
+        });
+        const result = await runner.runSchematic('renamed-inputs', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-galleria [containerStyle]="{ 'max-width': '640px' }"></p-galleria>\n`);
+    });
+
+    it('rewrites inside an inline component template only', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/card.component.ts':
+                `import { Component } from '@angular/core';\n` +
+                '@Component({\n' +
+                "    selector: 'app-card',\n" +
+                '    template: `<p-overlayBadge size="large" [value]="count"><i class="pi pi-bell"></i></p-overlayBadge>`\n' +
+                '})\n' +
+                `export class CardComponent {\n` +
+                `    count = 2;\n` +
+                `    note = 'a size="x" string elsewhere should be untouched';\n` +
+                `}\n`
+        });
+        const result = await runner.runSchematic('renamed-inputs', {}, tree);
+        const text = result.readContent('/src/app/card.component.ts');
+        expect(text).toContain('<p-overlayBadge badgeSize="large" [value]="count">');
+        expect(text).toContain(`note = 'a size="x" string elsewhere should be untouched';`);
+    });
+
+    it('leaves size on elements that are not in the rename table', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-avatar size="xlarge"></p-avatar><p-badge size="small"></p-badge>\n`
+        });
+        const result = await runner.runSchematic('renamed-inputs', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-avatar size="xlarge"></p-avatar><p-badge size="small"></p-badge>\n`);
+    });
+
+    it('reports a conflict instead of rewriting when badgeSize is already present', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-overlayBadge size="small" badgeSize="large"></p-overlayBadge>\n`
+        });
+        const result = await runner.runSchematic('renamed-inputs', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-overlayBadge size="small" badgeSize="large"></p-overlayBadge>\n`);
+    });
+
+    it('does not touch badgeSize itself when only badgeSize is present', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-overlayBadge badgeSize="large"></p-overlayBadge>\n`
+        });
+        const result = await runner.runSchematic('renamed-inputs', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-overlayBadge badgeSize="large"></p-overlayBadge>\n`);
+    });
+});

--- a/packages/optimus-ui/schematics/test/styleclass-to-class.spec.ts
+++ b/packages/optimus-ui/schematics/test/styleclass-to-class.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { createAppTree, createMigrationRunner } from './helpers';
+
+describe('styleclass-to-class', () => {
+    it('renames a static styleClass attribute on p-tag in a template file', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-tag value="New" severity="success" styleClass="font-medium"></p-tag>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-tag value="New" severity="success" class="font-medium"></p-tag>\n`);
+    });
+
+    it('renames a [styleClass] binding on p-tag', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-tag [value]="v" [styleClass]="klass"></p-tag>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-tag [value]="v" [class]="klass"></p-tag>\n`);
+    });
+
+    it('merges styleClass into an existing static class attribute', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-tag class="mr-2" styleClass="font-medium" value="X"></p-tag>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-tag class="mr-2 font-medium" value="X"></p-tag>\n`);
+    });
+
+    it('handles > characters inside other attribute values on the same tag', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-tag [severity]="count > 3 ? 'danger' : 'info'" styleClass="font-medium" [value]="v"></p-tag>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-tag [severity]="count > 3 ? 'danger' : 'info'" class="font-medium" [value]="v"></p-tag>\n`);
+    });
+
+    it('rewrites inside an inline component template only', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/card.component.ts':
+                `import { Component } from '@angular/core';\n` +
+                '@Component({\n' +
+                "    selector: 'app-card',\n" +
+                '    template: `<p-tag styleClass="mb-1" [value]="status"></p-tag>`\n' +
+                '})\n' +
+                `export class CardComponent {\n` +
+                `    status = 'ok';\n` +
+                `    note = 'a styleClass="x" string elsewhere should be untouched';\n` +
+                `}\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        const text = result.readContent('/src/app/card.component.ts');
+        expect(text).toContain('<p-tag class="mb-1" [value]="status"></p-tag>');
+        expect(text).toContain(`note = 'a styleClass="x" string elsewhere should be untouched';`);
+    });
+
+    it('leaves styleClass on components that are not migrated yet', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-drawer styleClass="x"></p-drawer><p-button styleClass="y"></p-button>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-drawer styleClass="x"></p-drawer><p-button styleClass="y"></p-button>\n`);
+    });
+
+    it('reports a conflict instead of rewriting when [class] is already bound', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-tag [class]="a" [styleClass]="b"></p-tag>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-tag [class]="a" [styleClass]="b"></p-tag>\n`);
+    });
+
+    it('rewrites the wave-1 selectors independently, including the p-inputgroup / p-inputgroup-addon prefix pair', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html':
+                `<p-inputgroup styleClass="g"><p-inputgroup-addon styleClass="a">$</p-inputgroup-addon></p-inputgroup>\n` +
+                `<p-iconfield [styleClass]="f"><p-inputicon styleClass="i" /></p-iconfield>\n` +
+                `<p-avatar-group styleClass="av"></p-avatar-group>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(
+            `<p-inputgroup class="g"><p-inputgroup-addon class="a">$</p-inputgroup-addon></p-inputgroup>\n` + `<p-iconfield [class]="f"><p-inputicon class="i" /></p-iconfield>\n` + `<p-avatar-group class="av"></p-avatar-group>\n`
+        );
+    });
+
+    it('does not confuse a p-tag prefix with longer selectors', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-tag-cloud styleClass="x"></p-tag-cloud><p-tag styleClass="y"></p-tag>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-tag-cloud styleClass="x"></p-tag-cloud><p-tag class="y"></p-tag>\n`);
+    });
+});

--- a/packages/optimus-ui/schematics/utils/removed-inputs.ts
+++ b/packages/optimus-ui/schematics/utils/removed-inputs.ts
@@ -1,0 +1,131 @@
+import * as ts from 'typescript';
+import { findOpeningTags } from './styleclass';
+
+interface Edit {
+    start: number;
+    end: number;
+    replacement: string;
+}
+
+export interface DeadInputResult {
+    text: string;
+    changed: boolean;
+    /** Number of attribute/binding usages removed. */
+    removed: number;
+}
+
+function bindingRegex(name: string): RegExp {
+    // `[name]="..."` property binding, single- or double-quoted, leading whitespace included so
+    // removal leaves no stray gap between the surrounding attributes.
+    const escaped = escapeRegExp(name);
+    return new RegExp(`\\s*\\[${escaped}\\]\\s*=\\s*(["'])(?:\\\\.|(?!\\1)[^\\\\])*\\1`);
+}
+
+function staticRegex(name: string): RegExp {
+    // `name="..."` static attribute (not a `[name]` binding).
+    const escaped = escapeRegExp(name);
+    return new RegExp(`\\s*(?<!\\[)\\b${escaped}\\s*=\\s*(["'])(?:\\\\.|(?!\\1)[^\\\\])*\\1`);
+}
+
+/**
+ * Removes `[name]="..."` bindings and `name="..."` static attributes for the given removed input
+ * names, but only on elements matching the given selectors — the same input name may still exist
+ * on other components, so a blind global removal would produce false positives.
+ */
+export function removeDeadInputs(html: string, selectors: readonly string[], names: readonly string[]): DeadInputResult {
+    const edits: Edit[] = [];
+    let removed = 0;
+
+    for (const selector of selectors) {
+        for (const [start, end] of findOpeningTags(html, selector)) {
+            const tag = html.slice(start, end);
+            let updated = tag;
+
+            for (const name of names) {
+                const binding = bindingRegex(name);
+                if (binding.test(updated)) {
+                    updated = updated.replace(binding, '');
+                    removed++;
+                }
+                const stat = staticRegex(name);
+                if (stat.test(updated)) {
+                    updated = updated.replace(stat, '');
+                    removed++;
+                }
+            }
+
+            if (updated !== tag) {
+                edits.push({ start, end, replacement: updated });
+            }
+        }
+    }
+
+    if (edits.length === 0) {
+        return { text: html, changed: false, removed };
+    }
+    edits.sort((a, b) => b.start - a.start);
+    let text = html;
+    for (const edit of edits) {
+        text = text.slice(0, edit.start) + edit.replacement + text.slice(edit.end);
+    }
+    return { text, changed: true, removed };
+}
+
+/**
+ * Same removal, applied only inside the `template: \`...\`` string literal of an `@Component`
+ * decorator in a TypeScript source file — mirrors utils/removed-outputs.ts so unrelated string
+ * literals elsewhere in the file are never touched.
+ */
+export function removeDeadInputsInTypeScript(fileName: string, text: string, selectors: readonly string[], names: readonly string[]): DeadInputResult {
+    const sourceFile = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
+    const edits: Edit[] = [];
+    let removed = 0;
+
+    const visit = (node: ts.Node): void => {
+        if (ts.isPropertyAssignment(node) && isTemplateProperty(node) && isInsideDecorator(node)) {
+            const initializer = node.initializer;
+            if (ts.isStringLiteralLike(initializer)) {
+                const raw = initializer.getText(sourceFile);
+                const quote = raw[0];
+                const body = raw.slice(1, -1);
+                const result = removeDeadInputs(body, selectors, names);
+                if (result.changed) {
+                    edits.push({ start: initializer.getStart(sourceFile), end: initializer.getEnd(), replacement: `${quote}${result.text}${quote}` });
+                    removed += result.removed;
+                }
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+
+    if (edits.length === 0) {
+        return { text, changed: false, removed };
+    }
+    edits.sort((a, b) => b.start - a.start);
+    let result = text;
+    for (const edit of edits) {
+        result = result.slice(0, edit.start) + edit.replacement + result.slice(edit.end);
+    }
+    return { text: result, changed: true, removed };
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isTemplateProperty(node: ts.PropertyAssignment): boolean {
+    const name = node.name;
+    return (ts.isIdentifier(name) || ts.isStringLiteral(name)) && name.text === 'template';
+}
+
+function isInsideDecorator(node: ts.Node): boolean {
+    let current: ts.Node | undefined = node.parent;
+    while (current) {
+        if (ts.isDecorator(current)) {
+            return true;
+        }
+        current = current.parent;
+    }
+    return false;
+}

--- a/packages/optimus-ui/schematics/utils/rename-input.ts
+++ b/packages/optimus-ui/schematics/utils/rename-input.ts
@@ -1,0 +1,144 @@
+import * as ts from 'typescript';
+import { findOpeningTags } from './styleclass';
+
+interface Edit {
+    start: number;
+    end: number;
+    replacement: string;
+}
+
+export interface RenameInputSpec {
+    /** Element selectors the rename applies to (list every selector variant of the component). */
+    selectors: readonly string[];
+    /** Old input name. */
+    from: string;
+    /** New input name. */
+    to: string;
+}
+
+export interface RenameResult {
+    text: string;
+    changed: boolean;
+    /** Number of attributes/bindings renamed. */
+    renamed: number;
+    /** 0-based offsets of tags skipped because they already carry the target attribute/binding. */
+    conflicts: number[];
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Renames a removed/renamed input on elements matching the given selectors:
+ *
+ * - `from="x"`   → `to="x"`
+ * - `[from]="e"` → `[to]="e"`
+ *
+ * A tag that already carries the target input (either form) keeps its `from` attribute untouched
+ * and is reported as a conflict for manual review — the target value is assumed to be the one the
+ * author wants to keep.
+ */
+export function renameInput(html: string, spec: RenameInputSpec): RenameResult {
+    const edits: Edit[] = [];
+    const conflicts: number[] = [];
+    let renamed = 0;
+
+    const from = escapeRegExp(spec.from);
+    const to = escapeRegExp(spec.to);
+    const fromBinding = new RegExp(`\\[${from}\\]\\s*=`);
+    const fromStatic = new RegExp(`(?<![\\[\\w-])${from}\\s*=\\s*(["'])`);
+    const toPresent = new RegExp(`(?:\\[${to}\\]|(?<![\\[\\w-])${to})\\s*=`);
+
+    for (const selector of spec.selectors) {
+        for (const [start, end] of findOpeningTags(html, selector)) {
+            const tag = html.slice(start, end);
+            const hasFrom = fromBinding.test(tag) || fromStatic.test(tag);
+            if (!hasFrom) {
+                continue;
+            }
+            if (toPresent.test(tag)) {
+                conflicts.push(start);
+                continue;
+            }
+            let updated = tag;
+            if (fromBinding.test(updated)) {
+                updated = updated.replace(fromBinding, (m) => m.replace(`[${spec.from}]`, `[${spec.to}]`));
+                renamed++;
+            }
+            if (fromStatic.test(updated)) {
+                updated = updated.replace(fromStatic, (m) => m.replace(spec.from, spec.to));
+                renamed++;
+            }
+            if (updated !== tag) {
+                edits.push({ start, end, replacement: updated });
+            }
+        }
+    }
+
+    if (edits.length === 0) {
+        return { text: html, changed: false, renamed, conflicts };
+    }
+    edits.sort((a, b) => b.start - a.start);
+    let text = html;
+    for (const edit of edits) {
+        text = text.slice(0, edit.start) + edit.replacement + text.slice(edit.end);
+    }
+    return { text, changed: true, renamed, conflicts };
+}
+
+/**
+ * Same rename, applied only inside the `template: \`...\`` string literal of an `@Component`
+ * decorator in a TypeScript source file.
+ */
+export function renameInputInTypeScript(fileName: string, text: string, spec: RenameInputSpec): RenameResult {
+    const sourceFile = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
+    const edits: Edit[] = [];
+    const conflicts: number[] = [];
+    let renamed = 0;
+
+    const visit = (node: ts.Node): void => {
+        if (ts.isPropertyAssignment(node) && isTemplateProperty(node) && isInsideDecorator(node)) {
+            const initializer = node.initializer;
+            if (ts.isStringLiteralLike(initializer)) {
+                const raw = initializer.getText(sourceFile);
+                const quote = raw[0];
+                const body = raw.slice(1, -1);
+                const result = renameInput(body, spec);
+                renamed += result.renamed;
+                conflicts.push(...result.conflicts.map(() => initializer.getStart(sourceFile)));
+                if (result.changed) {
+                    edits.push({ start: initializer.getStart(sourceFile), end: initializer.getEnd(), replacement: `${quote}${result.text}${quote}` });
+                }
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+
+    if (edits.length === 0) {
+        return { text, changed: false, renamed, conflicts };
+    }
+    edits.sort((a, b) => b.start - a.start);
+    let result = text;
+    for (const edit of edits) {
+        result = result.slice(0, edit.start) + edit.replacement + result.slice(edit.end);
+    }
+    return { text: result, changed: true, renamed, conflicts };
+}
+
+function isTemplateProperty(node: ts.PropertyAssignment): boolean {
+    const name = node.name;
+    return (ts.isIdentifier(name) || ts.isStringLiteral(name)) && name.text === 'template';
+}
+
+function isInsideDecorator(node: ts.Node): boolean {
+    let current: ts.Node | undefined = node.parent;
+    while (current) {
+        if (ts.isDecorator(current)) {
+            return true;
+        }
+        current = current.parent;
+    }
+    return false;
+}

--- a/packages/optimus-ui/schematics/utils/styleclass.ts
+++ b/packages/optimus-ui/schematics/utils/styleclass.ts
@@ -1,0 +1,170 @@
+import * as ts from 'typescript';
+
+interface Edit {
+    start: number;
+    end: number;
+    replacement: string;
+}
+
+export interface StyleClassResult {
+    text: string;
+    changed: boolean;
+    /** Number of styleClass attributes/bindings rewritten to class. */
+    renamed: number;
+    /** 0-based offsets (in the given fragment) of tags skipped because they already carry a [class] binding. */
+    conflicts: number[];
+}
+
+/**
+ * Finds the opening tags of the given element selectors in an HTML fragment, tolerating `>`
+ * characters inside quoted attribute values (e.g. `[severity]="a > b ? 'x' : 'y'"`). Returns
+ * [start, end] offsets of each opening tag, end exclusive (position after the closing `>`).
+ */
+export function findOpeningTags(html: string, selector: string): Array<[number, number]> {
+    const tags: Array<[number, number]> = [];
+    const open = new RegExp(`<${selector}(?=[\\s/>])`, 'g');
+    let match: RegExpExecArray | null;
+    while ((match = open.exec(html)) !== null) {
+        let i = match.index + match[0].length;
+        let quote: string | null = null;
+        while (i < html.length) {
+            const ch = html[i];
+            if (quote) {
+                if (ch === quote) {
+                    quote = null;
+                }
+            } else if (ch === '"' || ch === "'") {
+                quote = ch;
+            } else if (ch === '>') {
+                tags.push([match.index, i + 1]);
+                break;
+            }
+            i++;
+        }
+    }
+    return tags;
+}
+
+const STYLECLASS_BINDING = /\s*\[styleClass\]\s*=\s*(["'])((?:\\.|(?!\1)[^\\])*)\1/;
+const STYLECLASS_STATIC = /\s*(?<!\[)\bstyleClass\s*=\s*(["'])((?:\\.|(?!\1)[^\\])*)\1/;
+const CLASS_BINDING = /\[class\]\s*=/;
+const CLASS_STATIC = /\sclass\s*=\s*(["'])((?:\\.|(?!\1)[^\\])*)\1/;
+
+/**
+ * Rewrites the removed `styleClass` input to the plain `class` attribute on elements matching the
+ * given selectors:
+ *
+ * - `styleClass="x"` becomes `class="x"`, merged into an existing static `class` attribute when
+ *   one is present (`class="a" styleClass="x"` → `class="a x"`).
+ * - `[styleClass]="expr"` becomes `[class]="expr"` (Angular merges a static `class` attribute
+ *   with a `[class]` binding, so coexistence with `class="a"` keeps its behavior).
+ * - A tag that already carries BOTH `[styleClass]` and `[class]` is left untouched and reported
+ *   as a conflict for manual review — rewriting would produce two competing `[class]` bindings.
+ */
+export function migrateStyleClass(html: string, selectors: readonly string[]): StyleClassResult {
+    const edits: Edit[] = [];
+    const conflicts: number[] = [];
+    let renamed = 0;
+
+    for (const selector of selectors) {
+        for (const [start, end] of findOpeningTags(html, selector)) {
+            const tag = html.slice(start, end);
+            let updated = tag;
+
+            const binding = STYLECLASS_BINDING.exec(updated);
+            if (binding) {
+                if (CLASS_BINDING.test(updated)) {
+                    conflicts.push(start);
+                } else {
+                    updated = updated.replace(STYLECLASS_BINDING, (m) => m.replace('[styleClass]', '[class]'));
+                    renamed++;
+                }
+            }
+
+            const stat = STYLECLASS_STATIC.exec(updated);
+            if (stat) {
+                const value = stat[2];
+                const existing = CLASS_STATIC.exec(updated);
+                if (existing) {
+                    // merge into the existing static class attribute, drop styleClass
+                    updated = updated.replace(STYLECLASS_STATIC, '');
+                    updated = updated.replace(CLASS_STATIC, (m, quote: string, classes: string) => m.replace(`${quote}${classes}${quote}`, `${quote}${classes} ${value}${quote}`));
+                } else {
+                    updated = updated.replace(STYLECLASS_STATIC, (m) => m.replace(/\bstyleClass\b/, 'class'));
+                }
+                renamed++;
+            }
+
+            if (updated !== tag) {
+                edits.push({ start, end, replacement: updated });
+            }
+        }
+    }
+
+    if (edits.length === 0) {
+        return { text: html, changed: false, renamed, conflicts };
+    }
+    edits.sort((a, b) => b.start - a.start);
+    let text = html;
+    for (const edit of edits) {
+        text = text.slice(0, edit.start) + edit.replacement + text.slice(edit.end);
+    }
+    return { text, changed: true, renamed, conflicts };
+}
+
+/**
+ * Same rewrite, applied only inside the `template: \`...\`` string literal of an `@Component`
+ * decorator in a TypeScript source file — mirrors utils/removed-outputs.ts so unrelated string
+ * literals elsewhere in the file are never touched.
+ */
+export function migrateStyleClassInTypeScript(fileName: string, text: string, selectors: readonly string[]): StyleClassResult {
+    const sourceFile = ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
+    const edits: Edit[] = [];
+    const conflicts: number[] = [];
+    let renamed = 0;
+
+    const visit = (node: ts.Node): void => {
+        if (ts.isPropertyAssignment(node) && isTemplateProperty(node) && isInsideDecorator(node)) {
+            const initializer = node.initializer;
+            if (ts.isStringLiteralLike(initializer)) {
+                const raw = initializer.getText(sourceFile);
+                const quote = raw[0];
+                const body = raw.slice(1, -1);
+                const result = migrateStyleClass(body, selectors);
+                renamed += result.renamed;
+                conflicts.push(...result.conflicts.map(() => initializer.getStart(sourceFile)));
+                if (result.changed) {
+                    edits.push({ start: initializer.getStart(sourceFile), end: initializer.getEnd(), replacement: `${quote}${result.text}${quote}` });
+                }
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+
+    if (edits.length === 0) {
+        return { text, changed: false, renamed, conflicts };
+    }
+    edits.sort((a, b) => b.start - a.start);
+    let result = text;
+    for (const edit of edits) {
+        result = result.slice(0, edit.start) + edit.replacement + result.slice(edit.end);
+    }
+    return { text: result, changed: true, renamed, conflicts };
+}
+
+function isTemplateProperty(node: ts.PropertyAssignment): boolean {
+    const name = node.name;
+    return (ts.isIdentifier(name) || ts.isStringLiteral(name)) && name.text === 'template';
+}
+
+function isInsideDecorator(node: ts.Node): boolean {
+    let current: ts.Node | undefined = node.parent;
+    while (current) {
+        if (ts.isDecorator(current)) {
+            return true;
+        }
+        current = current.parent;
+    }
+    return false;
+}


### PR DESCRIPTION
Adds three migrations to the ng-update pipeline: remove-dead-inputs
(bindings of inputs that were declared but never read), renamed-inputs
(deprecated aliases dropped in favor of the input actually read), and
styleclass-to-class (components whose styleClass input was replaced by
the native class attribute). Selector-scoped template rewrites for both
.html files and inline @Component templates, with conflict reporting;
covered by the schematics test suite.

This is the dedicated migration PR: the three ng-update schematics that rewrite consumer templates for the input removals/renames shipped by the component PRs.
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5