### PR TITLE
docs(landing): replace removed styleClass usages with class

### DIFF
--- a/apps/docs/pages/landing/herosection.component.ts
+++ b/apps/docs/pages/landing/herosection.component.ts
@@ -240,7 +240,7 @@ import { OverviewApp } from './samples/overviewapp.component';
                                 <div class="overflow-y-auto flex-1 bg-surface-0 dark:bg-surface-900 mt-2 flex flex-col rounded-lg overflow-hidden divide-y divide-surface-200 dark:divide-surface-800">
                                     <div *ngFor="let data of callLogs" class="flex items-center gap-3 p-2">
                                         <p-overlayBadge severity="success" styleClass="w-fit">
-                                            <p-avatar [image]="data.image" size="normal" styleClass="rounded-md w-10 h-10 overflow-hidden flex" />
+                                            <p-avatar [image]="data.image" size="normal" class="rounded-md w-10 h-10 overflow-hidden flex" />
                                         </p-overlayBadge>
 
                                         <div class="flex-1">
@@ -259,7 +259,7 @@ import { OverviewApp } from './samples/overviewapp.component';
                                 <div class="overflow-y-auto flex-1 bg-surface-0 dark:bg-surface-900 mt-2 flex flex-col rounded-lg overflow-hidden divide-y divide-surface-200 dark:divide-surface-800">
                                     <div *ngFor="let data of emailRecords" class="flex items-center gap-3 p-2">
                                         <p-overlayBadge severity="danger" styleClass="w-fit">
-                                            <p-avatar [image]="data.image" size="normal" styleClass="rounded-md overflow-hidden w-10 h-10 flex" />
+                                            <p-avatar [image]="data.image" size="normal" class="rounded-md overflow-hidden w-10 h-10 flex" />
                                         </p-overlayBadge>
 
                                         <div class="w-1/5 text-sm leading-5 font-medium text-color">{{ data.name }}</div>
@@ -340,7 +340,7 @@ import { OverviewApp } from './samples/overviewapp.component';
                                         <div class="font-medium text-color p-2">Customer Satisfaction Score</div>
                                     </div>
                                     <div class="flex-1 py-4 mt-2 flex items-center justify-center rounded-lg bg-surface-0 dark:bg-surface-900 shadow-sm">
-                                        <p-knob [(ngModel)]="customerSatisfaction" [size]="150" [strokeWidth]="8" valueTemplate="{value}%" styleClass="pointer-events-none" />
+                                        <p-knob [(ngModel)]="customerSatisfaction" [size]="150" [strokeWidth]="8" valueTemplate="{value}%" class="pointer-events-none" />
                                     </div>
                                 </div>
                                 <div class="w-full h-full flex flex-col p-3 rounded-xl bg-emphasis">

--- a/apps/docs/pages/landing/samples/cardsapp.component.ts
+++ b/apps/docs/pages/landing/samples/cardsapp.component.ts
@@ -266,7 +266,7 @@ import { TooltipModule } from '@openng/optimus-ui/tooltip';
                     </div>
                     <div>
                         <label class="text-color font-medium leading-6">Tag (Optional)</label>
-                        <p-autocomplete [(ngModel)]="filesTag" styleClass="w-full mt-2" inputId="multiple-ac-2" multiple (completeMethod)="search($event)" [typeahead]="false" />
+                        <p-autocomplete [(ngModel)]="filesTag" class="w-full mt-2" inputId="multiple-ac-2" multiple (completeMethod)="search($event)" [typeahead]="false" />
                     </div>
                     <div class="flex items-center gap-2">
                         <label
@@ -313,7 +313,7 @@ import { TooltipModule } from '@openng/optimus-ui/tooltip';
                     <div>
                         <div class="text-muted-color leading-6">Email</div>
                         <div class="flex items-start gap-3 mt-2">
-                            <p-autocomplete [(ngModel)]="emailChips" inputId="multiple-ac-2" styleClass="w-full" class="flex-1" multiple (onSelect)="search($event)" [typeahead]="false" />
+                            <p-autocomplete [(ngModel)]="emailChips" inputId="multiple-ac-2" class="w-full flex-1" multiple (onSelect)="search($event)" [typeahead]="false" />
                             <p-button label="Invite" />
                         </div>
                     </div>
@@ -417,11 +417,11 @@ import { TooltipModule } from '@openng/optimus-ui/tooltip';
                     <div class="mt-4 flex gap-2">
                         <div class="flex-1">
                             <label for="price-min-val" class="leading-6 text-color">Min Value</label>
-                            <p-inputnumber [(ngModel)]="priceRange[0]" [min]="0" inputId="price-min-val" mode="currency" currency="USD" locale="en-US" styleClass="w-full" />
+                            <p-inputnumber [(ngModel)]="priceRange[0]" [min]="0" inputId="price-min-val" mode="currency" currency="USD" locale="en-US" class="w-full" />
                         </div>
                         <div class="flex-1">
                             <label for="price-max-val" class="leading-6 text-color">Max Value</label>
-                            <p-inputnumber [(ngModel)]="priceRange[1]" inputId="price-max-val" mode="currency" currency="USD" locale="en-US" styleClass="w-full" />
+                            <p-inputnumber [(ngModel)]="priceRange[1]" inputId="price-max-val" mode="currency" currency="USD" locale="en-US" class="w-full" />
                         </div>
                     </div>
                     <div class="mt-4">

--- a/apps/docs/pages/landing/samples/chatapp.component.ts
+++ b/apps/docs/pages/landing/samples/chatapp.component.ts
@@ -53,7 +53,7 @@ import { ToggleSwitchModule } from '@openng/optimus-ui/toggleswitch';
                             [ngClass]="{
                                 '!bg-primary-100 !text-primary-950': !chat.image
                             }"
-                            styleClass="text-base font-medium flex"
+                            class="text-base font-medium flex"
                             size="large"
                             shape="circle"
                         />
@@ -76,7 +76,7 @@ import { ToggleSwitchModule } from '@openng/optimus-ui/toggleswitch';
         <div class="w-8/12 xl:w-6/12 border-x border-surface flex flex-col">
             <div class="flex items-center p-4 gap-7 border-b border-surface">
                 <div class="flex items-center">
-                    <p-avatar image="logo-icon.svg" styleClass="mr-2 av" size="large" shape="circle" />
+                    <p-avatar image="logo-icon.svg" class="mr-2 av" size="large" shape="circle" />
                     <div class="flex-1">
                         <div class="text-color leading-6 cursor-pointer hover:text-muted-color-emphasis transition-colors">OpenNG</div>
                         <div class="text-muted-color leading-5 line-clamp-1 mt-1">Cody Fisher, Esther Howard, Jerome Bell, Kristin Watson, Ronald Richards, Darrell Steward</div>
@@ -103,7 +103,7 @@ import { ToggleSwitchModule } from '@openng/optimus-ui/toggleswitch';
                             [ngClass]="{
                                 'bg-primary-100 text-primary-950': !message.image
                             }"
-                            styleClass="w-10 h-10 text-sm font-medium"
+                            class="w-10 h-10 text-sm font-medium"
                             shape="circle"
                         />
                         <div>
@@ -144,7 +144,7 @@ import { ToggleSwitchModule } from '@openng/optimus-ui/toggleswitch';
         </div>
         <div class="w-3/12 xl:block hidden min-w-40 py-6 px-3 overflow-auto">
             <div class="flex flex-col items-center justify-center">
-                <p-avatar image="logo-icon.svg" styleClass="w-32 h-32" size="xlarge" shape="circle" />
+                <p-avatar image="logo-icon.svg" class="w-32 h-32" size="xlarge" shape="circle" />
                 <div class="leading-6 font-medium text-color mt-4 w-full text-center">OpenNG</div>
                 <div class="leading-5 text-sm text-muted-color mt-1 w-full text-center">&#64;openng</div>
                 <div class="flex items-center justify-center flex-wrap gap-1 mt-4">
@@ -186,7 +186,7 @@ import { ToggleSwitchModule } from '@openng/optimus-ui/toggleswitch';
                             [ngClass]="{
                                 'bg-orange-100 text-orange-950': !member.image
                             }"
-                            styleClass="font-medium text-xs"
+                            class="font-medium text-xs"
                             shape="circle"
                         />
 

--- a/apps/docs/pages/landing/samples/customersapp.component.ts
+++ b/apps/docs/pages/landing/samples/customersapp.component.ts
@@ -118,7 +118,7 @@ import { TooltipModule } from '@openng/optimus-ui/tooltip';
                             <div class="leading-6 text-muted-color">{{ data.lead }}</div>
                         </td>
                         <td>
-                            <p-tag [severity]="data.status === 'Active' ? 'success' : data.status === 'Inactive' ? 'danger' : 'info'" [value]="data.status" styleClass="font-medium" />
+                            <p-tag [severity]="data.status === 'Active' ? 'success' : data.status === 'Inactive' ? 'danger' : 'info'" [value]="data.status" class="font-medium" />
                         </td>
                         <td>
                             <div class="flex justify-end w-full">

--- a/apps/docs/pages/landing/samples/inboxapp.component.ts
+++ b/apps/docs/pages/landing/samples/inboxapp.component.ts
@@ -76,7 +76,7 @@ import { Tag } from '@openng/optimus-ui/tag';
                                 <input type="text" pInputText [(ngModel)]="search" placeholder="Search" class="w-full" />
                             </p-iconfield>
                             <p-button icon="pi pi-filter" outlined severity="secondary" />
-                            <p-divider layout="vertical" styleClass="m-0" />
+                            <p-divider layout="vertical" class="m-0" />
                             <p-button icon="pi pi-refresh" outlined severity="secondary" />
                             <p-button label="1 of 15" class="!whitespace-nowrap" outlined severity="secondary" />
                             <p-button icon="pi pi-chevron-left" outlined severity="secondary" />

--- a/apps/docs/pages/landing/samples/overviewapp.component.ts
+++ b/apps/docs/pages/landing/samples/overviewapp.component.ts
@@ -137,7 +137,7 @@ import { TooltipModule } from '@openng/optimus-ui/tooltip';
                                         <div class="text-muted-color">{{ item.date }}</div>
                                     </td>
                                     <td class="w-1/6">
-                                        <p-tag [severity]="item.process.type" [value]="item.process.value" styleClass="font-medium"></p-tag>
+                                        <p-tag [severity]="item.process.type" [value]="item.process.value" class="font-medium"></p-tag>
                                     </td>
                                     <td class="w-1/6">
                                         <div class="text-muted-color text-right">{{ item.amount }}</div>

--- a/apps/docs/pages/landing/themesection.component.ts
+++ b/apps/docs/pages/landing/themesection.component.ts
@@ -111,7 +111,7 @@ import { Tag } from '@openng/optimus-ui/tag';
                                     {{ customer.balance | currency: 'USD' : 'symbol' }}
                                 </td>
                                 <td style="width: 14%; min-width: 10rem">
-                                    <p-tag [value]="customer.status" [severity]="getSeverity(customer.status)" styleClass="text-sm font-bold"></p-tag>
+                                    <p-tag [value]="customer.status" [severity]="getSeverity(customer.status)" class="text-sm font-bold"></p-tag>
                                 </td>
                                 <td style="width: 14%; min-width: 6rem">
                                     <p-progressbar [value]="customer.activity" [showValue]="false" [style]="{ height: '6px' }"></p-progressbar>

--- a/apps/docs/pages/roadmap/index.ts
+++ b/apps/docs/pages/roadmap/index.ts
@@ -18,7 +18,7 @@ import { TimelineModule } from '@openng/optimus-ui/timeline';
             </div>
 
             <div class="card mt-8">
-                <p-timeline [value]="events" align="alternate" styleClass="customized-timeline">
+                <p-timeline [value]="events" align="alternate" class="customized-timeline">
                     <ng-template #content let-event>
                         <div class="p-4 mb-4 border rounded-xl shadow-sm bg-surface-0 dark:bg-surface-900 border-surface-200 dark:border-surface-800">
                             <div class="flex items-center gap-2 mb-2">


### PR DESCRIPTION
The landing samples and roadmap page bound styleClass on components
whose styleClass input is removed in 3.0 (avatar, knob, autocomplete,
inputnumber, tag, divider, timeline); the native class attribute lands
on the same host element. Safe to merge before or after the component
branches.
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5