### PR TITLE
refactor(badge,breadcrumb,dock,megamenu,menu,overlaybadge): migrate to signals

### DIFF
--- a/packages/optimus-ui/src/badge/badge.test.ts
+++ b/packages/optimus-ui/src/badge/badge.test.ts
@@ -56,7 +56,7 @@ class TestDisabledBadgeComponent {
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
     selector: 'test-style-class-badge',
-    template: `<p-badge [styleClass]="styleClass" value="1"></p-badge>`
+    template: `<p-badge [class]="styleClass" value="1"></p-badge>`
 })
 class TestStyleClassBadgeComponent {
     styleClass = 'custom-badge';
@@ -133,7 +133,7 @@ class TestDeprecatedSizeBadgeComponent {
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
     selector: 'test-dynamic-badge',
-    template: ` <p-badge [value]="value" [badgeSize]="badgeSize" [severity]="severity" [badgeDisabled]="disabled" [styleClass]="styleClass"> </p-badge> `
+    template: ` <p-badge [value]="value" [badgeSize]="badgeSize" [severity]="severity" [badgeDisabled]="disabled" [class]="styleClass"> </p-badge> `
 })
 class TestDynamicBadgeComponent {
     value: string | number | null = '1';
@@ -191,7 +191,6 @@ describe('Badge', () => {
                 expect(component.size()).toBeUndefined();
                 expect(component.severity()).toBeUndefined();
                 expect(component.badgeDisabled()).toBe(false);
-                expect(component.styleClass()).toBeUndefined();
             });
 
             it('should apply base CSS classes', () => {

--- a/packages/optimus-ui/src/badge/badge.ts
+++ b/packages/optimus-ui/src/badge/badge.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, Directive, effect, inject, InjectionToken, Input, input, NgModule, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import { afterEveryRender, afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, computed, Directive, effect, inject, input, NgModule, untracked, ViewEncapsulation } from '@angular/core';
 import { addClass, createElement, hasClass, isNotEmpty, removeClass, uuid } from '@openng/optimus-ui-utils';
 import { SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -6,21 +6,17 @@ import { Bind, BindModule } from '@openng/optimus-ui/bind';
 import type { BadgePassThrough, BadgeSeverity } from '@openng/optimus-ui/types/badge';
 import { BadgeStyle } from './style/badgestyle';
 
-const BADGE_INSTANCE = new InjectionToken<Badge>('BADGE_INSTANCE');
-
-const BADGE_DIRECTIVE_INSTANCE = new InjectionToken<BadgeDirective>('BADGE_DIRECTIVE_INSTANCE');
-
 /**
  * Badge Directive is directive usage of badge component.
  * @group Components
  */
 @Directive({
     selector: '[pBadge]',
-    providers: [BadgeStyle, { provide: BADGE_DIRECTIVE_INSTANCE, useExisting: BadgeDirective }, { provide: PARENT_INSTANCE, useExisting: BadgeDirective }],
+    providers: [BadgeStyle, { provide: PARENT_INSTANCE, useExisting: BadgeDirective }],
     standalone: true
 })
 export class BadgeDirective extends BaseComponent {
-    $pcBadgeDirective: BadgeDirective | undefined = inject(BADGE_DIRECTIVE_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
+    _componentStyle = inject(BadgeStyle);
 
     /**
      * Used to pass attributes to DOM elements inside the Badge component.
@@ -29,74 +25,74 @@ export class BadgeDirective extends BaseComponent {
      * @group Props
      */
     ptBadgeDirective = input<BadgePassThrough | undefined>();
+
     /**
      * Used to pass attributes to DOM elements inside the Badge component.
      * @defaultValue undefined
      * @group Props
      */
     pBadgePT = input<BadgePassThrough | undefined>();
+
     /**
      * Indicates whether the component should be rendered without styles.
      * @defaultValue undefined
      * @group Props
      */
     pBadgeUnstyled = input<boolean | undefined>();
+
     /**
      * When specified, disables the component.
      * @group Props
      */
-    @Input('badgeDisabled') public disabled: boolean;
+    readonly disabled = input<boolean>(false, { alias: 'badgeDisabled' });
+
     /**
      * Size of the badge, valid options are "large" and "xlarge".
      * @group Props
      */
-    @Input() public badgeSize: 'large' | 'xlarge' | 'small' | null | undefined;
+    readonly badgeSize = input<'large' | 'xlarge' | 'small' | null>();
+
     /**
      * Size of the badge, valid options are "large" and "xlarge".
      * @group Props
      * @deprecated use badgeSize instead.
      */
-    @Input() public set size(value: 'large' | 'xlarge' | 'small' | null | undefined) {
-        this._size = value;
-        console.log('size property is deprecated and will removed in v18, use badgeSize instead.');
-    }
-    get size() {
-        return this._size;
-    }
-    _size: 'large' | 'xlarge' | 'small' | null | undefined;
+    readonly size = input<'large' | 'xlarge' | 'small' | null>();
+
     /**
      * Severity type of the badge.
      * @group Props
      */
-    @Input() severity: BadgeSeverity | null | undefined;
+    readonly severity = input<BadgeSeverity | null>();
+
     /**
      * Value to display inside the badge.
      * @group Props
      */
-    @Input() public value: string | number;
+    readonly value = input<string | number>();
+
     /**
      * Inline style of the element.
      * @group Props
      */
-    @Input() badgeStyle: { [klass: string]: any } | null | undefined;
+    readonly badgeStyle = input<{ [klass: string]: any } | null>();
+
     /**
      * Class of the element.
      * @group Props
      */
-    @Input() badgeStyleClass: string;
+    readonly badgeStyleClass = input<string>();
 
     private id!: string;
 
     badgeEl: HTMLElement;
-
-    _componentStyle = inject(BadgeStyle);
 
     private get activeElement(): HTMLElement {
         return this.el.nativeElement.nodeName.indexOf('-') != -1 ? this.el.nativeElement.firstChild : this.el.nativeElement;
     }
 
     private get canUpdateBadge(): boolean {
-        return isNotEmpty(this.id) && !this.disabled;
+        return isNotEmpty(this.id) && !this.disabled();
     }
 
     constructor() {
@@ -109,39 +105,60 @@ export class BadgeDirective extends BaseComponent {
         effect(() => {
             this.pBadgeUnstyled() && this.directiveUnstyled.set(this.pBadgeUnstyled());
         });
-    }
 
-    onChanges(changes: SimpleChanges): void {
-        const { value, size, severity, disabled, badgeStyle, badgeStyleClass } = changes;
+        // React to input changes on the rendered badge element (replaces the former ngOnChanges).
+        // Before the badge element exists (id unset) every branch is a guarded no-op, matching the
+        // original behavior where updates only applied after the initial render.
+        effect(() => {
+            this.disabled();
+            untracked(() => this.toggleDisableState());
+        });
 
-        if (disabled) {
-            this.toggleDisableState();
-        }
+        let previousSeverity: BadgeSeverity | null | undefined;
+        effect(() => {
+            const severity = this.severity();
+            untracked(() => {
+                if (this.canUpdateBadge) {
+                    this.setSeverity(previousSeverity);
+                }
+                previousSeverity = severity;
+            });
+        });
 
-        if (!this.canUpdateBadge) {
-            return;
-        }
+        effect(() => {
+            this.size();
+            this.badgeSize();
+            untracked(() => {
+                if (this.canUpdateBadge) {
+                    this.setSizeClasses();
+                }
+            });
+        });
 
-        if (severity) {
-            this.setSeverity(severity.previousValue);
-        }
+        effect(() => {
+            this.value();
+            untracked(() => {
+                if (this.canUpdateBadge) {
+                    this.setValue();
+                }
+            });
+        });
 
-        if (size) {
-            this.setSizeClasses();
-        }
+        effect(() => {
+            this.badgeStyle();
+            this.badgeStyleClass();
+            untracked(() => {
+                if (this.canUpdateBadge) {
+                    this.applyStyles();
+                }
+            });
+        });
 
-        if (value) {
-            this.setValue();
-        }
-
-        if (badgeStyle || badgeStyleClass) {
-            this.applyStyles();
-        }
-    }
-
-    onAfterViewInit(): void {
-        this.id = uuid('pn_id_') + '_badge';
-        this.renderBadgeContent();
+        // Initial badge rendering (replaces the former ngAfterViewInit hook).
+        afterNextRender(() => {
+            this.id = uuid('pn_id_') + '_badge';
+            this.renderBadgeContent();
+        });
     }
 
     private setValue(element?: HTMLElement): void {
@@ -151,12 +168,12 @@ export class BadgeDirective extends BaseComponent {
             return;
         }
 
-        if (this.value != null) {
+        if (this.value() != null) {
             if (hasClass(badge, 'p-badge-dot')) {
                 removeClass(badge, 'p-badge-dot');
             }
 
-            if (this.value && String(this.value).length === 1) {
+            if (this.value() != null && String(this.value()).length === 1) {
                 addClass(badge, 'p-badge-circle');
             } else {
                 removeClass(badge, 'p-badge-circle');
@@ -170,7 +187,7 @@ export class BadgeDirective extends BaseComponent {
         }
 
         badge.textContent = '';
-        const badgeValue = this.value != null ? String(this.value) : '';
+        const badgeValue = this.value() != null ? String(this.value()) : '';
         this.renderer.appendChild(badge, this.document.createTextNode(badgeValue));
     }
 
@@ -181,23 +198,23 @@ export class BadgeDirective extends BaseComponent {
             return;
         }
 
-        if (this.badgeSize) {
-            if (this.badgeSize === 'large') {
+        if (this.badgeSize()) {
+            if (this.badgeSize() === 'large') {
                 addClass(badge, 'p-badge-lg');
                 removeClass(badge, 'p-badge-xl');
             }
 
-            if (this.badgeSize === 'xlarge') {
+            if (this.badgeSize() === 'xlarge') {
                 addClass(badge, 'p-badge-xl');
                 removeClass(badge, 'p-badge-lg');
             }
-        } else if (this.size && !this.badgeSize) {
-            if (this.size === 'large') {
+        } else if (this.size() && !this.badgeSize()) {
+            if (this.size() === 'large') {
                 addClass(badge, 'p-badge-lg');
                 removeClass(badge, 'p-badge-xl');
             }
 
-            if (this.size === 'xlarge') {
+            if (this.size() === 'xlarge') {
                 addClass(badge, 'p-badge-xl');
                 removeClass(badge, 'p-badge-lg');
             }
@@ -208,7 +225,7 @@ export class BadgeDirective extends BaseComponent {
     }
 
     private renderBadgeContent(): void {
-        if (this.disabled) {
+        if (this.disabled()) {
             return;
         }
 
@@ -224,13 +241,13 @@ export class BadgeDirective extends BaseComponent {
     }
 
     private applyStyles(): void {
-        if (this.badgeEl && this.badgeStyle && typeof this.badgeStyle === 'object') {
-            for (const [key, value] of Object.entries(this.badgeStyle)) {
+        if (this.badgeEl && this.badgeStyle() && typeof this.badgeStyle() === 'object') {
+            for (const [key, value] of Object.entries(this.badgeStyle()!)) {
                 this.renderer.setStyle(this.badgeEl, key, value);
             }
         }
-        if (this.badgeEl && this.badgeStyleClass) {
-            this.badgeEl.classList.add(...this.badgeStyleClass.split(' '));
+        if (this.badgeEl && this.badgeStyleClass()) {
+            this.badgeEl.classList.add(...this.badgeStyleClass()!.split(' '));
         }
     }
 
@@ -241,8 +258,8 @@ export class BadgeDirective extends BaseComponent {
             return;
         }
 
-        if (this.severity) {
-            addClass(badge, `p-badge-${this.severity}`);
+        if (this.severity()) {
+            addClass(badge, `p-badge-${this.severity()}`);
         }
 
         if (oldSeverity) {
@@ -255,7 +272,7 @@ export class BadgeDirective extends BaseComponent {
             return;
         }
 
-        if (this.disabled) {
+        if (this.disabled()) {
             const badge = this.activeElement?.querySelector(`#${this.id}`);
 
             if (badge) {
@@ -277,65 +294,68 @@ export class BadgeDirective extends BaseComponent {
     imports: [SharedModule, BindModule],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [BadgeStyle, { provide: BADGE_INSTANCE, useExisting: Badge }, { provide: PARENT_INSTANCE, useExisting: Badge }],
+    providers: [BadgeStyle, { provide: PARENT_INSTANCE, useExisting: Badge }],
     host: {
-        '[class]': "cn(cx('root'), styleClass())",
+        '[class]': "cx('root')",
         '[style.display]': 'badgeDisabled() ? "none" : null',
-        '[attr.data-p]': 'dataP'
+        '[attr.data-p]': 'dataP()'
     },
     hostDirectives: [Bind]
 })
 export class Badge extends BaseComponent<BadgePassThrough> {
-    componentName = 'Badge';
-
-    $pcBadge: Badge | undefined = inject(BADGE_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
-
     bindDirectiveInstance = inject(Bind, { self: true });
 
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
-    }
-    /**
-     * Class of the element.
-     * @deprecated since v20.0.0, use `class` instead.
-     * @group Props
-     */
-    styleClass = input<string>();
+    _componentStyle = inject(BadgeStyle);
+
     /**
      * Size of the badge, valid options are "large" and "xlarge".
      * @group Props
      */
     badgeSize = input<'small' | 'large' | 'xlarge' | null>();
+
     /**
      * Size of the badge, valid options are "large" and "xlarge".
      * @group Props
      */
     size = input<'small' | 'large' | 'xlarge' | null>();
+
     /**
      * Severity type of the badge.
      * @group Props
      */
     severity = input<BadgeSeverity | null>();
+
     /**
      * Value to display inside the badge.
      * @group Props
      */
     value = input<string | number | null>();
+
     /**
      * When specified, disables the component.
      * @group Props
      */
     badgeDisabled = input<boolean, boolean>(false, { transform: booleanAttribute });
 
-    _componentStyle = inject(BadgeStyle);
+    componentName = 'Badge';
 
-    get dataP() {
-        return this.cn({
+    readonly dataP = computed(() =>
+        this.cn({
             circle: this.value() != null && String(this.value()).length === 1,
             empty: this.value() == null,
             disabled: this.badgeDisabled(),
             [this.severity() as string]: this.severity(),
             [this.size() as string]: this.size()
+        })
+    );
+
+    constructor() {
+        super();
+        // Re-apply the host/root pass-through sections after each render (replaces the former
+        // ngAfterViewChecked hook). Bind.setAttrs writes into a signal behind an equality check,
+        // so unchanged PT resolutions are no-ops.
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
         });
     }
 }

--- a/packages/optimus-ui/src/breadcrumb/breadcrumb.test.ts
+++ b/packages/optimus-ui/src/breadcrumb/breadcrumb.test.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { MenuItem } from '@openng/optimus-ui/api';
+import { MenuItem, SharedModule } from '@openng/optimus-ui/api';
 import { Optimus } from '@openng/optimus-ui/config';
 import { BreadcrumbItemClickEvent } from '@openng/optimus-ui/types/breadcrumb';
 import { Breadcrumb } from './breadcrumb';
@@ -204,6 +204,7 @@ describe('Breadcrumb', () => {
             imports: [
                 Breadcrumb,
                 TestTargetComponent,
+                SharedModule,
 
                 RouterTestingModule.withRoutes([
                     { path: '', component: TestTargetComponent },
@@ -240,11 +241,11 @@ describe('Breadcrumb', () => {
 
             const freshBreadcrumb = freshFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(freshBreadcrumb.model).toBeUndefined();
-            expect(freshBreadcrumb.home).toBeUndefined();
-            expect(freshBreadcrumb.style).toBeUndefined();
-            expect(freshBreadcrumb.styleClass).toBeUndefined();
-            expect(freshBreadcrumb.homeAriaLabel).toBeUndefined();
+            expect(freshBreadcrumb.model()).toBeUndefined();
+            expect(freshBreadcrumb.home()).toBeUndefined();
+            expect(freshBreadcrumb.style()).toBeUndefined();
+            expect(freshBreadcrumb.styleClass()).toBeUndefined();
+            expect(freshBreadcrumb.homeAriaLabel()).toBeUndefined();
         });
 
         it('should accept custom values', async () => {
@@ -259,16 +260,16 @@ describe('Breadcrumb', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model).toBe(testModel);
-            expect(breadcrumbInstance.home).toBe(testHome);
-            expect(breadcrumbInstance.styleClass).toBe('custom-class');
-            expect(breadcrumbInstance.homeAriaLabel).toBe('Custom Home');
+            expect(breadcrumbInstance.model()).toBe(testModel);
+            expect(breadcrumbInstance.home()).toBe(testHome);
+            expect(breadcrumbInstance.styleClass()).toBe('custom-class');
+            expect(breadcrumbInstance.homeAriaLabel()).toBe('Custom Home');
         });
 
         it('should initialize templates properties', () => {
             expect(breadcrumbInstance.templates()).toBeDefined();
-            expect(breadcrumbInstance._itemTemplate).toBeUndefined();
-            expect(breadcrumbInstance._separatorTemplate).toBeUndefined();
+            expect(breadcrumbInstance.$itemTemplate()).toBeUndefined();
+            expect(breadcrumbInstance.$separatorTemplate()).toBeUndefined();
             expect(breadcrumbInstance.itemTemplate()).toBeUndefined();
             expect(breadcrumbInstance.separatorTemplate()).toBeUndefined();
         });
@@ -286,7 +287,7 @@ describe('Breadcrumb', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(breadcrumbInstance.model).toBe(newModel);
+            expect(breadcrumbInstance.model()).toBe(newModel);
         });
 
         it('should update home input', async () => {
@@ -295,7 +296,7 @@ describe('Breadcrumb', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(breadcrumbInstance.home).toBe(newHome);
+            expect(breadcrumbInstance.home()).toBe(newHome);
         });
 
         it('should update style input', async () => {
@@ -304,7 +305,7 @@ describe('Breadcrumb', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(breadcrumbInstance.style).toBe(newStyle);
+            expect(breadcrumbInstance.style()).toBe(newStyle);
         });
 
         it('should update styleClass input', async () => {
@@ -312,7 +313,7 @@ describe('Breadcrumb', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(breadcrumbInstance.styleClass).toBe('test-class');
+            expect(breadcrumbInstance.styleClass()).toBe('test-class');
         });
 
         it('should update homeAriaLabel input', async () => {
@@ -320,7 +321,7 @@ describe('Breadcrumb', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(breadcrumbInstance.homeAriaLabel).toBe('Go to home page');
+            expect(breadcrumbInstance.homeAriaLabel()).toBe('Go to home page');
         });
 
         it('should handle undefined inputs', async () => {
@@ -333,11 +334,11 @@ describe('Breadcrumb', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model).toBeUndefined();
-            expect(breadcrumbInstance.home).toBeUndefined();
-            expect(breadcrumbInstance.style).toBeUndefined();
-            expect(breadcrumbInstance.styleClass).toBeUndefined();
-            expect(breadcrumbInstance.homeAriaLabel).toBeUndefined();
+            expect(breadcrumbInstance.model()).toBeUndefined();
+            expect(breadcrumbInstance.home()).toBeUndefined();
+            expect(breadcrumbInstance.style()).toBeUndefined();
+            expect(breadcrumbInstance.styleClass()).toBeUndefined();
+            expect(breadcrumbInstance.homeAriaLabel()).toBeUndefined();
         });
     });
 
@@ -379,7 +380,7 @@ describe('Breadcrumb', () => {
                 expect(homeIcon).toBeTruthy();
             } else {
                 // Icon might be rendered differently in test environment
-                expect(breadcrumbInstance.home?.icon).toBe('pi pi-home');
+                expect(breadcrumbInstance.home()?.icon).toBe('pi pi-home');
             }
         });
 
@@ -396,7 +397,7 @@ describe('Breadcrumb', () => {
                 expect(defaultHomeIcon).toBeTruthy();
             } else {
                 // Default icon might render differently in test environment
-                expect(breadcrumbInstance.home).toBeTruthy();
+                expect(breadcrumbInstance.home()).toBeTruthy();
             }
         });
 
@@ -413,7 +414,7 @@ describe('Breadcrumb', () => {
                 expect(homeLink.nativeElement.getAttribute('ng-reflect-router-link')).toBe('/');
             } else {
                 // RouterLink might not be reflected in test environment
-                expect(breadcrumbInstance.home?.routerLink).toBe('/');
+                expect(breadcrumbInstance.home()?.routerLink).toBe('/');
             }
         });
 
@@ -429,7 +430,7 @@ describe('Breadcrumb', () => {
             if (homeLink) {
                 expect(homeLink.nativeElement.getAttribute('href')).toBe('/home');
             } else {
-                expect(breadcrumbInstance.home?.url).toBe('/home');
+                expect(breadcrumbInstance.home()?.url).toBe('/home');
             }
         });
 
@@ -446,7 +447,7 @@ describe('Breadcrumb', () => {
             if (homeLink) {
                 expect(homeLink.nativeElement.getAttribute('aria-label')).toBe('Navigate to home');
             } else {
-                expect(breadcrumbInstance.homeAriaLabel).toBe('Navigate to home');
+                expect(breadcrumbInstance.homeAriaLabel()).toBe('Navigate to home');
             }
         });
 
@@ -462,7 +463,7 @@ describe('Breadcrumb', () => {
             if (homeLink) {
                 expect(homeLink.nativeElement.hasAttribute('tabindex')).toBe(false);
             } else {
-                expect(breadcrumbInstance.home?.disabled).toBe(true);
+                expect(breadcrumbInstance.home()?.disabled).toBe(true);
             }
         });
     });
@@ -488,7 +489,7 @@ describe('Breadcrumb', () => {
             fixture.detectChanges();
 
             // Check if label exists in the component model
-            expect(breadcrumbInstance.model?.[0]?.label).toBe('Test Item');
+            expect(breadcrumbInstance.model()?.[0]?.label).toBe('Test Item');
         });
 
         it('should display item icons', async () => {
@@ -501,7 +502,7 @@ describe('Breadcrumb', () => {
             if (itemIcon) {
                 expect(itemIcon).toBeTruthy();
             } else {
-                expect(breadcrumbInstance.model?.[0]?.icon).toBe('pi pi-file');
+                expect(breadcrumbInstance.model()?.[0]?.icon).toBe('pi pi-file');
             }
         });
 
@@ -511,7 +512,7 @@ describe('Breadcrumb', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model?.[0]?.routerLink).toBe('/router');
+            expect(breadcrumbInstance.model()?.[0]?.routerLink).toBe('/router');
         });
 
         it('should handle invisible items', async () => {
@@ -549,8 +550,8 @@ describe('Breadcrumb', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model?.[0]?.label).toBe('<b>Bold Item</b>');
-            expect(breadcrumbInstance.model?.[0]?.escape).toBe(false);
+            expect(breadcrumbInstance.model()?.[0]?.label).toBe('<b>Bold Item</b>');
+            expect(breadcrumbInstance.model()?.[0]?.escape).toBe(false);
         });
     });
 
@@ -648,8 +649,8 @@ describe('Breadcrumb', () => {
 
             const itemTemplateBreadcrumb = itemTemplateFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(() => itemTemplateBreadcrumb.ngAfterContentInit()).not.toThrow();
-            expect(itemTemplateBreadcrumb.itemTemplate).toBeDefined();
+            expect(itemTemplateBreadcrumb.itemTemplate()).toBeDefined();
+            expect(itemTemplateBreadcrumb.$itemTemplate()).toBeDefined();
         });
 
         it('should handle pTemplate item processing', async () => {
@@ -659,8 +660,8 @@ describe('Breadcrumb', () => {
 
             const pTemplateBreadcrumb = pTemplateFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(() => pTemplateBreadcrumb.ngAfterContentInit()).not.toThrow();
-            expect(pTemplateBreadcrumb.templates).toBeDefined();
+            expect(pTemplateBreadcrumb.templates().length).toBe(1);
+            expect(pTemplateBreadcrumb.$itemTemplate()).toBeDefined();
         });
 
         it('should render custom item template', async () => {
@@ -676,7 +677,7 @@ describe('Breadcrumb', () => {
             } else {
                 // Template processing might work differently in test environment
                 const breadcrumbComp = itemTemplateFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
-                expect(breadcrumbComp.itemTemplate).toBeDefined();
+                expect(breadcrumbComp.$itemTemplate()).toBeDefined();
             }
         });
 
@@ -687,8 +688,8 @@ describe('Breadcrumb', () => {
 
             const separatorBreadcrumb = separatorTemplateFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(() => separatorBreadcrumb.ngAfterContentInit()).not.toThrow();
-            expect(separatorBreadcrumb.separatorTemplate).toBeDefined();
+            expect(separatorBreadcrumb.separatorTemplate()).toBeDefined();
+            expect(separatorBreadcrumb.$separatorTemplate()).toBeDefined();
         });
 
         it('should render custom separator template', async () => {
@@ -703,7 +704,7 @@ describe('Breadcrumb', () => {
             } else {
                 // Template might not render in test environment
                 const breadcrumbComp = separatorTemplateFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
-                expect(breadcrumbComp.separatorTemplate).toBeDefined();
+                expect(breadcrumbComp.$separatorTemplate()).toBeDefined();
             }
         });
 
@@ -714,26 +715,24 @@ describe('Breadcrumb', () => {
 
             const pTemplateBreadcrumb = pTemplateFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            pTemplateBreadcrumb.ngAfterContentInit();
-
-            expect(pTemplateBreadcrumb.templates).toBeDefined();
+            expect(pTemplateBreadcrumb.templates().length).toBe(1);
+            expect(pTemplateBreadcrumb.templates()[0].getType()).toBe('item');
         });
 
-        it('should prioritize itemTemplate over _itemTemplate', async () => {
+        it('should prioritize the #item content child over legacy pTemplate items', async () => {
             const itemTemplateFixture = TestBed.createComponent(TestItemTemplateBreadcrumbComponent);
             itemTemplateFixture.detectChanges();
             await new Promise((resolve) => setTimeout(resolve, 100));
 
             const breadcrumbComp = itemTemplateFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(breadcrumbComp.itemTemplate).toBeDefined();
-            expect(() => breadcrumbComp.ngAfterContentInit()).not.toThrow();
+            expect(breadcrumbComp.itemTemplate()).toBeDefined();
+            expect(breadcrumbComp.$itemTemplate()).toBe(breadcrumbComp.itemTemplate());
         });
 
         it('should handle missing templates gracefully', () => {
-            expect(() => breadcrumbInstance.ngAfterContentInit()).not.toThrow();
-            expect(breadcrumbInstance._itemTemplate).toBeUndefined();
-            expect(breadcrumbInstance._separatorTemplate).toBeUndefined();
+            expect(breadcrumbInstance.$itemTemplate()).toBeUndefined();
+            expect(breadcrumbInstance.$separatorTemplate()).toBeUndefined();
         });
     });
 
@@ -819,8 +818,8 @@ describe('Breadcrumb', () => {
 
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model?.[0]?.style).toEqual({ color: 'red', fontWeight: 'bold' });
-            expect(breadcrumbInstance.model?.[0]?.styleClass).toBe('item-class');
+            expect(breadcrumbInstance.model()?.[0]?.style).toEqual({ color: 'red', fontWeight: 'bold' });
+            expect(breadcrumbInstance.model()?.[0]?.styleClass).toBe('item-class');
         });
     });
 
@@ -838,7 +837,7 @@ describe('Breadcrumb', () => {
             if (homeLink) {
                 expect(homeLink.nativeElement.getAttribute('aria-label')).toBe('Go to homepage');
             } else {
-                expect(breadcrumbInstance.homeAriaLabel).toBe('Go to homepage');
+                expect(breadcrumbInstance.homeAriaLabel()).toBe('Go to homepage');
             }
         });
 
@@ -903,7 +902,7 @@ describe('Breadcrumb', () => {
 
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model?.[0]?.disabled).toBe(true);
+            expect(breadcrumbInstance.model()?.[0]?.disabled).toBe(true);
         });
 
         it('should handle tabindex for enabled items', async () => {
@@ -914,7 +913,7 @@ describe('Breadcrumb', () => {
 
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model?.[0]?.disabled).toBe(false);
+            expect(breadcrumbInstance.model()?.[0]?.disabled).toBe(false);
         });
 
         it('should support title attributes', async () => {
@@ -926,8 +925,8 @@ describe('Breadcrumb', () => {
 
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.home?.title).toBe('Home Page');
-            expect(breadcrumbInstance.model?.[0]?.title).toBe('Item Page');
+            expect(breadcrumbInstance.home()?.title).toBe('Home Page');
+            expect(breadcrumbInstance.model()?.[0]?.title).toBe('Item Page');
         });
 
         it('should support tooltip options', async () => {
@@ -939,8 +938,8 @@ describe('Breadcrumb', () => {
 
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.home?.tooltipOptions?.tooltipLabel).toBe('Home tooltip');
-            expect(breadcrumbInstance.model?.[0]?.tooltipOptions?.tooltipLabel).toBe('Item tooltip');
+            expect(breadcrumbInstance.home()?.tooltipOptions?.tooltipLabel).toBe('Home tooltip');
+            expect(breadcrumbInstance.model()?.[0]?.tooltipOptions?.tooltipLabel).toBe('Item tooltip');
         });
 
         it('should mark the last item link with aria-current="page"', async () => {
@@ -1027,7 +1026,7 @@ describe('Breadcrumb', () => {
             fixture.detectChanges();
 
             expect(() => fixture.detectChanges()).not.toThrow();
-            expect(breadcrumbInstance.model).toBeUndefined();
+            expect(breadcrumbInstance.model()).toBeUndefined();
         });
 
         it('should handle empty model array', async () => {
@@ -1039,7 +1038,7 @@ describe('Breadcrumb', () => {
             fixture.detectChanges();
 
             expect(() => fixture.detectChanges()).not.toThrow();
-            expect(breadcrumbInstance.model).toEqual([]);
+            expect(breadcrumbInstance.model()).toEqual([]);
         });
 
         it('should handle items without labels', async () => {
@@ -1051,7 +1050,7 @@ describe('Breadcrumb', () => {
             fixture.detectChanges();
 
             expect(() => fixture.detectChanges()).not.toThrow();
-            expect(breadcrumbInstance.model?.[0]?.url).toBe('/no-label');
+            expect(breadcrumbInstance.model()?.[0]?.url).toBe('/no-label');
         });
 
         it('should handle items with special characters in labels', async () => {
@@ -1071,7 +1070,7 @@ describe('Breadcrumb', () => {
                 await fixture.whenStable();
                 fixture.detectChanges();
 
-                expect(breadcrumbInstance.model?.[0]?.label).toBe(item.label);
+                expect(breadcrumbInstance.model()?.[0]?.label).toBe(item.label);
                 expect(() => fixture.detectChanges()).not.toThrow();
             }
         });
@@ -1089,7 +1088,7 @@ describe('Breadcrumb', () => {
 
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model?.length).toBe(50);
+            expect(breadcrumbInstance.model()?.length).toBe(50);
             expect(() => fixture.detectChanges()).not.toThrow();
         });
 
@@ -1104,8 +1103,8 @@ describe('Breadcrumb', () => {
                 await fixture.whenStable();
                 fixture.detectChanges();
 
-                expect(breadcrumbInstance.model).toBe(model);
-                expect(breadcrumbInstance.styleClass).toBe(`class-${index}`);
+                expect(breadcrumbInstance.model()).toBe(model);
+                expect(breadcrumbInstance.styleClass()).toBe(`class-${index}`);
             }
         });
 
@@ -1138,10 +1137,10 @@ describe('Breadcrumb', () => {
             const instance1 = fixture1.debugElement.query(By.directive(Breadcrumb)).componentInstance;
             const instance2 = fixture2.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(instance1.model?.[0]?.label).toBe('Breadcrumb 1');
-            expect(instance1.styleClass).toBe('breadcrumb-1');
-            expect(instance2.model?.[0]?.label).toBe('Breadcrumb 2');
-            expect(instance2.styleClass).toBe('breadcrumb-2');
+            expect(instance1.model()?.[0]?.label).toBe('Breadcrumb 1');
+            expect(instance1.styleClass()).toBe('breadcrumb-1');
+            expect(instance2.model()?.[0]?.label).toBe('Breadcrumb 2');
+            expect(instance2.styleClass()).toBe('breadcrumb-2');
             expect(instance1).not.toBe(instance2);
         });
     });
@@ -1153,9 +1152,9 @@ describe('Breadcrumb', () => {
 
             const staticBreadcrumb = staticFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(staticBreadcrumb.model.length).toBe(2);
-            expect(staticBreadcrumb.model[0].label).toBe('Category');
-            expect(staticBreadcrumb.home.icon).toBe('pi pi-home');
+            expect(staticBreadcrumb.model().length).toBe(2);
+            expect(staticBreadcrumb.model()[0].label).toBe('Category');
+            expect(staticBreadcrumb.home().icon).toBe('pi pi-home');
         });
 
         it('should work with styled component', () => {
@@ -1172,8 +1171,8 @@ describe('Breadcrumb', () => {
 
             const routerBreadcrumb = routerFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(routerBreadcrumb.model[0].routerLink).toBe('/products');
-            expect(routerBreadcrumb.home.routerLink).toBe('/');
+            expect(routerBreadcrumb.model()[0].routerLink).toBe('/products');
+            expect(routerBreadcrumb.home().routerLink).toBe('/');
         });
 
         it('should maintain state across property changes', async () => {
@@ -1185,8 +1184,8 @@ describe('Breadcrumb', () => {
 
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model?.[0]?.label).toBe('Initial');
-            expect(breadcrumbInstance.styleClass).toBe('initial-class');
+            expect(breadcrumbInstance.model()?.[0]?.label).toBe('Initial');
+            expect(breadcrumbInstance.styleClass()).toBe('initial-class');
 
             component.model = [{ label: 'Updated' }];
             component.styleClass = 'updated-class';
@@ -1196,8 +1195,8 @@ describe('Breadcrumb', () => {
 
             fixture.detectChanges();
 
-            expect(breadcrumbInstance.model?.[0]?.label).toBe('Updated');
-            expect(breadcrumbInstance.styleClass).toBe('updated-class');
+            expect(breadcrumbInstance.model()?.[0]?.label).toBe('Updated');
+            expect(breadcrumbInstance.styleClass()).toBe('updated-class');
         });
 
         it('should work with dynamic content changes', async () => {
@@ -1207,7 +1206,7 @@ describe('Breadcrumb', () => {
 
             const dynamicBreadcrumb = dynamicFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(dynamicBreadcrumb.model.length).toBe(0);
+            expect(dynamicBreadcrumb.model().length).toBe(0);
 
             // Add items dynamically
             dynamicComponent.addItem({ label: 'Dynamic 1', url: '/d1' });
@@ -1216,8 +1215,8 @@ describe('Breadcrumb', () => {
             await dynamicFixture.whenStable();
             dynamicFixture.detectChanges();
 
-            expect(dynamicBreadcrumb.model.length).toBe(2);
-            expect(dynamicBreadcrumb.model[0].label).toBe('Dynamic 1');
+            expect(dynamicBreadcrumb.model().length).toBe(2);
+            expect(dynamicBreadcrumb.model()[0].label).toBe('Dynamic 1');
 
             // Clear items
             dynamicComponent.clearItems();
@@ -1225,7 +1224,7 @@ describe('Breadcrumb', () => {
             await dynamicFixture.whenStable();
             dynamicFixture.detectChanges();
 
-            expect(dynamicBreadcrumb.model.length).toBe(0);
+            expect(dynamicBreadcrumb.model().length).toBe(0);
         });
 
         it('should handle complete workflow with templates', async () => {
@@ -1235,9 +1234,9 @@ describe('Breadcrumb', () => {
 
             const templateBreadcrumb = templateFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(templateBreadcrumb.model.length).toBe(2);
-            expect(templateBreadcrumb.home.label).toBe('Custom Home');
-            expect(templateBreadcrumb.itemTemplate).toBeDefined();
+            expect(templateBreadcrumb.model().length).toBe(2);
+            expect(templateBreadcrumb.home().label).toBe('Custom Home');
+            expect(templateBreadcrumb.itemTemplate()).toBeDefined();
         });
     });
 
@@ -1246,8 +1245,9 @@ describe('Breadcrumb', () => {
             expect(typeof breadcrumbInstance.onClick).toBe('function');
         });
 
-        it('should have ngAfterContentInit method', () => {
-            expect(typeof breadcrumbInstance.ngAfterContentInit).toBe('function');
+        it('should expose the effective template computeds', () => {
+            expect(typeof breadcrumbInstance.$itemTemplate).toBe('function');
+            expect(typeof breadcrumbInstance.$separatorTemplate).toBe('function');
         });
 
         it('should call onClick programmatically', () => {
@@ -1276,19 +1276,20 @@ describe('Breadcrumb', () => {
             });
         });
 
-        it('should call ngAfterContentInit programmatically', () => {
-            expect(() => breadcrumbInstance.ngAfterContentInit()).not.toThrow();
+        it('should evaluate template computeds without templates', () => {
+            expect(() => breadcrumbInstance.$itemTemplate()).not.toThrow();
+            expect(() => breadcrumbInstance.$separatorTemplate()).not.toThrow();
         });
 
-        it('should process templates in ngAfterContentInit', async () => {
+        it('should process legacy pTemplate templates', async () => {
             const templateFixture = TestBed.createComponent(TestPTemplateItemBreadcrumbComponent);
             templateFixture.detectChanges();
             await new Promise((resolve) => setTimeout(resolve, 100));
 
             const templateBreadcrumb = templateFixture.debugElement.query(By.directive(Breadcrumb)).componentInstance;
 
-            expect(() => templateBreadcrumb.ngAfterContentInit()).not.toThrow();
-            expect(templateBreadcrumb.templates).toBeDefined();
+            expect(templateBreadcrumb.templates()).toBeDefined();
+            expect(templateBreadcrumb.$itemTemplate()).toBeDefined();
         });
 
         it('should handle preventDefault in onClick for disabled items', () => {
@@ -1377,14 +1378,14 @@ describe('Breadcrumb', () => {
                 list: ({ instance }: any) => {
                     return {
                         class: {
-                            HAS_MODEL: instance?.model?.length > 0
+                            HAS_MODEL: instance?.model()?.length > 0
                         }
                     };
                 },
                 homeItem: ({ instance }: any) => {
                     return {
                         style: {
-                            'background-color': instance?.home ? 'yellow' : 'red'
+                            'background-color': instance?.home() ? 'yellow' : 'red'
                         }
                     };
                 }

--- a/packages/optimus-ui/src/breadcrumb/breadcrumb.ts
+++ b/packages/optimus-ui/src/breadcrumb/breadcrumb.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, TemplateRef, ViewEncapsulation, contentChild, contentChildren, output } from '@angular/core';
+import { afterEveryRender, ChangeDetectionStrategy, Component, computed, inject, input, NgModule, TemplateRef, ViewEncapsulation, contentChild, contentChildren, output } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive, RouterModule } from '@angular/router';
 import { MenuItem, PrimeTemplate, SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { Badge } from '@openng/optimus-ui/badge';
@@ -10,8 +10,6 @@ import { TooltipModule } from '@openng/optimus-ui/tooltip';
 import { BreadcrumbItemClickEvent, BreadcrumbItemTemplateContext, BreadcrumbPassThrough } from '@openng/optimus-ui/types/breadcrumb';
 import { BreadCrumbStyle } from './style/breadcrumbstyle';
 
-const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE');
-
 /**
  * Breadcrumb provides contextual information about page hierarchy.
  * @group Components
@@ -21,96 +19,96 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
     standalone: true,
     imports: [CommonModule, RouterModule, RouterLink, RouterLinkActive, TooltipModule, ChevronRightIcon, HomeIcon, SharedModule, Bind, Badge],
     template: `
-        <nav [pBind]="ptm('root')" [class]="cn(cx('root'), styleClass)" [style]="style">
+        <nav [pBind]="ptm('root')" [class]="cn(cx('root'), styleClass())" [style]="style()">
             <ol [class]="cx('list')" [pBind]="ptm('list')">
-                @if (home && home.visible !== false) {
-                    <li [attr.id]="home.id" [class]="cn(cx('homeItem'), home.styleClass)" [ngStyle]="home.style" pTooltip [tooltipOptions]="home.tooltipOptions" [pBind]="ptm('homeItem')" [unstyled]="unstyled()">
-                        @if (itemTemplate() || _itemTemplate) {
-                            <ng-template *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: home }"></ng-template>
+                @if (home() && home()!.visible !== false) {
+                    <li [attr.id]="home().id" [class]="cn(cx('homeItem'), home().styleClass)" [ngStyle]="home().style" pTooltip [tooltipOptions]="home().tooltipOptions" [pBind]="ptm('homeItem')" [unstyled]="unstyled()">
+                        @if ($itemTemplate()) {
+                            <ng-template *ngTemplateOutlet="$itemTemplate(); context: { $implicit: home() }"></ng-template>
                         } @else {
-                            @if (!home.routerLink) {
+                            @if (!home()!.routerLink) {
                                 <a
-                                    [href]="home.url ? home.url : null"
+                                    [href]="home().url ? home().url : null"
                                     [attr.aria-label]="homeLinkAriaLabel"
-                                    [class]="cn(cx('itemLink'), home.linkClass)"
-                                    [ngStyle]="home.linkStyle"
-                                    (click)="onClick($event, home)"
-                                    [target]="home.target"
-                                    [attr.title]="home.title"
-                                    [attr.tabindex]="home.disabled ? null : home.tabindex || '0'"
-                                    [attr.data-automationid]="home.automationId"
+                                    [class]="cn(cx('itemLink'), home().linkClass)"
+                                    [ngStyle]="home().linkStyle"
+                                    (click)="onClick($event, home())"
+                                    [target]="home().target"
+                                    [attr.title]="home().title"
+                                    [attr.tabindex]="home().disabled ? null : home().tabindex || '0'"
+                                    [attr.data-automationid]="home().automationId"
                                     [pBind]="ptm('itemLink')"
                                 >
-                                    @if (home.icon) {
-                                        <span [class]="cn(cx('itemIcon'), home.icon, home.iconClass)" [ngStyle]="home.iconStyle" [pBind]="ptm('itemIcon')"></span>
+                                    @if (home().icon) {
+                                        <span [class]="cn(cx('itemIcon'), home().icon, home().iconClass)" [ngStyle]="home().iconStyle" [pBind]="ptm('itemIcon')"></span>
                                     }
-                                    @if (!home.icon) {
+                                    @if (!home().icon) {
                                         <svg data-p-icon="home" [class]="cx('itemIcon')" [pBind]="ptm('itemIcon')" />
                                     }
-                                    @if (home.label) {
-                                        @if (home.escape !== false) {
-                                            <span [class]="cn(cx('itemLabel'), home.labelClass)" [ngStyle]="home.labelStyle" [pBind]="ptm('itemLabel')">{{ home.label }}</span>
+                                    @if (home().label) {
+                                        @if (home().escape !== false) {
+                                            <span [class]="cn(cx('itemLabel'), home().labelClass)" [ngStyle]="home().labelStyle" [pBind]="ptm('itemLabel')">{{ home().label }}</span>
                                         } @else {
-                                            <span [class]="cn(cx('itemLabel'), home.labelClass)" [ngStyle]="home.labelStyle" [innerHTML]="home.label" [pBind]="ptm('itemLabel')"></span>
+                                            <span [class]="cn(cx('itemLabel'), home().labelClass)" [ngStyle]="home().labelStyle" [innerHTML]="home().label" [pBind]="ptm('itemLabel')"></span>
                                         }
                                     }
-                                    @if (home.badge) {
-                                        <p-badge [styleClass]="home.badgeStyleClass" [value]="home.badge" [pt]="ptm('pcBadge')" [unstyled]="unstyled()" />
+                                    @if (home().badge) {
+                                        <p-badge [class]="home().badgeStyleClass" [value]="home().badge" [pt]="ptm('pcBadge')" [unstyled]="unstyled()" />
                                     }
                                 </a>
                             }
-                            @if (home.routerLink) {
+                            @if (home()!.routerLink) {
                                 <a
-                                    [routerLink]="home.routerLink"
+                                    [routerLink]="home().routerLink"
                                     routerLinkActive="p-menuitem-link-active"
                                     [attr.aria-label]="homeLinkAriaLabel"
-                                    [queryParams]="home.queryParams"
-                                    [routerLinkActiveOptions]="home.routerLinkActiveOptions || { exact: false }"
-                                    [class]="cn(cx('itemLink'), home.linkClass)"
-                                    [ngStyle]="home.linkStyle"
-                                    (click)="onClick($event, home)"
-                                    [target]="home.target"
-                                    [attr.title]="home.title"
-                                    [attr.tabindex]="home.disabled ? null : home.tabindex || '0'"
-                                    [attr.data-automationid]="home.automationId"
-                                    [fragment]="home.fragment"
-                                    [queryParamsHandling]="home.queryParamsHandling"
-                                    [preserveFragment]="home.preserveFragment"
-                                    [skipLocationChange]="home.skipLocationChange"
-                                    [replaceUrl]="home.replaceUrl"
-                                    [state]="home.state"
+                                    [queryParams]="home().queryParams"
+                                    [routerLinkActiveOptions]="home().routerLinkActiveOptions || { exact: false }"
+                                    [class]="cn(cx('itemLink'), home().linkClass)"
+                                    [ngStyle]="home().linkStyle"
+                                    (click)="onClick($event, home())"
+                                    [target]="home().target"
+                                    [attr.title]="home().title"
+                                    [attr.tabindex]="home().disabled ? null : home().tabindex || '0'"
+                                    [attr.data-automationid]="home().automationId"
+                                    [fragment]="home().fragment"
+                                    [queryParamsHandling]="home().queryParamsHandling"
+                                    [preserveFragment]="home().preserveFragment"
+                                    [skipLocationChange]="home().skipLocationChange"
+                                    [replaceUrl]="home().replaceUrl"
+                                    [state]="home().state"
                                     [pBind]="ptm('itemLink')"
                                 >
-                                    @if (home.icon) {
-                                        <span [class]="cn(cx('itemIcon'), home.icon, home.iconClass)" [ngStyle]="home.iconStyle" [pBind]="ptm('itemIcon')"></span>
+                                    @if (home().icon) {
+                                        <span [class]="cn(cx('itemIcon'), home().icon, home().iconClass)" [ngStyle]="home().iconStyle" [pBind]="ptm('itemIcon')"></span>
                                     }
-                                    @if (!home.icon) {
+                                    @if (!home().icon) {
                                         <svg data-p-icon="home" [class]="cx('itemIcon')" [pBind]="ptm('itemIcon')" />
                                     }
-                                    @if (home.label) {
-                                        @if (home.escape !== false) {
-                                            <span [class]="cn(cx('itemLabel'), home.labelClass)" [ngStyle]="home.labelStyle" [pBind]="ptm('itemLabel')">{{ home.label }}</span>
+                                    @if (home().label) {
+                                        @if (home().escape !== false) {
+                                            <span [class]="cn(cx('itemLabel'), home().labelClass)" [ngStyle]="home().labelStyle" [pBind]="ptm('itemLabel')">{{ home().label }}</span>
                                         } @else {
-                                            <span [class]="cn(cx('itemLabel'), home.labelClass)" [ngStyle]="home.labelStyle" [innerHTML]="home.label" [pBind]="ptm('itemLabel')"></span>
+                                            <span [class]="cn(cx('itemLabel'), home().labelClass)" [ngStyle]="home().labelStyle" [innerHTML]="home().label" [pBind]="ptm('itemLabel')"></span>
                                         }
                                     }
-                                    @if (home.badge) {
-                                        <p-badge [styleClass]="home.badgeStyleClass" [value]="home.badge" [pt]="ptm('pcBadge')" [unstyled]="unstyled()" />
+                                    @if (home().badge) {
+                                        <p-badge [class]="home().badgeStyleClass" [value]="home().badge" [pt]="ptm('pcBadge')" [unstyled]="unstyled()" />
                                     }
                                 </a>
                             }
                         }
                     </li>
                 }
-                @if (model && home) {
+                @if (model() && home()) {
                     <li [class]="cx('separator')" [pBind]="ptm('separator')" aria-hidden="true">
-                        @if (!separatorTemplate() && !_separatorTemplate) {
+                        @if (!$separatorTemplate()) {
                             <svg data-p-icon="chevron-right" [pBind]="ptm('separatorIcon')" />
                         }
-                        <ng-template *ngTemplateOutlet="separatorTemplate() || _separatorTemplate"></ng-template>
+                        <ng-template *ngTemplateOutlet="$separatorTemplate()"></ng-template>
                     </li>
                 }
-                @for (menuitem of model; track menuitem; let end = $last; let i = $index) {
+                @for (menuitem of model(); track menuitem; let end = $last; let i = $index) {
                     @if (menuitem.visible !== false) {
                         <li
                             [class]="cn(cx('item', { menuitem }), menuitem.styleClass)"
@@ -121,8 +119,8 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                             [pBind]="getPTOptions(menuitem, i, 'item')"
                             [pTooltipUnstyled]="unstyled()"
                         >
-                            @if (itemTemplate() || _itemTemplate) {
-                                <ng-template *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: menuitem }"></ng-template>
+                            @if ($itemTemplate()) {
+                                <ng-template *ngTemplateOutlet="$itemTemplate(); context: { $implicit: menuitem }"></ng-template>
                             } @else {
                                 @if (!menuitem?.routerLink) {
                                     <a
@@ -137,7 +135,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                                         [attr.aria-current]="isCurrentPage(i) ? 'page' : undefined"
                                         [pBind]="getPTOptions(menuitem, i, 'itemLink')"
                                     >
-                                        @if (!itemTemplate() && !_itemTemplate) {
+                                        @if (!$itemTemplate()) {
                                             @if (menuitem?.icon) {
                                                 <span [class]="cn(cx('itemIcon'), menuitem?.icon, menuitem?.iconClass)" [ngStyle]="menuitem?.iconStyle" [pBind]="getPTOptions(menuitem, i, 'itemIcon')"></span>
                                             }
@@ -149,7 +147,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                                                 }
                                             }
                                             @if (menuitem?.badge) {
-                                                <p-badge [styleClass]="menuitem?.badgeStyleClass" [value]="menuitem?.badge" [pt]="getPTOptions(menuitem, i, 'pcBadge')" [unstyled]="unstyled()" />
+                                                <p-badge [class]="menuitem?.badgeStyleClass" [value]="menuitem?.badge" [pt]="getPTOptions(menuitem, i, 'pcBadge')" [unstyled]="unstyled()" />
                                             }
                                         }
                                     </a>
@@ -187,7 +185,7 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                                             }
                                         }
                                         @if (menuitem?.badge) {
-                                            <p-badge [styleClass]="menuitem?.badgeStyleClass" [value]="menuitem?.badge" [pt]="getPTOptions(menuitem, i, 'pcBadge')" [unstyled]="unstyled()" />
+                                            <p-badge [class]="menuitem?.badgeStyleClass" [value]="menuitem?.badge" [pt]="getPTOptions(menuitem, i, 'pcBadge')" [unstyled]="unstyled()" />
                                         }
                                     </a>
                                 }
@@ -196,10 +194,10 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
                     }
                     @if (!end && menuitem.visible !== false) {
                         <li [class]="cx('separator')" [pBind]="ptm('separator')" aria-hidden="true">
-                            @if (!separatorTemplate() && !_separatorTemplate) {
+                            @if (!$separatorTemplate()) {
                                 <svg data-p-icon="chevron-right" [pBind]="ptm('separatorIcon')" />
                             }
-                            <ng-template *ngTemplateOutlet="separatorTemplate() || _separatorTemplate"></ng-template>
+                            <ng-template *ngTemplateOutlet="$separatorTemplate()"></ng-template>
                         </li>
                     }
                 }
@@ -208,38 +206,46 @@ const BREADCRUMB_INSTANCE = new InjectionToken<Breadcrumb>('BREADCRUMB_INSTANCE'
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [BreadCrumbStyle, { provide: BREADCRUMB_INSTANCE, useExisting: Breadcrumb }, { provide: PARENT_INSTANCE, useExisting: Breadcrumb }],
+    providers: [BreadCrumbStyle, { provide: PARENT_INSTANCE, useExisting: Breadcrumb }],
     hostDirectives: [Bind]
 })
 export class Breadcrumb extends BaseComponent<BreadcrumbPassThrough> {
-    componentName = 'Breadcrumb';
-
     bindDirectiveInstance = inject(Bind, { self: true });
+
+    _componentStyle = inject(BreadCrumbStyle);
+
+    router = inject(Router);
+
     /**
      * An array of menuitems.
      * @group Props
      */
-    @Input() model: MenuItem[] | undefined;
+    readonly model = input<MenuItem[]>();
+
     /**
      * Inline style of the component.
      * @group Props
      */
-    @Input() style: { [klass: string]: any } | null | undefined;
+    readonly style = input<{ [klass: string]: any } | null>();
+
     /**
      * Style class of the component.
      * @group Props
      */
-    @Input() styleClass: string | undefined;
+    readonly styleClass = input<string>();
+
     /**
      * MenuItem configuration for the home icon.
      * @group Props
      */
-    @Input() home: MenuItem | undefined;
+    readonly home = input<MenuItem>();
+
     /**
      * Defines a string that labels the home icon for accessibility. Defaults to the `aria.home` translation when the home item has no visible label.
      * @group Props
      */
-    @Input() homeAriaLabel: string | undefined;
+    readonly homeAriaLabel = input<string>();
+
     /**
      * Fired when an item is selected.
      * @param {BreadcrumbItemClickEvent} event - custom click event.
@@ -247,17 +253,54 @@ export class Breadcrumb extends BaseComponent<BreadcrumbPassThrough> {
      */
     readonly onItemClick = output<BreadcrumbItemClickEvent>();
 
-    _componentStyle = inject(BreadCrumbStyle);
+    /**
+     * Custom item template.
+     * @group Templates
+     */
+    readonly itemTemplate = contentChild<TemplateRef<BreadcrumbItemTemplateContext>>('item');
 
-    router = inject(Router);
+    /**
+     * Custom separator template.
+     * @group Templates
+     */
+    readonly separatorTemplate = contentChild<TemplateRef<void>>('separator');
+
+    readonly templates = contentChildren(PrimeTemplate);
+
+    componentName = 'Breadcrumb';
 
     get homeLinkAriaLabel(): string | undefined {
-        if (this.homeAriaLabel) {
-            return this.homeAriaLabel;
+        if (this.homeAriaLabel()) {
+            return this.homeAriaLabel();
         }
 
         // A visible label already names the link, so an aria-label would only override it.
-        return this.home?.label ? undefined : this.config.getTranslation(TranslationKeys.ARIA)?.home;
+        return this.home()?.label ? undefined : this.config.getTranslation(TranslationKeys.ARIA)?.home;
+    }
+
+    /** Effective separator template: the \`#separator\` content child, or a legacy \`pTemplate="separator"\`. */
+    readonly $separatorTemplate = computed(() => this.separatorTemplate() ?? this.templates().find((item) => item.getType() === 'separator')?.template);
+
+    /**
+     * Effective item template: the \`#item\` content child, a legacy \`pTemplate="item"\`, or
+     * (legacy behavior) the last \`pTemplate\` with an unrecognized type.
+     */
+    readonly $itemTemplate = computed(() => {
+        const itemTemplate = this.itemTemplate();
+        if (itemTemplate) {
+            return itemTemplate;
+        }
+        return [...this.templates()].reverse().find((item) => item.getType() !== 'separator')?.template as TemplateRef<BreadcrumbItemTemplateContext> | undefined;
+    });
+
+    constructor() {
+        super();
+        // Re-apply the host pass-through section after each render (replaces the former
+        // ngAfterViewChecked hook). Bind.setAttrs writes into a signal behind an equality check,
+        // so unchanged PT resolutions are no-ops.
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptm('host'));
+        });
     }
 
     onClick(event: MouseEvent, item: MenuItem) {
@@ -283,46 +326,6 @@ export class Breadcrumb extends BaseComponent<BreadcrumbPassThrough> {
         });
     }
 
-    /**
-     * Custom item template.
-     * @group Templates
-     */
-    readonly itemTemplate = contentChild<TemplateRef<BreadcrumbItemTemplateContext>>('item');
-
-    /**
-     * Custom separator template.
-     * @group Templates
-     */
-    readonly separatorTemplate = contentChild<TemplateRef<void>>('separator');
-
-    readonly templates = contentChildren(PrimeTemplate);
-
-    _separatorTemplate: TemplateRef<void> | undefined;
-
-    _itemTemplate: TemplateRef<BreadcrumbItemTemplateContext> | undefined;
-
-    onAfterContentInit() {
-        this.templates()?.forEach((item) => {
-            switch (item.getType()) {
-                case 'separator':
-                    this._separatorTemplate = item.template;
-                    break;
-
-                case 'item':
-                    this._itemTemplate = item.template;
-                    break;
-
-                default:
-                    this._itemTemplate = item.template;
-                    break;
-            }
-        });
-    }
-
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptm('host'));
-    }
-
     getPTOptions(item: MenuItem, index: number, key: string) {
         return this.ptm(key, {
             context: {
@@ -333,12 +336,13 @@ export class Breadcrumb extends BaseComponent<BreadcrumbPassThrough> {
     }
 
     isCurrentPage(index: number): boolean {
-        if (!this.model) {
+        const model = this.model();
+        if (!model) {
             return false;
         }
 
-        for (let i = this.model.length - 1; i >= 0; i--) {
-            if (this.model[i]?.visible !== false) {
+        for (let i = model.length - 1; i >= 0; i--) {
+            if (model[i]?.visible !== false) {
                 return i === index;
             }
         }

--- a/packages/optimus-ui/src/dock/dock.test.ts
+++ b/packages/optimus-ui/src/dock/dock.test.ts
@@ -11,7 +11,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
-    template: ` <p-dock [id]="id" [model]="model" [position]="position" [styleClass]="styleClass" [ariaLabel]="ariaLabel" [ariaLabelledBy]="ariaLabelledBy" [breakpoint]="breakpoint" (onFocus)="onFocus($event)" (onBlur)="onBlur($event)"> </p-dock> `
+    template: ` <p-dock [id]="id" [model]="model" [position]="position" [class]="styleClass" [ariaLabel]="ariaLabel" [ariaLabelledBy]="ariaLabelledBy" [breakpoint]="breakpoint" (onFocus)="onFocus($event)" (onBlur)="onBlur($event)"> </p-dock> `
 })
 class TestBasicDockComponent {
     id: string | undefined;
@@ -121,7 +121,7 @@ class TestDisabledItemsDockComponent {
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
     selector: 'test-styled-dock',
-    template: ` <p-dock [model]="model" [styleClass]="customStyleClass"></p-dock> `
+    template: ` <p-dock [model]="model" [class]="customStyleClass"></p-dock> `
 })
 class TestStyledDockComponent {
     model: MenuItem[] = [{ label: 'Test', icon: 'pi pi-test' }];
@@ -246,13 +246,12 @@ describe('Dock', () => {
 
             const freshDock = freshFixture.debugElement.query(By.directive(Dock)).componentInstance;
 
-            expect(freshDock.model).toBeNull();
-            expect(freshDock.position).toBe('bottom');
-            expect(freshDock.breakpoint).toBe('960px');
+            expect(freshDock.model()).toBeNull();
+            expect(freshDock.position()).toBe('bottom');
+            expect(freshDock.breakpoint()).toBe('960px');
             expect(freshDock.tabindex).toBe(0);
-            expect(freshDock.focused).toBe(false);
-            expect(freshDock.focusedOptionIndex).toBe(-1);
-            expect(freshDock.currentIndex).toBe(-3);
+            expect(freshDock.focused()).toBe(false);
+            expect(freshDock.focusedOptionIndex()).toBe(-1);
         });
 
         it('should accept custom values', async () => {
@@ -265,17 +264,17 @@ describe('Dock', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(dockInstance.model).toBe(testModel);
-            expect(dockInstance.position).toBe('top');
-            expect(dockInstance.styleClass).toBe('custom-dock');
-            expect(dockInstance.ariaLabel).toBe('Custom Dock');
-            expect(dockInstance.breakpoint).toBe('768px');
+            expect(dockInstance.model()).toBe(testModel);
+            expect(dockInstance.position()).toBe('top');
+            expect(fixture.debugElement.query(By.css('p-dock')).nativeElement.classList.contains('custom-dock')).toBe(true);
+            expect(dockInstance.ariaLabel()).toBe('Custom Dock');
+            expect(dockInstance.breakpoint()).toBe('768px');
         });
 
         it('should initialize with generated id', () => {
-            expect(dockInstance.id).toBeTruthy();
-            expect(typeof dockInstance.id).toBe('string');
-            expect(dockInstance.id).toMatch(/^pn_id_/);
+            expect(dockInstance.$id()).toBeTruthy();
+            expect(typeof dockInstance.$id()).toBe('string');
+            expect(dockInstance.$id()).toMatch(/^pn_id_/);
         });
 
         it('should have onFocus and onBlur output emitters', () => {
@@ -296,7 +295,7 @@ describe('Dock', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(dockInstance.model).toBe(newModel);
+            expect(dockInstance.model()).toBe(newModel);
         });
 
         it('should update position input', async () => {
@@ -304,7 +303,7 @@ describe('Dock', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(dockInstance.position).toBe('left');
+            expect(dockInstance.position()).toBe('left');
         });
 
         it('should update styleClass input', async () => {
@@ -312,7 +311,7 @@ describe('Dock', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(dockInstance.styleClass).toBe('test-class');
+            expect(fixture.debugElement.query(By.css('p-dock')).nativeElement.classList.contains('test-class')).toBe(true);
         });
 
         it('should update ariaLabel and ariaLabelledBy inputs', async () => {
@@ -321,22 +320,22 @@ describe('Dock', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(dockInstance.ariaLabel).toBe('Test Dock');
-            expect(dockInstance.ariaLabelledBy).toBe('dock-label');
+            expect(dockInstance.ariaLabel()).toBe('Test Dock');
+            expect(dockInstance.ariaLabelledBy()).toBe('dock-label');
         });
 
         it('should update breakpoint input', async () => {
             component.breakpoint = '768px';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(dockInstance.breakpoint).toBe('768px');
+            expect(dockInstance.breakpoint()).toBe('768px');
         });
 
         it('should update id input', async () => {
             component.id = 'custom-dock-id';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(dockInstance.id).toBe('custom-dock-id');
+            expect(dockInstance.id()).toBe('custom-dock-id');
         });
     });
 
@@ -450,34 +449,6 @@ describe('Dock', () => {
             expect(commandComponent.commandExecuted).toBeDefined();
             expect(commandComponent.commandExecuted.item.label).toBe('Command Item');
         });
-
-        it('should handle mouse enter on item', () => {
-            vi.spyOn(dockInstance, 'onItemMouseEnter').mockImplementation(() => {});
-
-            const itemElement = fixture.debugElement.query(By.css('li[role="menuitem"]'));
-            itemElement.triggerEventHandler('mouseenter', {});
-
-            expect(dockInstance.onItemMouseEnter).toHaveBeenCalled();
-        });
-
-        it('should handle mouse leave on list', () => {
-            vi.spyOn(dockInstance, 'onListMouseLeave').mockImplementation(() => {});
-
-            const listElement = fixture.debugElement.query(By.css('ul[role="menu"]'));
-            listElement.triggerEventHandler('mouseleave', {});
-
-            expect(dockInstance.onListMouseLeave).toHaveBeenCalled();
-        });
-
-        it('should update currentIndex on mouse enter', () => {
-            dockInstance.onItemMouseEnter(2);
-            expect(dockInstance.currentIndex).toBe(2);
-        });
-
-        it('should reset currentIndex on mouse leave', () => {
-            dockInstance.onListMouseLeave();
-            expect(dockInstance.currentIndex).toBe(-3);
-        });
     });
 
     describe('Template Tests', () => {
@@ -555,8 +526,8 @@ describe('Dock', () => {
 
     describe('Keyboard Navigation Tests', () => {
         beforeEach(() => {
-            dockInstance.focused = true;
-            dockInstance.focusedOptionIndex = 0;
+            dockInstance.focused.set(true);
+            dockInstance.focusedOptionIndex.set(0);
         });
 
         it('should handle arrow right key for horizontal positions', async () => {
@@ -671,19 +642,19 @@ describe('Dock', () => {
 
             dockInstance.onListFocus(focusEvent);
 
-            expect(dockInstance.focused).toBe(true);
+            expect(dockInstance.focused()).toBe(true);
             expect(dockInstance.onFocus.emit).toHaveBeenCalledWith(focusEvent);
         });
 
         it('should emit onBlur when list loses focus', () => {
             vi.spyOn(dockInstance.onBlur, 'emit').mockImplementation(() => {});
             const blurEvent = new FocusEvent('blur');
-            dockInstance.focused = true;
+            dockInstance.focused.set(true);
 
             dockInstance.onListBlur(blurEvent);
 
-            expect(dockInstance.focused).toBe(false);
-            expect(dockInstance.focusedOptionIndex).toBe(-1);
+            expect(dockInstance.focused()).toBe(false);
+            expect(dockInstance.focusedOptionIndex()).toBe(-1);
             expect(dockInstance.onBlur.emit).toHaveBeenCalledWith(blurEvent);
         });
 
@@ -701,11 +672,11 @@ describe('Dock', () => {
         });
 
         it('should get focusedOptionId correctly', () => {
-            dockInstance.focusedOptionIndex = -1;
-            expect(dockInstance.focusedOptionId).toBeNull();
+            dockInstance.focusedOptionIndex.set(-1);
+            expect(dockInstance.focusedOptionId()).toBeNull();
 
-            dockInstance.focusedOptionIndex = '2';
-            expect(dockInstance.focusedOptionId).toBe('2');
+            dockInstance.focusedOptionIndex.set('2');
+            expect(dockInstance.focusedOptionId()).toBe('2');
         });
     });
 
@@ -731,7 +702,7 @@ describe('Dock', () => {
         it('should apply correct CSS classes based on position', () => {
             // This test assumes CSS classes are applied based on position
             // The actual CSS class structure depends on the component's styling implementation
-            expect(dockInstance.position).toBe('bottom'); // Default position
+            expect(dockInstance.position()).toBe('bottom'); // Default position
         });
 
         it('should have generated id on list element', () => {
@@ -770,11 +741,11 @@ describe('Dock', () => {
         });
 
         it('should set aria-activedescendant when focused', async () => {
-            dockInstance.focused = true;
-            dockInstance.focusedOptionIndex = '1';
+            dockInstance.focused.set(true);
+            dockInstance.focusedOptionIndex.set('1');
 
             // Verify the getter works correctly
-            expect(dockInstance.focusedOptionId).toBe('1');
+            expect(dockInstance.focusedOptionId()).toBe('1');
 
             // Force change detection
             dockInstance.cd.markForCheck();
@@ -790,7 +761,7 @@ describe('Dock', () => {
         });
 
         it('should not set aria-activedescendant when not focused', async () => {
-            dockInstance.focused = false;
+            dockInstance.focused.set(false);
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
@@ -868,8 +839,8 @@ describe('Dock', () => {
             await disabledFixture.whenStable();
 
             const disabledDock = disabledFixture.debugElement.query(By.directive(Dock)).componentInstance;
-            const disabledItem = disabledDock.model[1];
-            const functionDisabledItem = disabledDock.model[2];
+            const disabledItem = disabledDock.model()![1];
+            const functionDisabledItem = disabledDock.model()![2];
 
             expect(disabledDock.disabled(disabledItem)).toBe(true);
             expect(disabledDock.disabled(functionDisabledItem)).toBe(true);
@@ -899,7 +870,7 @@ describe('Dock', () => {
             await dynamicFixture.whenStable();
 
             // Initially empty
-            expect(dynamicDock.model.length).toBe(0);
+            expect(dynamicDock.model()!.length).toBe(0);
 
             // Add items
             dynamicComponent.addItem({ label: 'Item 1', icon: 'pi pi-test' });
@@ -907,23 +878,23 @@ describe('Dock', () => {
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
 
-            expect(dynamicDock.model.length).toBe(2);
-            expect(dynamicDock.model[0].label).toBe('Item 1');
+            expect(dynamicDock.model()!.length).toBe(2);
+            expect(dynamicDock.model()![0].label).toBe('Item 1');
 
             // Remove item
             dynamicComponent.removeItem(0);
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
 
-            expect(dynamicDock.model.length).toBe(1);
-            expect(dynamicDock.model[0].label).toBe('Item 2');
+            expect(dynamicDock.model()!.length).toBe(1);
+            expect(dynamicDock.model()![0].label).toBe('Item 2');
 
             // Clear all
             dynamicComponent.clearItems();
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
 
-            expect(dynamicDock.model.length).toBe(0);
+            expect(dynamicDock.model()!.length).toBe(0);
         });
     });
 
@@ -938,7 +909,7 @@ describe('Dock', () => {
                 fixture.changeDetectorRef.markForCheck();
                 await fixture.whenStable();
             }).not.toThrow();
-            expect(dockInstance.model).toBeUndefined();
+            expect(dockInstance.model()).toBeUndefined();
         });
 
         it('should handle items without icons', async () => {
@@ -996,7 +967,6 @@ describe('Dock', () => {
     describe('Public Methods', () => {
         it('should have required public methods', () => {
             expect(typeof dockInstance.getItemId).toBe('function');
-            expect(typeof dockInstance.getItemProp).toBe('function');
             expect(typeof dockInstance.disabled).toBe('function');
             expect(typeof dockInstance.isItemActive).toBe('function');
             expect(typeof dockInstance.isClickableRouterLink).toBe('function');
@@ -1011,7 +981,7 @@ describe('Dock', () => {
         });
 
         it('should check item active state correctly', () => {
-            dockInstance.focusedOptionIndex = 1;
+            dockInstance.focusedOptionIndex.set(1);
 
             expect(dockInstance.isItemActive(1)).toBe(true);
             expect(dockInstance.isItemActive(2)).toBe(false);
@@ -1118,15 +1088,15 @@ describe('Dock', () => {
                 list: ({ instance }: any) => {
                     return {
                         class: {
-                            HAS_MODEL: instance?.model?.length > 0,
-                            IS_TOP: instance?.position === 'top'
+                            HAS_MODEL: instance?.model()?.length > 0,
+                            IS_TOP: instance?.position() === 'top'
                         }
                     };
                 },
                 listContainer: ({ instance }: any) => {
                     return {
                         style: {
-                            'background-color': instance?.position === 'top' ? 'yellow' : 'red'
+                            'background-color': instance?.position() === 'top' ? 'yellow' : 'red'
                         }
                     };
                 }

--- a/packages/optimus-ui/src/dock/dock.ts
+++ b/packages/optimus-ui/src/dock/dock.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, InjectionToken, Input, NgModule, signal, TemplateRef, ViewEncapsulation, viewChild, contentChild, contentChildren, output } from '@angular/core';
+import { afterEveryRender, ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, NgModule, signal, TemplateRef, ViewEncapsulation, viewChild, contentChild, contentChildren, output } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterModule } from '@angular/router';
-import { find, findSingle, resolve, uuid } from '@openng/optimus-ui-utils';
+import { find, findSingle, uuid } from '@openng/optimus-ui-utils';
 import { MenuItem, PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { Badge } from '@openng/optimus-ui/badge';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -10,8 +10,6 @@ import { Ripple } from '@openng/optimus-ui/ripple';
 import { TooltipModule } from '@openng/optimus-ui/tooltip';
 import { DockItemTemplateContext, DockPassThrough } from '@openng/optimus-ui/types/dock';
 import { DockStyle } from './style/dockstyle';
-
-const DOCK_INSTANCE = new InjectionToken<Dock>('DOCK_INSTANCE');
 
 /**
  * Dock is a navigation component consisting of menuitems.
@@ -25,21 +23,20 @@ const DOCK_INSTANCE = new InjectionToken<Dock>('DOCK_INSTANCE');
         <div [class]="cx('listContainer')" [pBind]="ptm('listContainer')">
             <ul
                 #list
-                [attr.id]="id"
+                [attr.id]="$id()"
                 [class]="cx('list')"
                 role="menu"
-                [attr.aria-orientation]="position === 'bottom' || position === 'top' ? 'horizontal' : 'vertical'"
-                [attr.aria-activedescendant]="focused ? focusedOptionId : undefined"
+                [attr.aria-orientation]="position() === 'bottom' || position() === 'top' ? 'horizontal' : 'vertical'"
+                [attr.aria-activedescendant]="focused() ? focusedOptionId() : undefined"
                 [tabindex]="tabindex"
-                [attr.aria-label]="ariaLabel"
-                [attr.aria-labelledby]="ariaLabelledBy"
+                [attr.aria-label]="ariaLabel()"
+                [attr.aria-labelledby]="ariaLabelledBy()"
                 (focus)="onListFocus($event)"
                 (blur)="onListBlur($event)"
                 (keydown)="onListKeyDown($event)"
-                (mouseleave)="onListMouseLeave()"
                 [pBind]="ptm('list')"
             >
-                @for (item of model; track item.label; let i = $index) {
+                @for (item of model(); track item.label; let i = $index) {
                     @if (item.visible !== false) {
                         <li
                             [attr.id]="getItemId(item, i)"
@@ -49,7 +46,6 @@ const DOCK_INSTANCE = new InjectionToken<Dock>('DOCK_INSTANCE');
                             [attr.aria-label]="item.label"
                             [attr.aria-disabled]="disabled(item) || false"
                             (click)="onItemClick($event, item)"
-                            (mouseenter)="onItemMouseEnter(i)"
                             [pBind]="getPTOptions(item, i, 'item')"
                             [attr.data-p-focused]="isItemActive(getItemId(item, i))"
                             [attr.data-p-disabled]="disabled(item) || false"
@@ -80,12 +76,12 @@ const DOCK_INSTANCE = new InjectionToken<Dock>('DOCK_INSTANCE');
                                         [attr.aria-hidden]="true"
                                         [pBind]="getPTOptions(item, i, 'itemLink')"
                                     >
-                                        @if (item.icon && !itemTemplate() && !_itemTemplate) {
+                                        @if (item.icon && !$itemTemplate()) {
                                             <span [class]="cn(cx('itemIcon'), item.icon, item.iconClass)" [ngStyle]="item.iconStyle" [pBind]="getPTOptions(item, i, 'itemIcon')"></span>
                                         }
-                                        <ng-container *ngTemplateOutlet="itemTemplate() || itemTemplate(); context: { $implicit: item }"></ng-container>
+                                        <ng-container *ngTemplateOutlet="$itemTemplate(); context: { $implicit: item }"></ng-container>
                                         @if (item.badge) {
-                                            <p-badge [styleClass]="item.badgeStyleClass" [value]="item.badge" [pt]="getPTOptions(item, i, 'pcBadge')" [unstyled]="unstyled()" />
+                                            <p-badge [class]="item.badgeStyleClass" [value]="item.badge" [pt]="getPTOptions(item, i, 'pcBadge')" [unstyled]="unstyled()" />
                                         }
                                     </a>
                                 } @else {
@@ -105,12 +101,12 @@ const DOCK_INSTANCE = new InjectionToken<Dock>('DOCK_INSTANCE');
                                         [attr.aria-hidden]="true"
                                         [pBind]="getPTOptions(item, i, 'itemLink')"
                                     >
-                                        @if (item.icon && !itemTemplate() && !_itemTemplate) {
+                                        @if (item.icon && !$itemTemplate()) {
                                             <span [class]="cn(cx('itemIcon'), item.icon, item.iconClass)" [ngStyle]="item.iconStyle" [pBind]="getPTOptions(item, i, 'itemIcon')"></span>
                                         }
-                                        <ng-container *ngTemplateOutlet="itemTemplate() || _itemTemplate; context: { $implicit: item }"></ng-container>
+                                        <ng-container *ngTemplateOutlet="$itemTemplate(); context: { $implicit: item }"></ng-container>
                                         @if (item.badge) {
-                                            <p-badge [styleClass]="item.badgeStyleClass" [value]="item.badge" [pt]="getPTOptions(item, i, 'pcBadge')" [unstyled]="unstyled()" />
+                                            <p-badge [class]="item.badgeStyleClass" [value]="item.badge" [pt]="getPTOptions(item, i, 'pcBadge')" [unstyled]="unstyled()" />
                                         }
                                     </a>
                                 }
@@ -123,60 +119,61 @@ const DOCK_INSTANCE = new InjectionToken<Dock>('DOCK_INSTANCE');
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [DockStyle, { provide: DOCK_INSTANCE, useExisting: Dock }, { provide: PARENT_INSTANCE, useExisting: Dock }],
+    providers: [DockStyle, { provide: PARENT_INSTANCE, useExisting: Dock }],
     host: {
-        '[class]': 'cn(cx("root"), styleClass)'
+        '[class]': 'cx("root")'
     },
     hostDirectives: [Bind]
 })
 export class Dock extends BaseComponent<DockPassThrough> {
-    cd = inject(ChangeDetectorRef);
+    _componentStyle = inject(DockStyle);
 
-    componentName = 'Dock';
+    bindDirectiveInstance = inject(Bind, { self: true });
 
     /**
      * Current id state as a string.
      * @group Props
      */
-    @Input() id: string | undefined;
-    /**
-     * Class of the element.
-     * @deprecated since v20.0.0, use `class` instead.
-     * @group Props
-     */
-    @Input() styleClass: string | undefined;
+    readonly id = input<string>();
+
     /**
      * MenuModel instance to define the action items.
      * @group Props
      */
-    @Input() model: MenuItem[] | undefined | null = null;
+    readonly model = input<MenuItem[] | null>(null);
+
     /**
      * Position of element.
      * @group Props
      */
-    @Input() position: 'bottom' | 'top' | 'left' | 'right' = 'bottom';
+    readonly position = input<'bottom' | 'top' | 'left' | 'right'>('bottom');
+
     /**
      * Defines a string that labels the input for accessibility.
      * @group Props
      */
-    @Input() ariaLabel: string | undefined;
+    readonly ariaLabel = input<string>();
+
     /**
      * The breakpoint to define the maximum width boundary.
      * @defaultValue 960px
      * @group Props
      */
-    @Input() breakpoint: string | undefined = '960px';
+    readonly breakpoint = input<string>('960px');
+
     /**
      * Defines a string that labels the dropdown button for accessibility.
      * @group Props
      */
-    @Input() ariaLabelledBy: string | undefined;
+    readonly ariaLabelledBy = input<string>();
+
     /**
      * Callback to execute when button is focused.
      * @param {FocusEvent} event - Focus event.
      * @group Emits
      */
     readonly onFocus = output<FocusEvent>();
+
     /**
      * Callback to invoke when the component loses focus.
      * @param {FocusEvent} event - Focus event.
@@ -186,19 +183,27 @@ export class Dock extends BaseComponent<DockPassThrough> {
 
     readonly listViewChild = viewChild.required<ElementRef>('list');
 
-    currentIndex: number;
+    /**
+     * Custom item template.
+     * @param {DockItemTemplateContext} context - item template context.
+     * @group Templates
+     */
+    readonly itemTemplate = contentChild<TemplateRef<DockItemTemplateContext>>('item');
+
+    readonly templates = contentChildren(PrimeTemplate);
+
+    componentName = 'Dock';
+
+    private readonly generatedId = uuid('pn_id_');
+
+    /** Effective id: the `id` input, or a generated unique id. */
+    readonly $id = computed(() => this.id() || this.generatedId);
 
     tabindex: number = 0;
 
-    focused: boolean = false;
+    readonly focused = signal<boolean>(false);
 
-    focusedOptionIndex: string | number = -1;
-
-    _componentStyle = inject(DockStyle);
-
-    bindDirectiveInstance = inject(Bind, { self: true });
-
-    $pcDock: Dock | undefined = inject(DOCK_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
+    readonly focusedOptionIndex = signal<string | number>(-1);
 
     matchMediaListener: any;
 
@@ -208,17 +213,29 @@ export class Dock extends BaseComponent<DockPassThrough> {
 
     mobileActive = signal<boolean>(false);
 
-    get focusedOptionId() {
-        return this.focusedOptionIndex !== -1 && this.focusedOptionIndex !== '-1' ? String(this.focusedOptionIndex) : null;
-    }
+    /** Id of the focused option, or null while nothing is focused. */
+    readonly focusedOptionId = computed(() => {
+        const focusedOptionIndex = this.focusedOptionIndex();
+        return focusedOptionIndex !== -1 && focusedOptionIndex !== '-1' ? String(focusedOptionIndex) : null;
+    });
+
+    /**
+     * Effective item template: the `#item` content child, or (legacy behavior) the last
+     * projected `pTemplate` of any type.
+     */
+    readonly $itemTemplate = computed(() => this.itemTemplate() ?? (this.templates().at(-1)?.template as TemplateRef<DockItemTemplateContext> | undefined));
 
     constructor() {
         super();
-        this.currentIndex = -3;
+        // Re-apply the host/root pass-through sections after each render (replaces the former
+        // ngAfterViewChecked hook). Bind.setAttrs writes into a signal behind an equality check,
+        // so unchanged PT resolutions are no-ops.
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
+        });
     }
 
     onInit() {
-        this.id = this.id || uuid('pn_id_');
         this.bindMatchMediaListener();
     }
 
@@ -226,21 +243,8 @@ export class Dock extends BaseComponent<DockPassThrough> {
         this.unbindMatchMediaListener();
     }
 
-    /**
-     * Custom item template.
-     * @param {DockItemTemplateContext} context - item template context.
-     * @group Templates
-     */
-    readonly itemTemplate = contentChild<TemplateRef<DockItemTemplateContext>>('item');
-
-    _itemTemplate: TemplateRef<DockItemTemplateContext> | undefined;
-
     getItemId(item, index) {
         return item && item?.id ? item.id : `${index}`;
-    }
-
-    getItemProp(processedItem, name) {
-        return processedItem && processedItem.item ? resolve(processedItem.item[name]) : undefined;
     }
 
     disabled(item) {
@@ -248,21 +252,7 @@ export class Dock extends BaseComponent<DockPassThrough> {
     }
 
     isItemActive(id) {
-        return String(id) === String(this.focusedOptionIndex);
-    }
-
-    onListMouseLeave() {
-        this.currentIndex = -3;
-        this.cd.markForCheck();
-    }
-
-    onItemMouseEnter(index: number) {
-        this.currentIndex = index;
-
-        if (index === 1) {
-        }
-
-        this.cd.markForCheck();
+        return String(id) === String(this.focusedOptionIndex());
     }
 
     onItemClick(e: Event, item: MenuItem) {
@@ -272,39 +262,39 @@ export class Dock extends BaseComponent<DockPassThrough> {
     }
 
     onListFocus(event) {
-        this.focused = true;
+        this.focused.set(true);
         this.changeFocusedOptionIndex(0);
         this.onFocus.emit(event);
     }
 
     onListBlur(event) {
-        this.focused = false;
-        this.focusedOptionIndex = -1;
+        this.focused.set(false);
+        this.focusedOptionIndex.set(-1);
         this.onBlur.emit(event);
     }
 
     onListKeyDown(event) {
         switch (event.code) {
             case 'ArrowDown': {
-                if (this.position === 'left' || this.position === 'right') this.onArrowDownKey();
+                if (this.position() === 'left' || this.position() === 'right') this.onArrowDownKey();
                 event.preventDefault();
                 break;
             }
 
             case 'ArrowUp': {
-                if (this.position === 'left' || this.position === 'right') this.onArrowUpKey();
+                if (this.position() === 'left' || this.position() === 'right') this.onArrowUpKey();
                 event.preventDefault();
                 break;
             }
 
             case 'ArrowRight': {
-                if (this.position === 'top' || this.position === 'bottom') this.onArrowDownKey();
+                if (this.position() === 'top' || this.position() === 'bottom') this.onArrowDownKey();
                 event.preventDefault();
                 break;
             }
 
             case 'ArrowLeft': {
-                if (this.position === 'top' || this.position === 'bottom') this.onArrowUpKey();
+                if (this.position() === 'top' || this.position() === 'bottom') this.onArrowUpKey();
                 event.preventDefault();
                 break;
             }
@@ -335,13 +325,13 @@ export class Dock extends BaseComponent<DockPassThrough> {
     }
 
     onArrowDownKey() {
-        const optionIndex = this.findNextOptionIndex(this.focusedOptionIndex);
+        const optionIndex = this.findNextOptionIndex(this.focusedOptionIndex());
 
         this.changeFocusedOptionIndex(optionIndex);
     }
 
     onArrowUpKey() {
-        const optionIndex = this.findPrevOptionIndex(this.focusedOptionIndex);
+        const optionIndex = this.findPrevOptionIndex(this.focusedOptionIndex());
 
         this.changeFocusedOptionIndex(optionIndex);
     }
@@ -355,7 +345,7 @@ export class Dock extends BaseComponent<DockPassThrough> {
     }
 
     onSpaceKey() {
-        const element = <HTMLElement>findSingle(this.listViewChild().nativeElement, `li[id="${`${this.focusedOptionIndex}`}"]`);
+        const element = <HTMLElement>findSingle(this.listViewChild().nativeElement, `li[id="${`${this.focusedOptionIndex()}`}"]`);
         const anchorElement = element && <HTMLElement>findSingle(element, 'a,button');
 
         anchorElement ? anchorElement.click() : element && element.click();
@@ -373,7 +363,7 @@ export class Dock extends BaseComponent<DockPassThrough> {
 
         let order = index >= menuitems.length ? menuitems.length - 1 : index < 0 ? 0 : index;
 
-        this.focusedOptionIndex = menuitems[order]?.getAttribute('id');
+        this.focusedOptionIndex.set(menuitems[order]?.getAttribute('id'));
     }
 
     findPrevOptionIndex(index) {
@@ -387,26 +377,6 @@ export class Dock extends BaseComponent<DockPassThrough> {
         return !!item.routerLink && !this.disabled(item);
     }
 
-    readonly templates = contentChildren(PrimeTemplate);
-
-    onAfterContentInit() {
-        this.templates()?.forEach((item) => {
-            switch (item.getType()) {
-                case 'item':
-                    this._itemTemplate = item.template;
-                    break;
-
-                default:
-                    this._itemTemplate = item.template;
-                    break;
-            }
-        });
-    }
-
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
-    }
-
     getPTOptions(item: MenuItem, index: number, key: string) {
         return this.ptm(key, {
             context: {
@@ -418,7 +388,7 @@ export class Dock extends BaseComponent<DockPassThrough> {
 
     bindMatchMediaListener() {
         if (!this.matchMediaListener) {
-            const query = window.matchMedia(`(max-width: ${this.breakpoint})`);
+            const query = window.matchMedia(`(max-width: ${this.breakpoint()})`);
             this.query = query;
             this.queryMatches.set(query.matches);
 

--- a/packages/optimus-ui/src/dock/style/dockstyle.ts
+++ b/packages/optimus-ui/src/dock/style/dockstyle.ts
@@ -5,7 +5,7 @@ import { BaseStyle } from '@openng/optimus-ui/base';
 const classes = {
     root: ({ instance }) => [
         'p-dock p-component',
-        `p-dock-${instance.position}`,
+        `p-dock-${instance.position()}`,
         {
             'p-dock-mobile': instance.queryMatches()
         }

--- a/packages/optimus-ui/src/megamenu/megamenu.test.ts
+++ b/packages/optimus-ui/src/megamenu/megamenu.test.ts
@@ -16,7 +16,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
             [id]="id"
             [model]="model"
             [orientation]="orientation"
-            [styleClass]="styleClass"
+            [class]="styleClass"
             [breakpoint]="breakpoint"
             [scrollHeight]="scrollHeight"
             [disabled]="disabled"
@@ -225,7 +225,7 @@ class TestDisabledMegaMenuComponent {
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
     selector: 'test-styled-megamenu',
-    template: ` <p-megamenu [model]="model" [styleClass]="customStyleClass"></p-megamenu> `
+    template: ` <p-megamenu [model]="model" [class]="customStyleClass"></p-megamenu> `
 })
 class TestStyledMegaMenuComponent {
     model: MegaMenuItem[] = [{ label: 'Styled Item', icon: 'pi pi-test' }];
@@ -376,12 +376,12 @@ describe('MegaMenu', () => {
 
             const freshMegaMenu = freshFixture.debugElement.query(By.directive(MegaMenu)).componentInstance;
 
-            expect(freshMegaMenu.model).toBeUndefined();
-            expect(freshMegaMenu.orientation).toBe('horizontal');
-            expect(freshMegaMenu.breakpoint).toBe('960px');
-            expect(freshMegaMenu.scrollHeight).toBe('20rem');
-            expect(freshMegaMenu.disabled).toBe(false);
-            expect(freshMegaMenu.tabindex).toBe(0);
+            expect(freshMegaMenu.model()).toBeUndefined();
+            expect(freshMegaMenu.orientation()).toBe('horizontal');
+            expect(freshMegaMenu.breakpoint()).toBe('960px');
+            expect(freshMegaMenu.scrollHeight()).toBe('20rem');
+            expect(freshMegaMenu.disabled()).toBe(false);
+            expect(freshMegaMenu.tabindex()).toBe(0);
             expect(freshMegaMenu.focused).toBe(false);
             expect(freshMegaMenu.mobileActive).toBe(false);
         });
@@ -396,11 +396,11 @@ describe('MegaMenu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(megaMenuInstance.model).toBe(testModel);
-            expect(megaMenuInstance.orientation).toBe('vertical');
-            expect(megaMenuInstance.styleClass).toBe('custom-megamenu');
-            expect(megaMenuInstance.ariaLabel).toBe('Custom MegaMenu');
-            expect(megaMenuInstance.tabindex).toBe(1);
+            expect(megaMenuInstance.model()).toBe(testModel);
+            expect(megaMenuInstance.orientation()).toBe('vertical');
+            expect(fixture.debugElement.query(By.directive(MegaMenu)).nativeElement.classList.contains('custom-megamenu')).toBe(true);
+            expect(megaMenuInstance.ariaLabel()).toBe('Custom MegaMenu');
+            expect(megaMenuInstance.tabindex()).toBe(1);
         });
 
         it('should initialize with generated id', () => {
@@ -408,9 +408,9 @@ describe('MegaMenu', () => {
             const freshMegaMenu = freshFixture.debugElement.query(By.directive(MegaMenu)).componentInstance;
             freshFixture.detectChanges();
 
-            expect(freshMegaMenu.id).toBeTruthy();
-            expect(typeof freshMegaMenu.id).toBe('string');
-            expect(freshMegaMenu.id).toMatch(/^pn_id_/);
+            expect(freshMegaMenu.$id()).toBeTruthy();
+            expect(typeof freshMegaMenu.$id()).toBe('string');
+            expect(freshMegaMenu.$id()).toMatch(/^pn_id_/);
         });
 
         it('should initialize signal states', () => {
@@ -421,8 +421,8 @@ describe('MegaMenu', () => {
         });
 
         it('should process model items on initialization', () => {
-            expect(megaMenuInstance.processedItems).toBeDefined();
-            expect(megaMenuInstance.processedItems.length).toBeGreaterThan(0);
+            expect(megaMenuInstance.processedItems()).toBeDefined();
+            expect(megaMenuInstance.processedItems().length).toBeGreaterThan(0);
         });
     });
 
@@ -433,8 +433,8 @@ describe('MegaMenu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(megaMenuInstance.model).toBe(newModel);
-            expect(megaMenuInstance.processedItems.length).toBe(1);
+            expect(megaMenuInstance.model()).toBe(newModel);
+            expect(megaMenuInstance.processedItems().length).toBe(1);
         });
 
         it('should update orientation input', async () => {
@@ -442,7 +442,7 @@ describe('MegaMenu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(megaMenuInstance.orientation).toBe('vertical');
+            expect(megaMenuInstance.orientation()).toBe('vertical');
         });
 
         it('should update styling inputs', async () => {
@@ -452,9 +452,9 @@ describe('MegaMenu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(megaMenuInstance.styleClass).toBe('test-class');
-            expect(megaMenuInstance.breakpoint).toBe('768px');
-            expect(megaMenuInstance.scrollHeight).toBe('15rem');
+            expect(fixture.debugElement.query(By.directive(MegaMenu)).nativeElement.classList.contains('test-class')).toBe(true);
+            expect(megaMenuInstance.breakpoint()).toBe('768px');
+            expect(megaMenuInstance.scrollHeight()).toBe('15rem');
         });
 
         it('should update disabled and tabindex inputs', async () => {
@@ -463,8 +463,8 @@ describe('MegaMenu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(megaMenuInstance.disabled).toBe(true);
-            expect(megaMenuInstance.tabindex).toBe(2);
+            expect(megaMenuInstance.disabled()).toBe(true);
+            expect(megaMenuInstance.tabindex()).toBe(2);
         });
 
         it('should update aria inputs', async () => {
@@ -473,15 +473,15 @@ describe('MegaMenu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(megaMenuInstance.ariaLabel).toBe('Test MegaMenu');
-            expect(megaMenuInstance.ariaLabelledBy).toBe('megamenu-label');
+            expect(megaMenuInstance.ariaLabel()).toBe('Test MegaMenu');
+            expect(megaMenuInstance.ariaLabelledBy()).toBe('megamenu-label');
         });
 
         it('should update id input', async () => {
             component.id = 'custom-megamenu-id';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(megaMenuInstance.id).toBe('custom-megamenu-id');
+            expect(megaMenuInstance.$id()).toBe('custom-megamenu-id');
         });
     });
 
@@ -540,7 +540,7 @@ describe('MegaMenu', () => {
 
     describe('Mega Panel Tests', () => {
         it('should detect if model has mega panels', () => {
-            const firstProcessedItem = megaMenuInstance.processedItems[0];
+            const firstProcessedItem = megaMenuInstance.processedItems()[0];
             expect(megaMenuInstance.isProcessedItemGroup(firstProcessedItem)).toBe(true);
         });
 
@@ -572,7 +572,7 @@ describe('MegaMenu', () => {
             component.orientation = 'horizontal';
             fixture.detectChanges();
 
-            expect(megaMenuInstance.orientation).toBe('horizontal');
+            expect(megaMenuInstance.orientation()).toBe('horizontal');
 
             const rootList = fixture.debugElement.query(By.css('ul[data-pc-section="rootlist"]'));
             expect(rootList.nativeElement.getAttribute('aria-orientation')).toBe('horizontal');
@@ -583,7 +583,7 @@ describe('MegaMenu', () => {
             verticalFixture.detectChanges();
 
             const verticalMegaMenu = verticalFixture.debugElement.query(By.directive(MegaMenu)).componentInstance;
-            expect(verticalMegaMenu.orientation).toBe('vertical');
+            expect(verticalMegaMenu.orientation()).toBe('vertical');
 
             const rootList = verticalFixture.debugElement.query(By.css('ul[data-pc-section="rootlist"]'));
             expect(rootList.nativeElement.getAttribute('aria-orientation')).toBe('vertical');
@@ -694,9 +694,9 @@ describe('MegaMenu', () => {
             pTemplateMegaMenu.ngAfterContentInit();
 
             expect(pTemplateMegaMenu.templates).toBeDefined();
-            expect(pTemplateMegaMenu._startTemplate).toBeDefined();
-            expect(pTemplateMegaMenu._endTemplate).toBeDefined();
-            expect(pTemplateMegaMenu._buttonTemplate).toBeDefined();
+            expect(pTemplateMegaMenu.$startTemplate()).toBeDefined();
+            expect(pTemplateMegaMenu.$endTemplate()).toBeDefined();
+            expect(pTemplateMegaMenu.$buttonTemplate()).toBeDefined();
         });
 
         it('should render start and end templates', () => {
@@ -927,14 +927,14 @@ describe('MegaMenu', () => {
 
             const hostElement = freshFixture.debugElement.query(By.directive(MegaMenu)).nativeElement;
             expect(hostElement.getAttribute('id')).toBeTruthy();
-            expect(hostElement.getAttribute('id')).toBe(freshMegaMenu.id);
+            expect(hostElement.getAttribute('id')).toBe(freshMegaMenu.$id());
         });
 
         it('should have generated id on host element', () => {
             // MegaMenu sets id on the host element (p-megamenu), not on the ul element
             const hostElement = fixture.debugElement.query(By.directive(MegaMenu)).nativeElement;
             expect(hostElement.getAttribute('id')).toBeTruthy();
-            expect(hostElement.getAttribute('id')).toBe(megaMenuInstance.id);
+            expect(hostElement.getAttribute('id')).toBe(megaMenuInstance.$id());
         });
     });
 
@@ -968,7 +968,7 @@ describe('MegaMenu', () => {
                 });
             } else {
                 // If no menu items are found, check that component is properly initialized
-                expect(megaMenuInstance.processedItems).toBeDefined();
+                expect(megaMenuInstance.processedItems()).toBeDefined();
             }
         });
 
@@ -997,7 +997,7 @@ describe('MegaMenu', () => {
             await fixture.whenStable();
 
             // Check if ariaLabel is set on component instance
-            expect(megaMenuInstance.ariaLabel).toBe('Main Navigation Menu');
+            expect(megaMenuInstance.ariaLabel()).toBe('Main Navigation Menu');
 
             // The current implementation may not bind aria-label to ul element
             const listElement = fixture.debugElement.query(By.css('ul[data-pc-section="rootlist"]'));
@@ -1015,7 +1015,7 @@ describe('MegaMenu', () => {
             await fixture.whenStable();
 
             // Check if ariaLabelledBy is set on component instance
-            expect(megaMenuInstance.ariaLabelledBy).toBe('megamenu-heading');
+            expect(megaMenuInstance.ariaLabelledBy()).toBe('megamenu-heading');
 
             // The current implementation may not bind aria-labelledby to ul element
             const listElement = fixture.debugElement.query(By.css('ul[data-pc-section="rootlist"]'));
@@ -1034,8 +1034,8 @@ describe('MegaMenu', () => {
                 expect(groupedItems.length).toBeGreaterThanOrEqual(1);
             } else {
                 // If no grouped items are found, verify the model has group items
-                const hasGroupedItems = megaMenuInstance.processedItems.some((item) => item.items && item.items.length > 0);
-                expect(hasGroupedItems || megaMenuInstance.processedItems.length).toBeGreaterThan(0);
+                const hasGroupedItems = megaMenuInstance.processedItems().some((item) => item.items && item.items.length > 0);
+                expect(hasGroupedItems || megaMenuInstance.processedItems().length).toBeGreaterThan(0);
             }
         });
     });
@@ -1050,7 +1050,7 @@ describe('MegaMenu', () => {
             expect(routerMegaMenu).toBeTruthy();
 
             // Verify that model items with router links are processed
-            const hasRouterItems = routerMegaMenu.processedItems.some((item) => {
+            const hasRouterItems = routerMegaMenu.processedItems().some((item) => {
                 function hasRouterLink(processedItem) {
                     if (processedItem.item && processedItem.item.routerLink) return true;
                     if (processedItem.items && processedItem.items.length) {
@@ -1068,7 +1068,7 @@ describe('MegaMenu', () => {
             routerFixture.detectChanges();
 
             const routerMegaMenu = routerFixture.debugElement.query(By.directive(MegaMenu)).componentInstance;
-            const processedItems = routerMegaMenu.processedItems;
+            const processedItems = routerMegaMenu.processedItems();
 
             // Find item with query params
             let foundQueryParams = false;
@@ -1106,7 +1106,7 @@ describe('MegaMenu', () => {
                 });
             }
 
-            checkForRouterLinks(routerMegaMenu.processedItems);
+            checkForRouterLinks(routerMegaMenu.processedItems());
             expect(foundRouterLinks).toBe(true);
         });
     });
@@ -1117,7 +1117,7 @@ describe('MegaMenu', () => {
             responsiveFixture.detectChanges();
 
             const responsiveMegaMenu = responsiveFixture.debugElement.query(By.directive(MegaMenu)).componentInstance;
-            expect(responsiveMegaMenu.breakpoint).toBe('768px');
+            expect(responsiveMegaMenu.breakpoint()).toBe('768px');
         });
 
         it('should show menu button on mobile', () => {
@@ -1151,7 +1151,7 @@ describe('MegaMenu', () => {
             await dynamicFixture.whenStable();
 
             // Initially empty
-            expect(dynamicMegaMenu.model.length).toBe(0);
+            expect(dynamicMegaMenu.model().length).toBe(0);
 
             // Add items
             dynamicComponent.addItem({ label: 'Item 1', icon: 'pi pi-test' });
@@ -1159,23 +1159,23 @@ describe('MegaMenu', () => {
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
 
-            expect(dynamicMegaMenu.model.length).toBe(2);
-            expect(dynamicMegaMenu.model[0].label).toBe('Item 1');
+            expect(dynamicMegaMenu.model().length).toBe(2);
+            expect(dynamicMegaMenu.model()[0].label).toBe('Item 1');
 
             // Remove item
             dynamicComponent.removeItem(0);
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
 
-            expect(dynamicMegaMenu.model.length).toBe(1);
-            expect(dynamicMegaMenu.model[0].label).toBe('Item 2');
+            expect(dynamicMegaMenu.model().length).toBe(1);
+            expect(dynamicMegaMenu.model()[0].label).toBe('Item 2');
 
             // Clear all
             dynamicComponent.clearItems();
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
 
-            expect(dynamicMegaMenu.model.length).toBe(0);
+            expect(dynamicMegaMenu.model().length).toBe(0);
         });
     });
 
@@ -1187,7 +1187,7 @@ describe('MegaMenu', () => {
             await fixture.whenStable();
 
             expect(() => fixture.changeDetectorRef.markForCheck()).not.toThrow();
-            expect(megaMenuInstance.model).toBeUndefined();
+            expect(megaMenuInstance.model()).toBeUndefined();
         });
 
         it('should handle items without icons', async () => {

--- a/packages/optimus-ui/src/megamenu/megamenu.ts
+++ b/packages/optimus-ui/src/megamenu/megamenu.ts
@@ -1,14 +1,15 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import {
+    afterEveryRender,
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
+    computed,
     effect,
     ElementRef,
     forwardRef,
     inject,
-    InjectionToken,
-    Input,
+    input,
     NgModule,
     numberAttribute,
     signal,
@@ -33,21 +34,18 @@ import { MegaMenuItemTemplateContext, MegaMenuPassThrough } from '@openng/optimu
 import { ZIndexUtils } from '@openng/optimus-ui/utils';
 import { MegaMenuStyle } from './style/megamenustyle';
 
-const MEGAMENU_INSTANCE = new InjectionToken<MegaMenu>('MEGAMENU_INSTANCE');
-const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INSTANCE');
-
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     selector: 'p-megaMenuSub, p-megamenu-sub, ul[pMegaMenuSub]',
     standalone: true,
     imports: [CommonModule, RouterModule, Ripple, TooltipModule, AngleDownIcon, AngleRightIcon, BadgeModule, SharedModule, Bind],
     template: `
-        @if (submenu) {
-            <li [class]="cn(cx('submenuLabel'), getItemProp(submenu, 'class'))" [style]="getItemProp(submenu, 'style')" role="presentation" [pBind]="ptm('submenuLabel')">
-                {{ getItemLabel(submenu) }}
+        @if (submenu()) {
+            <li [class]="cn(cx('submenuLabel'), getItemProp(submenu(), 'class'))" [style]="getItemProp(submenu(), 'style')" role="presentation" [pBind]="ptm('submenuLabel')">
+                {{ getItemLabel(submenu()) }}
             </li>
         }
-        @for (processedItem of items; track processedItem; let index = $index) {
+        @for (processedItem of items(); track processedItem; let index = $index) {
             @if (isItemVisible(processedItem) && getItemProp(processedItem, 'separator')) {
                 <li [attr.id]="getItemId(processedItem)" [style]="getItemProp(processedItem, 'style')" [class]="cn(cx('separator'), this.getItemProp(processedItem, 'class'))" role="separator" [pBind]="ptm('separator')"></li>
             }
@@ -63,7 +61,7 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
                     [attr.aria-disabled]="isItemDisabled(processedItem) || undefined"
                     [attr.aria-haspopup]="isItemGroup(processedItem) && !getItemProp(processedItem, 'to') ? 'menu' : undefined"
                     [attr.aria-expanded]="isItemGroup(processedItem) ? isItemActive(processedItem) : undefined"
-                    [attr.aria-level]="level + 1"
+                    [attr.aria-level]="level() + 1"
                     [attr.aria-setsize]="getAriaSetSize()"
                     [attr.aria-posinset]="getAriaPosInset(index)"
                     [ngStyle]="getItemProp(processedItem, 'style')"
@@ -74,7 +72,7 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
                     [pTooltipUnstyled]="unstyled()"
                 >
                     <div [class]="cx('itemContent')" [pBind]="getPTOptions(processedItem, index, 'itemContent')" (click)="onItemClick($event, processedItem)" (mouseenter)="onItemMouseEnter({ $event, processedItem })">
-                        @if (!itemTemplate) {
+                        @if (!itemTemplate()) {
                             @if (!getItemProp(processedItem, 'routerLink')) {
                                 <a
                                     [attr.href]="getItemProp(processedItem, 'url')"
@@ -112,16 +110,16 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
                                         <p-badge [class]="getItemProp(processedItem, 'badgeStyleClass')" [value]="getItemProp(processedItem, 'badge')" [unstyled]="unstyled()" />
                                     }
                                     @if (isItemGroup(processedItem)) {
-                                        @if (!megaMenu.submenuIconTemplate() && !megaMenu._submenuIconTemplate) {
-                                            @if (orientation === 'horizontal' || mobileActive) {
+                                        @if (!megaMenu.$submenuIconTemplate()) {
+                                            @if (orientation() === 'horizontal' || mobileActive()) {
                                                 <svg data-p-icon="angle-down" [class]="cx('submenuIcon')" [pBind]="getPTOptions(processedItem, index, 'submenuIcon')" [attr.aria-hidden]="true" />
                                             } @else {
-                                                @if (orientation === 'vertical') {
+                                                @if (orientation() === 'vertical') {
                                                     <svg data-p-icon="angle-right" [class]="cx('submenuIcon')" [pBind]="getPTOptions(processedItem, index, 'submenuIcon')" [attr.aria-hidden]="true" />
                                                 }
                                             }
                                         }
-                                        <ng-template *ngTemplateOutlet="megaMenu.submenuIconTemplate() || megaMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
+                                        <ng-template *ngTemplateOutlet="megaMenu.$submenuIconTemplate()" [attr.aria-hidden]="true"></ng-template>
                                     }
                                 </a>
                             }
@@ -167,24 +165,24 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
                                         ></span>
                                     }
                                     @if (getItemProp(processedItem, 'badge')) {
-                                        <p-badge [styleClass]="getItemProp(processedItem, 'badgeStyleClass')" [value]="getItemProp(processedItem, 'badge')" [unstyled]="unstyled()" />
+                                        <p-badge [class]="getItemProp(processedItem, 'badgeStyleClass')" [value]="getItemProp(processedItem, 'badge')" [unstyled]="unstyled()" />
                                     }
                                     @if (isItemGroup(processedItem)) {
-                                        @if (!megaMenu.submenuIconTemplate() && !megaMenu._submenuIconTemplate) {
-                                            @if (orientation === 'horizontal') {
+                                        @if (!megaMenu.$submenuIconTemplate()) {
+                                            @if (orientation() === 'horizontal') {
                                                 <svg data-p-icon="angle-down" [class]="cx('submenuIcon')" [pBind]="getPTOptions(processedItem, index, 'submenuIcon')" [attr.aria-hidden]="true" />
                                             }
-                                            @if (orientation === 'vertical') {
+                                            @if (orientation() === 'vertical') {
                                                 <svg data-p-icon="angle-right" [class]="cx('submenuIcon')" [pBind]="getPTOptions(processedItem, index, 'submenuIcon')" [attr.aria-hidden]="true" />
                                             }
                                         }
-                                        <ng-template *ngTemplateOutlet="megaMenu.submenuIconTemplate() || megaMenu._submenuIconTemplate" [attr.aria-hidden]="true"></ng-template>
+                                        <ng-template *ngTemplateOutlet="megaMenu.$submenuIconTemplate()" [attr.aria-hidden]="true"></ng-template>
                                     }
                                 </a>
                             }
                         }
-                        @if (itemTemplate) {
-                            <ng-template *ngTemplateOutlet="itemTemplate; context: { $implicit: processedItem.item }"></ng-template>
+                        @if (itemTemplate()) {
+                            <ng-template *ngTemplateOutlet="itemTemplate(); context: { $implicit: processedItem.item }"></ng-template>
                         }
                     </div>
                     @if (isItemVisible(processedItem) && isItemGroup(processedItem)) {
@@ -198,11 +196,11 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
                                                 [id]="getSubListId(submenu)"
                                                 [submenu]="submenu"
                                                 [items]="submenu.items"
-                                                [itemTemplate]="itemTemplate"
-                                                [mobileActive]="mobileActive"
-                                                [menuId]="menuId"
-                                                [focusedItemId]="focusedItemId"
-                                                [level]="level + 1"
+                                                [itemTemplate]="itemTemplate()"
+                                                [mobileActive]="mobileActive()"
+                                                [menuId]="menuId()"
+                                                [focusedItemId]="focusedItemId()"
+                                                [level]="level() + 1"
                                                 [root]="false"
                                                 (itemClick)="itemClick.emit($event)"
                                                 (itemMouseEnter)="onItemMouseEnter($event)"
@@ -220,20 +218,17 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
         }
     `,
     encapsulation: ViewEncapsulation.None,
-    providers: [
-        { provide: MEGAMENU_SUB_INSTANCE, useExisting: MegaMenuSub },
-        { provide: PARENT_INSTANCE, useExisting: MegaMenuSub }
-    ],
+    providers: [{ provide: PARENT_INSTANCE, useExisting: MegaMenuSub }],
     host: {
-        '[class]': 'root ? cx("rootList") : cx("submenu")',
+        '[class]': 'root() ? cx("rootList") : cx("submenu")',
         '[style]': 'sx("rootList")',
-        '[style.display]': 'isSubmenuVisible(submenu) ? null : "none"',
-        '[attr.role]': 'root ? "menubar" : "menu"',
-        '[attr.id]': 'id',
-        '[attr.aria-orientation]': 'orientation',
-        '[tabindex]': 'tabindex',
-        '[attr.aria-activedescendant]': 'focusedItemId',
-        '[attr.data-pc-section]': 'root ? "rootlist" : "submenu"',
+        '[style.display]': 'isSubmenuVisible(submenu()) ? null : "none"',
+        '[attr.role]': 'root() ? "menubar" : "menu"',
+        '[attr.id]': 'id()',
+        '[attr.aria-orientation]': 'orientation()',
+        '[tabindex]': 'tabindex()',
+        '[attr.aria-activedescendant]': 'focusedItemId()',
+        '[attr.data-pc-section]': 'root() ? "rootlist" : "submenu"',
         '(keydown)': 'menuKeydown.emit($event)',
         '(focus)': 'menuFocus.emit($event)',
         '(blur)': 'menuBlur.emit($event)',
@@ -244,43 +239,43 @@ const MEGAMENU_SUB_INSTANCE = new InjectionToken<MegaMenuSub>('MEGAMENU_SUB_INST
 export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
     bindDirectiveInstance = inject(Bind, { self: true });
 
-    $pcMegaMenu: MegaMenu | undefined = inject(MEGAMENU_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
+    megaMenu: MegaMenu = inject(forwardRef(() => MegaMenu));
 
-    $pcMegaMenuSub: MegaMenuSub | undefined = inject(MEGAMENU_SUB_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
+    _componentStyle = inject(MegaMenuStyle);
 
-    @Input() id: string | undefined;
+    readonly id = input<string>();
 
-    @Input() items: any[] | undefined;
+    readonly items = input<any[]>();
 
-    @Input() itemTemplate: TemplateRef<MegaMenuItemTemplateContext> | undefined;
+    readonly itemTemplate = input<TemplateRef<MegaMenuItemTemplateContext>>();
 
-    @Input() menuId: string | undefined;
+    readonly menuId = input<string>();
 
-    @Input() ariaLabel: string | undefined;
+    readonly ariaLabel = input<string>();
 
-    @Input() ariaLabelledBy: string | undefined;
+    readonly ariaLabelledBy = input<string>();
 
-    @Input({ transform: numberAttribute }) level: number = 0;
+    readonly level = input<number, unknown>(0, { transform: numberAttribute });
 
-    @Input() focusedItemId: string | undefined;
+    readonly focusedItemId = input<string>();
 
-    @Input({ transform: booleanAttribute }) disabled: boolean = false;
+    readonly disabled = input<boolean, unknown>(false, { transform: booleanAttribute });
 
-    @Input() orientation: string | undefined;
+    readonly orientation = input<string>();
 
-    @Input() activeItem: any;
+    readonly activeItem = input<any>();
 
-    @Input() submenu: any;
+    readonly submenu = input<any>();
 
-    @Input({ transform: booleanAttribute }) queryMatches: boolean = false;
+    readonly queryMatches = input<boolean, unknown>(false, { transform: booleanAttribute });
 
-    @Input({ transform: booleanAttribute }) mobileActive: boolean = false;
+    readonly mobileActive = input<boolean, unknown>(false, { transform: booleanAttribute });
 
-    @Input() scrollHeight: string;
+    readonly scrollHeight = input<string>();
 
-    @Input({ transform: numberAttribute }) tabindex: number = 0;
+    readonly tabindex = input<number, unknown>(0, { transform: numberAttribute });
 
-    @Input({ transform: booleanAttribute }) root: boolean = false;
+    readonly root = input<boolean, unknown>(false, { transform: booleanAttribute });
 
     readonly itemClick = output<any>();
 
@@ -294,12 +289,13 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
 
     readonly menuMouseDown = output<any>();
 
-    megaMenu: MegaMenu = inject(forwardRef(() => MegaMenu));
-
-    _componentStyle = inject(MegaMenuStyle);
-
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptm(this.root ? 'rootList' : 'submenu'));
+    constructor() {
+        super();
+        // Re-apply the list pass-through section after each render (replaces the former
+        // ngAfterViewChecked hook).
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptm(this.root() ? 'rootList' : 'submenu'));
+        });
     }
 
     onItemClick(event: any, processedItem: any) {
@@ -312,7 +308,7 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
     }
 
     getItemId(processedItem: any): string {
-        return processedItem.item && processedItem.item?.id ? processedItem.item.id : `${this.menuId}_${processedItem.key}`;
+        return processedItem.item && processedItem.item?.id ? processedItem.item.id : `${this.menuId()}_${processedItem.key}`;
     }
 
     getSubListId(processedItem) {
@@ -324,7 +320,7 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
     }
 
     isSubmenuVisible(submenu: any) {
-        if (this.submenu && !this.root) {
+        if (this.submenu() && !this.root()) {
             return this.isItemVisible(submenu);
         } else {
             return true;
@@ -336,7 +332,7 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
     }
 
     isItemActive(processedItem) {
-        return isNotEmpty(this.activeItem) ? this.activeItem.key === processedItem.key : false;
+        return isNotEmpty(this.activeItem()) ? this.activeItem().key === processedItem.key : false;
     }
 
     isItemDisabled(processedItem: any): boolean {
@@ -344,7 +340,7 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
     }
 
     isItemFocused(processedItem: any): boolean {
-        return this.focusedItemId === this.getItemId(processedItem);
+        return this.focusedItemId() === this.getItemId(processedItem);
     }
 
     isItemGroup(processedItem: any): boolean {
@@ -352,11 +348,17 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
     }
 
     getAriaSetSize() {
-        return this.items?.filter((processedItem) => this.isItemVisible(processedItem) && !this.getItemProp(processedItem, 'separator')).length;
+        return this.items()?.filter((processedItem) => this.isItemVisible(processedItem) && !this.getItemProp(processedItem, 'separator')).length;
     }
 
     getAriaPosInset(index: number) {
-        return index - (this.items?.slice(0, index).filter((processedItem) => this.isItemVisible(processedItem) && this.getItemProp(processedItem, 'separator')).length || 0) + 1;
+        return (
+            index -
+            (this.items()
+                ?.slice(0, index)
+                .filter((processedItem) => this.isItemVisible(processedItem) && this.getItemProp(processedItem, 'separator')).length || 0) +
+            1
+        );
     }
 
     onItemMouseEnter(param: any) {
@@ -387,49 +389,49 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
     standalone: true,
     imports: [CommonModule, RouterModule, MegaMenuSub, TooltipModule, BarsIcon, BadgeModule, SharedModule, Bind],
     template: `
-        @if (startTemplate() || _startTemplate) {
+        @if ($startTemplate()) {
             <div [class]="cx('start')" [pBind]="ptm('start')">
-                <ng-container *ngTemplateOutlet="startTemplate() || _startTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="$startTemplate()"></ng-container>
             </div>
         }
-        @if (!buttonTemplate() && !_buttonTemplate) {
-            @if (model && model.length > 0) {
+        @if (!$buttonTemplate()) {
+            @if (model() && model()!.length > 0) {
                 <a
                     #menubutton
                     role="button"
                     tabindex="0"
                     [class]="cx('button')"
-                    [attr.aria-haspopup]="model.length && model.length > 0 ? true : false"
+                    [attr.aria-haspopup]="model()!.length && model()!.length > 0 ? true : false"
                     [attr.aria-expanded]="mobileActive"
-                    [attr.aria-controls]="id"
+                    [attr.aria-controls]="$id()"
                     [attr.aria-label]="config.translation.aria.navigation"
                     [pBind]="ptm('button')"
                     (click)="menuButtonClick($event)"
                     (keydown)="menuButtonKeydown($event)"
                 >
-                    @if (!buttonIconTemplate() && !_buttonIconTemplate) {
+                    @if (!$buttonIconTemplate()) {
                         <svg data-p-icon="bars" [pBind]="ptm('buttonIcon')" />
                     }
-                    <ng-template *ngTemplateOutlet="buttonIconTemplate() || _buttonIconTemplate"></ng-template>
+                    <ng-template *ngTemplateOutlet="$buttonIconTemplate()"></ng-template>
                 </a>
             }
         }
-        <ng-container *ngTemplateOutlet="buttonTemplate() || _buttonTemplate"></ng-container>
+        <ng-container *ngTemplateOutlet="$buttonTemplate()"></ng-container>
         <ul
             pMegaMenuSub
             #rootmenu
-            [itemTemplate]="itemTemplate() || _itemTemplate"
-            [items]="processedItems"
-            [attr.id]="id + '_list'"
-            [menuId]="id"
+            [itemTemplate]="$itemTemplate()"
+            [items]="processedItems()"
+            [attr.id]="$id() + '_list'"
+            [menuId]="$id()"
             [root]="true"
-            [orientation]="orientation"
-            [ariaLabel]="ariaLabel"
-            [disabled]="disabled"
-            [tabindex]="!disabled ? tabindex : -1"
+            [orientation]="orientation()"
+            [ariaLabel]="ariaLabel()"
+            [disabled]="disabled()"
+            [tabindex]="!disabled() ? tabindex() : -1"
             [activeItem]="activeItem()"
             [level]="0"
-            [ariaLabelledBy]="ariaLabelledBy"
+            [ariaLabelledBy]="ariaLabelledBy()"
             [focusedItemId]="focused ? focusedItemId : undefined"
             [mobileActive]="mobileActive"
             (itemClick)="onItemClick($event)"
@@ -439,101 +441,106 @@ export class MegaMenuSub extends BaseComponent<MegaMenuPassThrough> {
             (menuMouseDown)="onMenuMouseDown($event)"
             (itemMouseEnter)="onItemMouseEnter($event)"
             [queryMatches]="queryMatches()"
-            [scrollHeight]="scrollHeight"
+            [scrollHeight]="scrollHeight()"
             [pt]="pt()"
             [unstyled]="unstyled()"
         ></ul>
-        @if (endTemplate() || _endTemplate) {
+        @if ($endTemplate()) {
             <div [class]="cx('end')" [pBind]="ptm('end')">
-                <ng-container *ngTemplateOutlet="endTemplate() || _endTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="$endTemplate()"></ng-container>
             </div>
         }
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [MegaMenuStyle, { provide: MEGAMENU_INSTANCE, useExisting: MegaMenu }, { provide: PARENT_INSTANCE, useExisting: MegaMenu }],
+    providers: [MegaMenuStyle, { provide: PARENT_INSTANCE, useExisting: MegaMenu }],
     host: {
-        '[class]': 'cn(cx("root"), styleClass)',
-        '[id]': 'id'
+        '[class]': 'cx("root")',
+        '[id]': '$id()'
     },
     hostDirectives: [Bind]
 })
 export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
-    componentName = 'MegaMenu';
-
     bindDirectiveInstance = inject(Bind, { self: true });
+
+    _componentStyle = inject(MegaMenuStyle);
+
     /**
      * An array of menuitems.
      * @group Props
      */
-    @Input() set model(value: MegaMenuItem[] | undefined) {
-        this._model = value;
-        this._processedItems = this.createProcessedItems(this._model || []);
-    }
-    get model(): MegaMenuItem[] | undefined {
-        return this._model;
-    }
-    /**
-     * Class of the element.
-     * @deprecated since v20.0.0, use `class` instead.
-     * @group Props
-     */
-    @Input() styleClass: string | undefined;
+    readonly model = input<MegaMenuItem[]>();
+
     /**
      * Defines the orientation.
      * @group Props
      */
-    @Input() orientation: 'horizontal' | 'vertical' | string = 'horizontal';
+    readonly orientation = input<'horizontal' | 'vertical' | string>('horizontal');
+
     /**
      * Current id state as a string.
      * @group Props
      */
-    @Input() id: string | undefined;
+    readonly id = input<string>();
+
     /**
      * Defines a string value that labels an interactive element.
      * @group Props
      */
-    @Input() ariaLabel: string | undefined;
+    readonly ariaLabel = input<string>();
+
     /**
      * Identifier of the underlying input element.
      * @group Props
      */
-    @Input() ariaLabelledBy: string | undefined;
+    readonly ariaLabelledBy = input<string>();
+
     /**
      * The breakpoint to define the maximum width boundary.
      * @group Props
      */
-    @Input() breakpoint: string = '960px';
+    readonly breakpoint = input<string>('960px');
+
     /**
      * Height of the viewport, a scrollbar is defined if height of list exceeds this value.
      * @group Props
      */
-    @Input() scrollHeight: string = '20rem';
+    readonly scrollHeight = input<string>('20rem');
+
     /**
      * When present, it specifies that the component should be disabled.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) disabled: boolean = false;
+    readonly disabled = input<boolean, unknown>(false, { transform: booleanAttribute });
+
     /**
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number = 0;
+    readonly tabindex = input<number, unknown>(0, { transform: numberAttribute });
+
+    readonly menubuttonViewChild = viewChild<ElementRef>('menubutton');
+
+    readonly rootmenu = viewChild.required<MegaMenuSub>('rootmenu');
+
     /**
      * Defines template option for start.
      * @group Templates
      */
     readonly startTemplate = contentChild<TemplateRef<void>>('start', { descendants: false });
+
     /**
      * Defines template option for end.
      * @group Templates
      */
     readonly endTemplate = contentChild<TemplateRef<void>>('end', { descendants: false });
+
     /**
      * Defines template option for submenu icon.
      * @group Templates
      */
     readonly submenuIconTemplate = contentChild<TemplateRef<void>>('submenuicon', { descendants: false });
+
     /**
      * Custom item template.
      * @param {MegaMenuItemTemplateContext} context - item context.
@@ -541,11 +548,13 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
      * @group Templates
      */
     readonly itemTemplate = contentChild<TemplateRef<MegaMenuItemTemplateContext>>('item', { descendants: false });
+
     /**
      * Custom menu button template on responsive mode.
      * @group Templates
      */
     readonly buttonTemplate = contentChild<TemplateRef<void>>('button', { descendants: false });
+
     /**
      * Custom menu button icon template on responsive mode.
      * @group Templates
@@ -554,23 +563,71 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
 
     readonly templates = contentChildren(PrimeTemplate);
 
-    readonly menubuttonViewChild = viewChild<ElementRef>('menubutton');
+    componentName = 'MegaMenu';
 
-    readonly rootmenu = viewChild.required<MegaMenuSub>('rootmenu');
+    /** Stable generated fallback used when no `id` is provided. */
+    private readonly generatedId = uuid('pn_id_');
 
-    _startTemplate: TemplateRef<void> | undefined;
+    /** Effective id: the `id` input or a generated unique id. */
+    readonly $id = computed(() => this.id() || this.generatedId);
 
-    _endTemplate: TemplateRef<void> | undefined;
+    /** Effective start template: the `#start` content child or the `pTemplate="start"`. */
+    readonly $startTemplate = computed(
+        () =>
+            this.startTemplate() ??
+            this.templates()
+                .filter((item) => item.getType() === 'start')
+                .at(-1)?.template
+    );
 
-    _menuIconTemplate: TemplateRef<void> | undefined;
+    /** Effective end template: the `#end` content child or the `pTemplate="end"`. */
+    readonly $endTemplate = computed(
+        () =>
+            this.endTemplate() ??
+            this.templates()
+                .filter((item) => item.getType() === 'end')
+                .at(-1)?.template
+    );
 
-    _submenuIconTemplate: TemplateRef<void> | undefined;
+    /** Effective submenu icon template: the `#submenuicon` content child or the `pTemplate="submenuicon"`. */
+    readonly $submenuIconTemplate = computed(
+        () =>
+            this.submenuIconTemplate() ??
+            this.templates()
+                .filter((item) => item.getType() === 'submenuicon')
+                .at(-1)?.template
+    );
 
-    _itemTemplate: TemplateRef<MegaMenuItemTemplateContext> | undefined;
+    /** Effective button template: the `#button` content child or the `pTemplate="button"`. */
+    readonly $buttonTemplate = computed(
+        () =>
+            this.buttonTemplate() ??
+            this.templates()
+                .filter((item) => item.getType() === 'button')
+                .at(-1)?.template
+    );
 
-    _buttonTemplate: TemplateRef<void> | undefined;
+    /** Effective button icon template: the `#buttonicon` content child or the `pTemplate="buttonicon"`. */
+    readonly $buttonIconTemplate = computed(
+        () =>
+            this.buttonIconTemplate() ??
+            this.templates()
+                .filter((item) => item.getType() === 'buttonicon')
+                .at(-1)?.template
+    );
 
-    _buttonIconTemplate: TemplateRef<void> | undefined;
+    /**
+     * Effective item template: the `#item` content child or (legacy behavior) the last projected
+     * pTemplate of type `item` or of an unknown type. The legacy `menuicon` pTemplate was assigned
+     * but never rendered, so it is excluded here as well.
+     */
+    readonly $itemTemplate = computed(
+        () =>
+            this.itemTemplate() ??
+            (this.templates()
+                .filter((item) => !['start', 'end', 'menuicon', 'submenuicon', 'button', 'buttonicon'].includes(item.getType()))
+                .at(-1)?.template as TemplateRef<MegaMenuItemTemplateContext> | undefined)
+    );
 
     outsideClickListener: VoidListener;
 
@@ -587,12 +644,6 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     searchValue: string = '';
 
     searchTimeout: any;
-
-    _processedItems: any[];
-
-    _model: MegaMenuItem[] | undefined;
-
-    _componentStyle = inject(MegaMenuStyle);
 
     private matchMediaListener: () => void;
 
@@ -615,23 +666,25 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
 
                   return items;
               }, [])
-            : this.processedItems;
+            : this.processedItems();
     }
 
-    get processedItems() {
-        if (!this._processedItems || !this._processedItems.length) {
-            this._processedItems = this.createProcessedItems(this.model || []);
-        }
-        return this._processedItems;
-    }
+    /** Processed model tree, recomputed whenever the `model` input changes (replaces the legacy setter). */
+    readonly processedItems = computed(() => this.createProcessedItems(this.model() || []));
 
     get focusedItemId() {
         const focusedItem = this.focusedItemInfo();
-        return focusedItem?.item && focusedItem.item?.id ? focusedItem.item.id : isNotEmpty(focusedItem.key) ? `${this.id}_${focusedItem.key}` : null;
+        return focusedItem?.item && focusedItem.item?.id ? focusedItem.item.id : isNotEmpty(focusedItem.key) ? `${this.$id()}_${focusedItem.key}` : null;
     }
 
     constructor() {
         super();
+        // Re-apply the host/root pass-through sections after each render (replaces the former
+        // ngAfterViewChecked hook).
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
+        });
+
         effect(() => {
             const activeItem = this.activeItem();
             if (isNotEmpty(activeItem)) {
@@ -646,55 +699,18 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
 
     onInit(): void {
         this.bindMatchMediaListener();
-        this.id = this.id || uuid('pn_id_');
     }
 
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
-    }
-
-    onAfterContentInit() {
-        this.templates()?.forEach((item) => {
-            switch (item.getType()) {
-                case 'start':
-                    this._startTemplate = item.template;
-                    break;
-
-                case 'end':
-                    this._endTemplate = item.template;
-                    break;
-
-                case 'menuicon':
-                    this._menuIconTemplate = item.template;
-                    break;
-
-                case 'submenuicon':
-                    this._submenuIconTemplate = item.template;
-                    break;
-
-                case 'item':
-                    this._itemTemplate = item.template;
-                    break;
-
-                case 'button':
-                    this._buttonTemplate = item.template;
-                    break;
-
-                case 'buttonicon':
-                    this._buttonIconTemplate = item.template;
-                    break;
-
-                default:
-                    this._itemTemplate = item.template;
-                    break;
-            }
-        });
+    onDestroy() {
+        this.unbindOutsideClickListener();
+        this.unbindResizeListener();
+        this.unbindMatchMediaListener();
     }
 
     bindMatchMediaListener() {
         if (isPlatformBrowser(this.platformId)) {
             if (!this.matchMediaListener) {
-                const query = window.matchMedia(`(max-width: ${this.breakpoint})`);
+                const query = window.matchMedia(`(max-width: ${this.breakpoint()})`);
 
                 this.query = query;
                 this.queryMatches.set(query.matches);
@@ -810,7 +826,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     }
 
     scrollInView(index: number = -1) {
-        const id = index !== -1 ? `${this.id}_${index}` : this.focusedItemId;
+        const id = index !== -1 ? `${this.$id()}_${index}` : this.focusedItemId;
 
         let element;
 
@@ -1058,7 +1074,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     }
 
     onArrowDownKey(event: KeyboardEvent) {
-        if (this.orientation === 'horizontal') {
+        if (this.orientation() === 'horizontal') {
             if (isNotEmpty(this.activeItem()) && this.activeItem().key === this.focusedItemInfo().key) {
                 const { key, item } = this.activeItem();
                 this.focusedItemInfo.set({ index: -1, key: '', parentKey: key, item });
@@ -1085,7 +1101,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
         const grouped = this.isProccessedItemGroup(processedItem);
 
         if (grouped) {
-            if (this.orientation === 'vertical') {
+            if (this.orientation() === 'vertical') {
                 if (isNotEmpty(this.activeItem()) && this.activeItem().key === processedItem.key) {
                     this.focusedItemInfo.set({ index: -1, key: '', parentKey: this.activeItem().key, item: processedItem.item });
                 } else {
@@ -1119,7 +1135,7 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
     }
 
     onArrowUpKey(event: KeyboardEvent) {
-        if (event.altKey && this.orientation === 'horizontal') {
+        if (event.altKey && this.orientation() === 'horizontal') {
             if (this.focusedItemInfo().index !== -1) {
                 const processedItem = this.findVisibleItem(this.focusedItemInfo().index);
                 const grouped = this.isProccessedItemGroup(processedItem);
@@ -1153,13 +1169,13 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
         const grouped = this.isProccessedItemGroup(processedItem);
 
         if (grouped) {
-            if (this.orientation === 'horizontal') {
+            if (this.orientation() === 'horizontal') {
                 const itemIndex = this.focusedItemInfo().index !== -1 ? this.findPrevItemIndex(this.focusedItemInfo().index) : this.findLastFocusedItemIndex();
 
                 this.changeFocusedItemInfo(event, itemIndex);
             }
         } else {
-            if (this.orientation === 'vertical' && isNotEmpty(this.activeItem())) {
+            if (this.orientation() === 'vertical' && isNotEmpty(this.activeItem())) {
                 if (processedItem.columnIndex === 0) {
                     this.focusedItemInfo.set({
                         index: this.activeItem().index,
@@ -1295,12 +1311,6 @@ export class MegaMenu extends BaseComponent<MegaMenuPassThrough> {
             window.removeEventListener('resize', this.resizeListener);
             this.resizeListener = null!;
         }
-    }
-
-    onDestroy() {
-        this.unbindOutsideClickListener();
-        this.unbindResizeListener();
-        this.unbindMatchMediaListener();
     }
 }
 

--- a/packages/optimus-ui/src/megamenu/style/megamenustyle.ts
+++ b/packages/optimus-ui/src/megamenu/style/megamenustyle.ts
@@ -3,7 +3,7 @@ import { style } from '@openng/optimus-ui-styles/megamenu';
 import { BaseStyle } from '@openng/optimus-ui/base';
 
 const inlineStyles = {
-    rootList: ({ instance }) => ({ 'max-height': instance.scrollHeight, overflow: 'auto' })
+    rootList: ({ instance }) => ({ 'max-height': instance.scrollHeight(), overflow: 'auto' })
 };
 
 const classes = {
@@ -12,8 +12,8 @@ const classes = {
         {
             'p-megamenu-mobile': instance.queryMatches(),
             'p-megamenu-mobile-active': instance.mobileActive,
-            'p-megamenu-horizontal': instance.orientation === 'horizontal',
-            'p-megamenu-vertical': instance.orientation === 'vertical'
+            'p-megamenu-horizontal': instance.orientation() === 'horizontal',
+            'p-megamenu-vertical': instance.orientation() === 'vertical'
         }
     ],
     start: 'p-megamenu-start',

--- a/packages/optimus-ui/src/menu/menu.test.ts
+++ b/packages/optimus-ui/src/menu/menu.test.ts
@@ -339,14 +339,14 @@ describe('Menu', () => {
 
             const freshMenu = freshFixture.debugElement.query(By.directive(Menu)).componentInstance;
 
-            expect(freshMenu.model).toBeUndefined();
-            expect(freshMenu.popup).toBeUndefined();
-            expect(freshMenu.autoZIndex).toBe(true);
-            expect(freshMenu.baseZIndex).toBe(0);
-            expect(freshMenu.tabindex).toBe(0);
-            expect(freshMenu.showTransitionOptions).toBe('.12s cubic-bezier(0, 0, 0.2, 1)');
-            expect(freshMenu.hideTransitionOptions).toBe('.1s linear');
-            expect(freshMenu.focused).toBe(false);
+            expect(freshMenu.model()).toBeUndefined();
+            expect(freshMenu.popup()).toBeUndefined();
+            expect(freshMenu.autoZIndex()).toBe(true);
+            expect(freshMenu.baseZIndex()).toBe(0);
+            expect(freshMenu.tabindex()).toBe(0);
+            expect(freshMenu.showTransitionOptions()).toBe('.12s cubic-bezier(0, 0, 0.2, 1)');
+            expect(freshMenu.hideTransitionOptions()).toBe('.1s linear');
+            expect(freshMenu.focused()).toBe(false);
             expect(menuInstance.focusedOptionIndex()).toBe(-1);
         });
 
@@ -360,11 +360,11 @@ describe('Menu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(menuInstance.model).toBe(testModel);
-            expect(menuInstance.popup).toBe(true);
-            expect(menuInstance.styleClass).toBe('custom-menu');
-            expect(menuInstance.ariaLabel).toBe('Custom Menu');
-            expect(menuInstance.tabindex).toBe(1);
+            expect(menuInstance.model()).toBe(testModel);
+            expect(menuInstance.popup()).toBe(true);
+            expect(menuInstance.styleClass()).toBe('custom-menu');
+            expect(menuInstance.ariaLabel()).toBe('Custom Menu');
+            expect(menuInstance.tabindex()).toBe(1);
         });
 
         it('should initialize with generated id', () => {
@@ -373,9 +373,9 @@ describe('Menu', () => {
             const freshMenu = freshFixture.debugElement.query(By.directive(Menu)).componentInstance;
             freshFixture.detectChanges();
 
-            expect(freshMenu.id).toBeTruthy();
-            expect(typeof freshMenu.id).toBe('string');
-            expect(freshMenu.id).toMatch(/^pn_id_/);
+            expect(freshMenu.$id()).toBeTruthy();
+            expect(typeof freshMenu.$id()).toBe('string');
+            expect(freshMenu.$id()).toMatch(/^pn_id_/);
         });
 
         it('should have output emitters', () => {
@@ -400,7 +400,7 @@ describe('Menu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(menuInstance.model).toBe(newModel);
+            expect(menuInstance.model()).toBe(newModel);
         });
 
         it('should update popup input', async () => {
@@ -408,7 +408,7 @@ describe('Menu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(menuInstance.popup).toBe(true);
+            expect(menuInstance.popup()).toBe(true);
         });
 
         it('should update style inputs', async () => {
@@ -417,8 +417,8 @@ describe('Menu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(menuInstance.style).toEqual({ width: '200px' });
-            expect(menuInstance.styleClass).toBe('test-class');
+            expect(menuInstance.style()).toEqual({ width: '200px' });
+            expect(menuInstance.styleClass()).toBe('test-class');
         });
 
         it('should update z-index inputs', async () => {
@@ -427,8 +427,8 @@ describe('Menu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(menuInstance.autoZIndex).toBe(false);
-            expect(menuInstance.baseZIndex).toBe(1000);
+            expect(menuInstance.autoZIndex()).toBe(false);
+            expect(menuInstance.baseZIndex()).toBe(1000);
         });
 
         it('should update transition inputs', async () => {
@@ -437,8 +437,8 @@ describe('Menu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(menuInstance.showTransitionOptions).toBe('.2s ease-in');
-            expect(menuInstance.hideTransitionOptions).toBe('.15s ease-out');
+            expect(menuInstance.showTransitionOptions()).toBe('.2s ease-in');
+            expect(menuInstance.hideTransitionOptions()).toBe('.15s ease-out');
         });
 
         it('should update aria inputs', async () => {
@@ -447,44 +447,44 @@ describe('Menu', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(menuInstance.ariaLabel).toBe('Test Menu');
-            expect(menuInstance.ariaLabelledBy).toBe('menu-label');
+            expect(menuInstance.ariaLabel()).toBe('Test Menu');
+            expect(menuInstance.ariaLabelledBy()).toBe('menu-label');
         });
 
         it('should update tabindex input', async () => {
             component.tabindex = 2;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(menuInstance.tabindex).toBe(2);
+            expect(menuInstance.tabindex()).toBe(2);
         });
 
         it('should update id input', async () => {
             component.id = 'custom-menu-id';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(menuInstance.id).toBe('custom-menu-id');
+            expect(menuInstance.$id()).toBe('custom-menu-id');
         });
     });
 
     describe('Menu Item Display Tests', () => {
         it('should render menu items from model', async () => {
             // Verify model has correct structure
-            expect(menuInstance.model).toBeDefined();
-            expect(menuInstance.model!.length).toBe(4); // File, Edit, separator, Settings
+            expect(menuInstance.model()).toBeDefined();
+            expect(menuInstance.model()!.length).toBe(4); // File, Edit, separator, Settings
             // Count non-separator items
-            const nonSeparatorItems = menuInstance.model!.filter((item) => !item.separator);
+            const nonSeparatorItems = menuInstance.model()!.filter((item) => !item.separator);
             expect(nonSeparatorItems.length).toBe(3);
         });
 
         it('should render item icons when provided', async () => {
             // Verify items have icons in model
-            const itemsWithIcons = menuInstance.model!.filter((item) => item.icon);
+            const itemsWithIcons = menuInstance.model()!.filter((item) => item.icon);
             expect(itemsWithIcons.length).toBeGreaterThanOrEqual(3);
         });
 
         it('should render item labels', async () => {
             // Verify labels in model
-            const items = menuInstance.model!.filter((item) => !item.separator);
+            const items = menuInstance.model()!.filter((item) => !item.separator);
             expect(items[0].label).toBe('File');
             expect(items[1].label).toBe('Edit');
             expect(items[2].label).toBe('Settings');
@@ -508,7 +508,7 @@ describe('Menu', () => {
             await emptyFixture.whenStable();
 
             const emptyMenu = emptyFixture.debugElement.query(By.directive(Menu)).componentInstance;
-            expect(emptyMenu.model).toBeUndefined();
+            expect(emptyMenu.model()).toBeUndefined();
         });
 
         it('should handle null model', async () => {
@@ -517,12 +517,12 @@ describe('Menu', () => {
             await minimalFixture.whenStable();
 
             const minimalMenu = minimalFixture.debugElement.query(By.directive(Menu)).componentInstance;
-            expect(minimalMenu.model).toBeUndefined();
+            expect(minimalMenu.model()).toBeUndefined();
         });
 
         it('should render separators', async () => {
             // Verify model has separator
-            const separators = menuInstance.model!.filter((item) => item.separator);
+            const separators = menuInstance.model()!.filter((item) => item.separator);
             expect(separators.length).toBe(1);
         });
     });
@@ -557,9 +557,9 @@ describe('Menu', () => {
             // Verify the menu instance has submenu
             const submenuInstance = submenuFixture.debugElement.query(By.directive(Menu)).componentInstance;
             expect(submenuInstance.hasSubMenu()).toBe(true);
-            expect(submenuInstance.model.length).toBe(2); // File and Edit groups
-            expect(submenuInstance.model[0].items.length).toBe(2); // File has 2 items
-            expect(submenuInstance.model[1].items.length).toBe(2); // Edit has 2 items
+            expect(submenuInstance.model()!.length).toBe(2); // File and Edit groups
+            expect(submenuInstance.model()![0].items.length).toBe(2); // File has 2 items
+            expect(submenuInstance.model()![1].items.length).toBe(2); // Edit has 2 items
         });
 
         it('should not render submenu header when visible is false', async () => {
@@ -598,11 +598,11 @@ describe('Menu', () => {
             await commandFixture.whenStable();
 
             const commandMenu = commandFixture.debugElement.query(By.directive(Menu)).componentInstance;
-            expect(commandMenu.model.length).toBe(1);
-            expect(commandMenu.model[0].label).toBe('Command Item');
+            expect(commandMenu.model()!.length).toBe(1);
+            expect(commandMenu.model()![0].label).toBe('Command Item');
 
             // Simulate command execution directly
-            commandMenu.model[0].command({ item: commandMenu.model[0], originalEvent: new Event('click') });
+            commandMenu.model()![0].command({ item: commandMenu.model()![0], originalEvent: new Event('click') });
 
             expect(commandComponent.commandExecuted).toBeDefined();
             expect(commandComponent.commandExecuted.item.label).toBe('Command Item');
@@ -614,8 +614,8 @@ describe('Menu', () => {
             await disabledFixture.whenStable();
 
             const disabledMenu = disabledFixture.debugElement.query(By.directive(Menu)).componentInstance;
-            const disabledItem = disabledMenu.model[1];
-            const functionDisabledItem = disabledMenu.model[2];
+            const disabledItem = disabledMenu.model()![1];
+            const functionDisabledItem = disabledMenu.model()![2];
 
             expect(disabledMenu.disabled(disabledItem.disabled)).toBe(true);
             expect(disabledMenu.disabled(functionDisabledItem.disabled)).toBe(true);
@@ -629,10 +629,10 @@ describe('Menu', () => {
             const disabledMenu = disabledFixture.debugElement.query(By.directive(Menu)).componentInstance;
 
             // Verify model is correct
-            expect(disabledMenu.model.length).toBe(3);
-            expect(disabledMenu.disabled(disabledMenu.model[0].disabled)).toBe(false);
-            expect(disabledMenu.disabled(disabledMenu.model[1].disabled)).toBe(true);
-            expect(disabledMenu.disabled(disabledMenu.model[2].disabled)).toBe(true);
+            expect(disabledMenu.model()!.length).toBe(3);
+            expect(disabledMenu.disabled(disabledMenu.model()![0].disabled)).toBe(false);
+            expect(disabledMenu.disabled(disabledMenu.model()![1].disabled)).toBe(true);
+            expect(disabledMenu.disabled(disabledMenu.model()![2].disabled)).toBe(true);
         });
     });
 
@@ -644,7 +644,7 @@ describe('Menu', () => {
 
             const itemTemplateMenu = itemTemplateFixture.debugElement.query(By.directive(Menu)).componentInstance;
 
-            expect(() => itemTemplateMenu.ngAfterContentInit()).not.toThrow();
+            expect(() => itemTemplateMenu.$itemTemplate()).not.toThrow();
             expect(itemTemplateMenu.itemTemplate).toBeDefined();
         });
 
@@ -655,7 +655,7 @@ describe('Menu', () => {
 
             const pTemplateMenu = pTemplateFixture.debugElement.query(By.directive(Menu)).componentInstance;
 
-            expect(() => pTemplateMenu.ngAfterContentInit()).not.toThrow();
+            expect(() => pTemplateMenu.$itemTemplate()).not.toThrow();
             expect(pTemplateMenu.templates).toBeDefined();
         });
 
@@ -666,11 +666,9 @@ describe('Menu', () => {
 
             const pTemplateMenu = pTemplateFixture.debugElement.query(By.directive(Menu)).componentInstance;
 
-            pTemplateMenu.ngAfterContentInit();
-
-            expect(pTemplateMenu.templates).toBeDefined();
-            expect(pTemplateMenu._startTemplate).toBeDefined();
-            expect(pTemplateMenu._endTemplate).toBeDefined();
+            expect(pTemplateMenu.templates()).toBeDefined();
+            expect(pTemplateMenu.$startTemplate()).toBeDefined();
+            expect(pTemplateMenu.$endTemplate()).toBeDefined();
         });
 
         it('should render start and end templates', () => {
@@ -706,7 +704,7 @@ describe('Menu', () => {
 
             const pTemplateMenu = pTemplateFixture.debugElement.query(By.directive(Menu)).componentInstance;
             expect(pTemplateMenu.templates).toBeDefined();
-            expect(() => pTemplateMenu.ngAfterContentInit()).not.toThrow();
+            expect(() => pTemplateMenu.$itemTemplate()).not.toThrow();
 
             // Test #item template rendering
             const itemTemplateFixture = TestBed.createComponent(TestItemTemplateMenuComponent);
@@ -720,7 +718,7 @@ describe('Menu', () => {
 
     describe('Keyboard Navigation Tests', () => {
         beforeEach(() => {
-            menuInstance.focused = true;
+            menuInstance.focused.set(true);
         });
 
         it('should handle arrow down key', () => {
@@ -798,18 +796,18 @@ describe('Menu', () => {
 
             menuInstance.onListFocus(focusEvent);
 
-            expect(menuInstance.focused).toBe(true);
+            expect(menuInstance.focused()).toBe(true);
             expect(menuInstance.onFocus.emit).toHaveBeenCalledWith(focusEvent);
         });
 
         it('should emit onBlur when list loses focus', () => {
             vi.spyOn(menuInstance.onBlur, 'emit').mockImplementation(() => {});
             const blurEvent = new FocusEvent('blur');
-            menuInstance.focused = true;
+            menuInstance.focused.set(true);
 
             menuInstance.onListBlur(blurEvent);
 
-            expect(menuInstance.focused).toBe(false);
+            expect(menuInstance.focused()).toBe(false);
             expect(menuInstance.focusedOptionIndex()).toBe(-1);
             expect(menuInstance.onBlur.emit).toHaveBeenCalledWith(blurEvent);
         });
@@ -867,15 +865,15 @@ describe('Menu', () => {
             const menuInstance = styleFixture.debugElement.query(By.directive(Menu)).componentInstance;
 
             // Check that component received the style input
-            expect(menuInstance.style).toEqual({ border: '2px solid red', padding: '10px' });
+            expect(menuInstance.style()).toEqual({ border: '2px solid red', padding: '10px' });
 
             const hostElement = styleFixture.debugElement.query(By.css('div[data-pc-name="menu"]')).nativeElement;
 
             // Manually apply styles to test the style binding works as expected
             // This simulates what ngStyle directive would do in a real browser
-            if (menuInstance.style) {
-                Object.keys(menuInstance.style).forEach((key) => {
-                    hostElement.style[key] = menuInstance.style[key];
+            if (menuInstance.style()) {
+                Object.keys(menuInstance.style()).forEach((key) => {
+                    hostElement.style[key] = menuInstance.style()[key];
                 });
             }
 
@@ -884,9 +882,9 @@ describe('Menu', () => {
             expect(hostElement.style.padding).toBe('10px');
 
             // Also verify the template binding
-            expect(menuInstance.style).toBeTruthy();
-            expect(Object.keys(menuInstance.style)).toContain('border');
-            expect(Object.keys(menuInstance.style)).toContain('padding');
+            expect(menuInstance.style()).toBeTruthy();
+            expect(Object.keys(menuInstance.style())).toContain('border');
+            expect(Object.keys(menuInstance.style())).toContain('padding');
         });
 
         it('should have proper data attributes', () => {
@@ -902,7 +900,7 @@ describe('Menu', () => {
 
             const containerElement = freshFixture.debugElement.query(By.css('div[data-pc-name="menu"]'));
             expect(containerElement.nativeElement.getAttribute('id')).toBeTruthy();
-            expect(containerElement.nativeElement.getAttribute('id')).toBe(freshMenu.id);
+            expect(containerElement.nativeElement.getAttribute('id')).toBe(freshMenu.$id());
         });
 
         it('should have generated id on list element', () => {
@@ -921,8 +919,8 @@ describe('Menu', () => {
 
         it('should have proper ARIA attributes on menu items', async () => {
             // Verify the menu has proper ARIA setup
-            expect(menuInstance.model).toBeDefined();
-            expect(menuInstance.model!.length).toBeGreaterThan(0);
+            expect(menuInstance.model()).toBeDefined();
+            expect(menuInstance.model()!.length).toBeGreaterThan(0);
 
             // Check that the menu list has proper ARIA attributes
             const listElement = fixture.debugElement.query(By.css('ul[role="menu"]'));
@@ -931,7 +929,7 @@ describe('Menu', () => {
         });
 
         it('should set aria-activedescendant when focused', () => {
-            menuInstance.focused = true;
+            menuInstance.focused.set(true);
             menuInstance.focusedOptionIndex.set('test_id');
 
             fixture.detectChanges();
@@ -943,7 +941,7 @@ describe('Menu', () => {
         });
 
         it('should not set aria-activedescendant when not focused', () => {
-            menuInstance.focused = false;
+            menuInstance.focused.set(false);
             fixture.detectChanges();
 
             const listElement = fixture.debugElement.query(By.css('ul[role="menu"]'));
@@ -1015,8 +1013,8 @@ describe('Menu', () => {
             const mockEvent = { currentTarget: document.createElement('button') };
             menuInstance.show(mockEvent);
 
-            expect(menuInstance.visible).toBe(true);
-            expect(menuInstance.overlayVisible).toBe(true);
+            expect(menuInstance.visible()).toBe(true);
+            expect(menuInstance.overlayVisible()).toBe(true);
 
             // show()/hide() only flip the visibility flags; onShow/onHide are actually emitted from
             // the overlay's motion lifecycle hooks, so those real handlers are invoked directly here.
@@ -1027,7 +1025,7 @@ describe('Menu', () => {
             // Hide menu
             menuInstance.hide();
 
-            expect(menuInstance.visible).toBe(false);
+            expect(menuInstance.visible()).toBe(false);
 
             menuInstance.onOverlayAfterLeave();
             expect(menuInstance.onHide.emit).toHaveBeenCalledWith({});
@@ -1046,11 +1044,11 @@ describe('Menu', () => {
 
             // First toggle - should show
             menuInstance.toggle(mockEvent);
-            expect(menuInstance.visible).toBe(true);
+            expect(menuInstance.visible()).toBe(true);
 
             // Second toggle - should hide
             menuInstance.toggle(mockEvent);
-            expect(menuInstance.visible).toBe(false);
+            expect(menuInstance.visible()).toBe(false);
         });
 
         it('should handle overlay click', async () => {
@@ -1090,7 +1088,7 @@ describe('Menu', () => {
             await dynamicFixture.whenStable();
 
             // Initially empty
-            expect(dynamicMenu.model.length).toBe(0);
+            expect(dynamicMenu.model()!.length).toBe(0);
 
             // Add items
             dynamicComponent.addItem({ label: 'Item 1', icon: 'pi pi-test' });
@@ -1098,23 +1096,23 @@ describe('Menu', () => {
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
 
-            expect(dynamicMenu.model.length).toBe(2);
-            expect(dynamicMenu.model[0].label).toBe('Item 1');
+            expect(dynamicMenu.model()!.length).toBe(2);
+            expect(dynamicMenu.model()![0].label).toBe('Item 1');
 
             // Remove item
             dynamicComponent.removeItem(0);
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
 
-            expect(dynamicMenu.model.length).toBe(1);
-            expect(dynamicMenu.model[0].label).toBe('Item 2');
+            expect(dynamicMenu.model()!.length).toBe(1);
+            expect(dynamicMenu.model()![0].label).toBe('Item 2');
 
             // Clear all
             dynamicComponent.clearItems();
             dynamicFixture.changeDetectorRef.markForCheck();
             await dynamicFixture.whenStable();
 
-            expect(dynamicMenu.model.length).toBe(0);
+            expect(dynamicMenu.model()!.length).toBe(0);
         });
     });
 
@@ -1133,11 +1131,11 @@ describe('Menu', () => {
 
         it('should create popup menu', () => {
             expect(popupMenuInstance).toBeTruthy();
-            expect(popupMenuInstance.popup).toBe(true);
+            expect(popupMenuInstance.popup()).toBe(true);
         });
 
         it('should be hidden by default', () => {
-            expect(popupMenuInstance.visible).toBeFalsy();
+            expect(popupMenuInstance.visible()).toBeFalsy();
         });
 
         it('should show menu when toggle is called with event', () => {
@@ -1149,7 +1147,7 @@ describe('Menu', () => {
             });
 
             popupMenuInstance.toggle(mockEvent);
-            expect(popupMenuInstance.visible).toBe(true);
+            expect(popupMenuInstance.visible()).toBe(true);
         });
 
         it('should hide menu when toggle is called again', () => {
@@ -1162,31 +1160,31 @@ describe('Menu', () => {
 
             // First toggle - should show
             popupMenuInstance.toggle(mockEvent);
-            expect(popupMenuInstance.visible).toBe(true);
+            expect(popupMenuInstance.visible()).toBe(true);
 
             // Second toggle - should hide
             popupMenuInstance.toggle(mockEvent);
-            expect(popupMenuInstance.visible).toBe(false);
+            expect(popupMenuInstance.visible()).toBe(false);
         });
 
         it('should show popup menu via button click', () => {
             const toggleButton = popupFixture.debugElement.query(By.css('.toggle-button'));
 
-            expect(popupMenuInstance.visible).toBeFalsy();
+            expect(popupMenuInstance.visible()).toBeFalsy();
 
             toggleButton.nativeElement.click();
             popupFixture.detectChanges();
 
-            expect(popupMenuInstance.visible).toBe(true);
+            expect(popupMenuInstance.visible()).toBe(true);
         });
 
         it('should render popup menu items when visible', async () => {
             // Verify model is set correctly (nested structure)
-            expect(popupMenuInstance.model!.length).toBe(1);
-            expect(popupMenuInstance.model![0].label).toBe('Options');
-            expect(popupMenuInstance.model![0].items!.length).toBe(2);
-            expect(popupMenuInstance.model![0].items![0].label).toBe('Refresh');
-            expect(popupMenuInstance.model![0].items![1].label).toBe('Export');
+            expect(popupMenuInstance.model()!.length).toBe(1);
+            expect(popupMenuInstance.model()![0].label).toBe('Options');
+            expect(popupMenuInstance.model()![0].items!.length).toBe(2);
+            expect(popupMenuInstance.model()![0].items![0].label).toBe('Refresh');
+            expect(popupMenuInstance.model()![0].items![1].label).toBe('Export');
 
             // Show the menu
             const toggleButton = popupFixture.debugElement.query(By.css('.toggle-button'));
@@ -1194,14 +1192,14 @@ describe('Menu', () => {
             popupFixture.detectChanges();
             await popupFixture.whenStable();
 
-            expect(popupMenuInstance.visible).toBe(true);
+            expect(popupMenuInstance.visible()).toBe(true);
         });
 
         it('should execute command when popup menu item is clicked', async () => {
             expect(popupComponent.refreshCalled).toBe(false);
 
             // Execute command directly since DOM rendering is flaky in zoneless mode
-            popupMenuInstance.model![0].items![0].command!({ item: popupMenuInstance.model![0].items![0], originalEvent: new Event('click') });
+            popupMenuInstance.model()![0].items![0].command!({ item: popupMenuInstance.model()![0].items![0], originalEvent: new Event('click') });
 
             expect(popupComponent.refreshCalled).toBe(true);
         });
@@ -1210,13 +1208,13 @@ describe('Menu', () => {
             // Show the menu
             const mockEvent = { currentTarget: document.createElement('button') };
             popupMenuInstance.show(mockEvent);
-            expect(popupMenuInstance.visible).toBe(true);
+            expect(popupMenuInstance.visible()).toBe(true);
 
             // Simulate item click which should hide the menu
-            popupMenuInstance.itemClick({ originalEvent: new Event('click'), item: popupMenuInstance.model![0].items![0] }, 'test-id');
+            popupMenuInstance.itemClick({ originalEvent: new Event('click'), item: popupMenuInstance.model()![0].items![0] }, 'test-id');
 
             // Menu should hide after item click
-            expect(popupMenuInstance.visible).toBe(false);
+            expect(popupMenuInstance.visible()).toBe(false);
         });
 
         it('should show popup menu programmatically', () => {
@@ -1226,11 +1224,11 @@ describe('Menu', () => {
                 configurable: true
             });
 
-            expect(popupMenuInstance.visible).toBeFalsy();
+            expect(popupMenuInstance.visible()).toBeFalsy();
 
             popupMenuInstance.show(mockEvent);
 
-            expect(popupMenuInstance.visible).toBe(true);
+            expect(popupMenuInstance.visible()).toBe(true);
         });
 
         it('should hide popup menu programmatically', () => {
@@ -1242,12 +1240,12 @@ describe('Menu', () => {
             });
 
             popupMenuInstance.show(mockEvent);
-            expect(popupMenuInstance.visible).toBe(true);
+            expect(popupMenuInstance.visible()).toBe(true);
 
             // Then hide it
             popupMenuInstance.hide();
 
-            expect(popupMenuInstance.visible).toBe(false);
+            expect(popupMenuInstance.visible()).toBe(false);
         });
 
         it('should handle overlay click to hide menu', () => {
@@ -1255,7 +1253,7 @@ describe('Menu', () => {
 
             // Show menu
             popupMenuInstance.show(mockEvent);
-            expect(popupMenuInstance.visible).toBe(true);
+            expect(popupMenuInstance.visible()).toBe(true);
 
             // Simulate overlay click
             vi.spyOn(popupMenuInstance, 'hide').mockImplementation(() => {});
@@ -1278,7 +1276,7 @@ describe('Menu', () => {
         it('should have proper ARIA attributes for popup', () => {
             // Check that component exists
             expect(popupMenuInstance).toBeTruthy();
-            expect(popupMenuInstance.popup).toBe(true);
+            expect(popupMenuInstance.popup()).toBe(true);
 
             // Show menu to check visibility
             const mockEvent = new MouseEvent('click');
@@ -1288,7 +1286,7 @@ describe('Menu', () => {
             });
 
             popupMenuInstance.show(mockEvent);
-            expect(popupMenuInstance.visible).toBe(true);
+            expect(popupMenuInstance.visible()).toBe(true);
         });
     });
 
@@ -1300,7 +1298,7 @@ describe('Menu', () => {
             await freshFixture.whenStable();
 
             const freshMenu = freshFixture.debugElement.query(By.directive(Menu)).componentInstance;
-            expect(freshMenu.model).toBeUndefined();
+            expect(freshMenu.model()).toBeUndefined();
         });
 
         it('should handle items without icons', async () => {
@@ -1320,7 +1318,7 @@ describe('Menu', () => {
             await styledFixture.whenStable();
 
             const menuInstance = styledFixture.debugElement.query(By.directive(Menu)).componentInstance;
-            expect(menuInstance.styleClass).toBe('custom-menu-class');
+            expect(menuInstance.styleClass()).toBe('custom-menu-class');
 
             const menuElement = styledFixture.debugElement.query(By.css('div[data-pc-name="menu"]'));
             expect(menuElement.nativeElement.classList.contains('custom-menu-class')).toBe(true);
@@ -1343,13 +1341,13 @@ describe('Menu', () => {
 
             // Rapid show/hide
             menuInstance.show(mockEvent);
-            expect(menuInstance.visible).toBe(true);
+            expect(menuInstance.visible()).toBe(true);
 
             menuInstance.hide();
-            expect(menuInstance.visible).toBe(false);
+            expect(menuInstance.visible()).toBe(false);
 
             menuInstance.show(mockEvent);
-            expect(menuInstance.visible).toBe(true);
+            expect(menuInstance.visible()).toBe(true);
         });
 
         it('should handle disabled items click prevention', async () => {
@@ -1418,19 +1416,18 @@ describe('Menu', () => {
         });
 
         it('should get tab index value correctly', () => {
-            menuInstance.tabindex = 0;
             expect(menuInstance.getTabIndexValue()).toBe('0');
 
-            menuInstance.tabindex = -1;
+            vi.spyOn(menuInstance, 'tabindex').mockReturnValue(-1);
             expect(menuInstance.getTabIndexValue()).toBe('-1');
         });
 
         it('should handle activedescendant correctly', () => {
-            menuInstance.focused = true;
+            menuInstance.focused.set(true);
             menuInstance.focusedOptionIndex.set('test_id');
             expect(menuInstance.activedescendant()).toBe('test_id');
 
-            menuInstance.focused = false;
+            menuInstance.focused.set(false);
             expect(menuInstance.activedescendant()).toBeUndefined();
         });
     });
@@ -1594,7 +1591,7 @@ describe('Menu', () => {
                 ptFixture.componentRef.setInput('pt', {
                     root: ({ instance }) => {
                         return {
-                            class: instance.popup ? 'POPUP_MENU' : 'STATIC_MENU'
+                            class: instance.popup() ? 'POPUP_MENU' : 'STATIC_MENU'
                         };
                     }
                 });
@@ -1611,7 +1608,7 @@ describe('Menu', () => {
                     list: ({ instance }) => {
                         return {
                             style: {
-                                'border-color': instance.model?.length > 1 ? 'green' : 'red'
+                                'border-color': instance.model()?.length > 1 ? 'green' : 'red'
                             }
                         };
                     }
@@ -1629,7 +1626,7 @@ describe('Menu', () => {
                 ptFixture.componentRef.setInput('pt', {
                     root: ({ instance }) => {
                         return {
-                            class: instance.tabindex === 5 ? 'CUSTOM_TABINDEX' : ''
+                            class: instance.tabindex() === 5 ? 'CUSTOM_TABINDEX' : ''
                         };
                     }
                 });
@@ -1647,7 +1644,7 @@ describe('Menu', () => {
                 ptFixture.componentRef.setInput('pt', {
                     root: ({ instance }) => {
                         return {
-                            class: !instance.popup && instance.tabindex === 0 ? 'STATIC_WITH_TABINDEX' : ''
+                            class: !instance.popup() && instance.tabindex() === 0 ? 'STATIC_WITH_TABINDEX' : ''
                         };
                     }
                 });
@@ -1702,7 +1699,7 @@ describe('Menu', () => {
                     root: ({ instance }) => {
                         return {
                             onclick: () => {
-                                instanceModelLength = instance.model?.length || 0;
+                                instanceModelLength = instance.model()?.length || 0;
                             }
                         };
                     }

--- a/packages/optimus-ui/src/menu/menu.ts
+++ b/packages/optimus-ui/src/menu/menu.ts
@@ -1,14 +1,13 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import {
+    afterEveryRender,
     booleanAttribute,
     ChangeDetectionStrategy,
     Component,
     computed,
     ElementRef,
     inject,
-    InjectionToken,
     input,
-    Input,
     NgModule,
     numberAttribute,
     Pipe,
@@ -40,8 +39,6 @@ import { MenuItemTemplateContext, MenuPassThrough, MenuSubmenuHeaderTemplateCont
 import { ZIndexUtils } from '@openng/optimus-ui/utils';
 import { MenuStyle } from './style/menustyle';
 
-const MENU_INSTANCE = new InjectionToken<Menu>('MENU_INSTANCE');
-
 @Pipe({
     name: 'safeHtml',
     standalone: true
@@ -64,64 +61,64 @@ export class SafeHtmlPipe implements PipeTransform {
     selector: '[pMenuItemContent]',
     standalone: true,
     imports: [CommonModule, RouterModule, Ripple, TooltipModule, BadgeModule, SharedModule, SafeHtmlPipe, BindModule],
-    template: ` <div [class]="cx('itemContent')" (click)="onItemClick($event, item)" [attr.data-pc-section]="'content'" [pBind]="getPTOptions('itemContent')">
-        @if (!itemTemplate) {
-            @if (!item?.routerLink) {
+    template: ` <div [class]="cx('itemContent')" (click)="onItemClick($event, item())" [attr.data-pc-section]="'content'" [pBind]="getPTOptions('itemContent')">
+        @if (!itemTemplate()) {
+            @if (!item()?.routerLink) {
                 <a
-                    [attr.title]="item.title"
-                    [attr.href]="item.url || null"
-                    [attr.data-automationid]="item.automationId"
+                    [attr.title]="item()!.title"
+                    [attr.href]="item()!.url || null"
+                    [attr.data-automationid]="item()!.automationId"
                     [attr.tabindex]="-1"
-                    [class]="cn(cx('itemLink'), item?.linkClass)"
-                    [ngStyle]="item?.linkStyle"
-                    [target]="item.target"
+                    [class]="cn(cx('itemLink'), item()?.linkClass)"
+                    [ngStyle]="item()?.linkStyle"
+                    [target]="item()!.target"
                     [pBind]="getPTOptions('itemLink')"
                     pRipple
                 >
-                    <ng-container *ngTemplateOutlet="itemContent; context: { $implicit: item }"></ng-container>
+                    <ng-container *ngTemplateOutlet="itemContent; context: { $implicit: item() }"></ng-container>
                 </a>
             }
-            @if (item?.routerLink) {
+            @if (item()?.routerLink) {
                 <a
-                    [routerLink]="item.routerLink"
-                    [attr.data-automationid]="item.automationId"
+                    [routerLink]="item()!.routerLink"
+                    [attr.data-automationid]="item()!.automationId"
                     [attr.tabindex]="-1"
-                    [attr.title]="item.title"
-                    [queryParams]="item.queryParams"
+                    [attr.title]="item()!.title"
+                    [queryParams]="item()!.queryParams"
                     routerLinkActive="p-menu-item-link-active"
-                    [routerLinkActiveOptions]="item.routerLinkActiveOptions || { exact: false }"
-                    [class]="cn(cx('itemLink'), item?.linkClass)"
-                    [ngStyle]="item?.linkStyle"
-                    [target]="item.target"
-                    [fragment]="item.fragment"
-                    [queryParamsHandling]="item.queryParamsHandling"
-                    [preserveFragment]="item.preserveFragment"
-                    [skipLocationChange]="item.skipLocationChange"
-                    [replaceUrl]="item.replaceUrl"
-                    [state]="item.state"
+                    [routerLinkActiveOptions]="item()!.routerLinkActiveOptions || { exact: false }"
+                    [class]="cn(cx('itemLink'), item()?.linkClass)"
+                    [ngStyle]="item()?.linkStyle"
+                    [target]="item()!.target"
+                    [fragment]="item()!.fragment"
+                    [queryParamsHandling]="item()!.queryParamsHandling"
+                    [preserveFragment]="item()!.preserveFragment"
+                    [skipLocationChange]="item()!.skipLocationChange"
+                    [replaceUrl]="item()!.replaceUrl"
+                    [state]="item()!.state"
                     [pBind]="getPTOptions('itemLink')"
                     pRipple
                 >
-                    <ng-container *ngTemplateOutlet="itemContent; context: { $implicit: item }"></ng-container>
+                    <ng-container *ngTemplateOutlet="itemContent; context: { $implicit: item() }"></ng-container>
                 </a>
             }
         }
 
-        @if (itemTemplate) {
-            <ng-template *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-template>
+        @if (itemTemplate()) {
+            <ng-template *ngTemplateOutlet="itemTemplate(); context: { $implicit: item() }"></ng-template>
         }
 
         <ng-template #itemContent>
-            @if (item.icon) {
-                <span [class]="cn(cx('itemIcon', { item }), item.iconClass)" [pBind]="getPTOptions('itemIcon')" [ngStyle]="item.iconStyle" [attr.data-pc-section]="'itemicon'"></span>
+            @if (item()!.icon) {
+                <span [class]="cn(cx('itemIcon', { item }), item()!.iconClass)" [pBind]="getPTOptions('itemIcon')" [ngStyle]="item()!.iconStyle" [attr.data-pc-section]="'itemicon'"></span>
             }
-            @if (item.escape !== false) {
-                <span [class]="cn(cx('itemLabel'), item.labelClass)" [ngStyle]="item.labelStyle" [pBind]="getPTOptions('itemLabel')" [attr.data-pc-section]="'itemlabel'">{{ item.label }}</span>
+            @if (item()!.escape !== false) {
+                <span [class]="cn(cx('itemLabel'), item()!.labelClass)" [ngStyle]="item()!.labelStyle" [pBind]="getPTOptions('itemLabel')" [attr.data-pc-section]="'itemlabel'">{{ item()!.label }}</span>
             } @else {
-                <span [class]="cn(cx('itemLabel'), item.labelClass)" [ngStyle]="item.labelStyle" [attr.data-pc-section]="'itemlabel'" [innerHTML]="item.label | safeHtml" [pBind]="getPTOptions('itemLabel')"></span>
+                <span [class]="cn(cx('itemLabel'), item()!.labelClass)" [ngStyle]="item()!.labelStyle" [attr.data-pc-section]="'itemlabel'" [innerHTML]="item()!.label | safeHtml" [pBind]="getPTOptions('itemLabel')"></span>
             }
-            @if (item.badge) {
-                <p-badge [styleClass]="item.badgeStyleClass" [value]="item.badge" [pt]="getPTOptions('pcBadge')" [unstyled]="unstyled()" />
+            @if (item()!.badge) {
+                <p-badge [class]="item()!.badgeStyleClass" [value]="item()!.badge" [pt]="getPTOptions('pcBadge')" [unstyled]="unstyled()" />
             }
         </ng-template>
     </div>`,
@@ -129,9 +126,11 @@ export class SafeHtmlPipe implements PipeTransform {
     providers: [MenuStyle]
 })
 export class MenuItemContent extends BaseComponent {
-    @Input('pMenuItemContent') item: MenuItem | undefined;
+    _componentStyle = inject(MenuStyle);
 
-    @Input() itemTemplate: any | undefined;
+    readonly item = input<MenuItem | undefined>(undefined, { alias: 'pMenuItemContent' });
+
+    readonly itemTemplate = input<any | undefined>();
 
     menuitemId = input<string>('');
 
@@ -140,8 +139,6 @@ export class MenuItemContent extends BaseComponent {
     readonly onMenuItemClick = output<any>();
 
     menu: Menu;
-
-    _componentStyle = inject(MenuStyle);
 
     hostName = 'Menu';
 
@@ -157,7 +154,7 @@ export class MenuItemContent extends BaseComponent {
     }
 
     getPTOptions(key: string) {
-        return this.menu.getPTOptions(key, this.item, this.idx(), this.menuitemId());
+        return this.menu.getPTOptions(key, this.item(), this.idx(), this.menuitemId());
     }
 }
 /**
@@ -169,27 +166,27 @@ export class MenuItemContent extends BaseComponent {
     standalone: true,
     imports: [CommonModule, RouterModule, MenuItemContent, TooltipModule, BadgeModule, SharedModule, SafeHtmlPipe, BindModule, MotionModule],
     template: `
-        @if (!popup || overlayVisible) {
+        @if (!popup() || overlayVisible()) {
             <div
                 #container
-                [class]="cn(cx('root'), styleClass)"
+                [class]="cn(cx('root'), styleClass())"
                 [style]="sx('root')"
-                [ngStyle]="style"
+                [ngStyle]="style()"
                 (click)="onOverlayClick($event)"
-                [attr.id]="id"
+                [attr.id]="$id()"
                 [pBind]="ptm('root')"
                 [attr.data-p]="dataP"
-                [pMotion]="visible || !popup"
+                [pMotion]="visible() || !popup()"
                 [pMotionName]="'p-anchored-overlay'"
-                [pMotionAppear]="!!popup"
-                [pMotionDisabled]="!popup"
+                [pMotionAppear]="!!popup()"
+                [pMotionDisabled]="!popup()"
                 [pMotionOptions]="computedMotionOptions()"
                 (pMotionOnBeforeEnter)="onOverlayBeforeEnter($event)"
                 (pMotionOnAfterLeave)="onOverlayAfterLeave()"
             >
-                @if (startTemplate() ?? _startTemplate) {
+                @if ($startTemplate()) {
                     <div [class]="cx('start')" [pBind]="ptm('start')" [attr.data-pc-section]="'start'">
-                        <ng-container *ngTemplateOutlet="startTemplate() ?? _startTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="$startTemplate()"></ng-container>
                     </div>
                 }
                 <ul
@@ -197,18 +194,18 @@ export class MenuItemContent extends BaseComponent {
                     [class]="cx('list')"
                     [pBind]="ptm('list')"
                     role="menu"
-                    [attr.id]="id + '_list'"
+                    [attr.id]="$id() + '_list'"
                     [attr.tabindex]="getTabIndexValue()"
                     [attr.data-pc-section]="'menu'"
                     [attr.aria-activedescendant]="activedescendant()"
-                    [attr.aria-label]="ariaLabel"
-                    [attr.aria-labelledBy]="ariaLabelledBy"
+                    [attr.aria-label]="ariaLabel()"
+                    [attr.aria-labelledBy]="ariaLabelledBy()"
                     (focus)="onListFocus($event)"
                     (blur)="onListBlur($event)"
                     (keydown)="onListKeyDown($event)"
                 >
                     @if (hasSubMenu()) {
-                        @for (submenu of model; track submenu; let i = $index) {
+                        @for (submenu of model(); track submenu; let i = $index) {
                             @if (submenu.visible !== false) {
                                 @if (submenu.separator) {
                                     <li [class]="cx('separator')" [pBind]="ptm('separator')" role="separator" [attr.data-pc-section]="'separator'"></li>
@@ -221,10 +218,10 @@ export class MenuItemContent extends BaseComponent {
                                         [tooltipOptions]="submenu.tooltipOptions"
                                         [pTooltipUnstyled]="unstyled()"
                                         role="none"
-                                        [attr.id]="menuitemId(submenu, id, i)"
+                                        [attr.id]="menuitemId(submenu, $id(), i)"
                                         [attr.data-pc-section]="'submenulabel'"
                                     >
-                                        @let submenuHeader = submenuHeaderTemplate() ?? _submenuHeaderTemplate;
+                                        @let submenuHeader = $submenuHeaderTemplate();
                                         @if (submenuHeader) {
                                             <ng-container *ngTemplateOutlet="submenuHeader; context: { $implicit: submenu }"></ng-container>
                                         } @else {
@@ -243,62 +240,62 @@ export class MenuItemContent extends BaseComponent {
                                 }
                                 @if (!item.separator && item.visible !== false && (item.visible !== undefined || submenu.visible !== false)) {
                                     <li
-                                        [class]="cn(cx('item', { item, id: menuitemId(item, id, i, j) }), item?.styleClass)"
+                                        [class]="cn(cx('item', { item, id: menuitemId(item, $id(), i, j) }), item?.styleClass)"
                                         [pBind]="ptm('item')"
                                         [pMenuItemContent]="item"
-                                        [itemTemplate]="itemTemplate() ?? _itemTemplate"
+                                        [itemTemplate]="$itemTemplate()"
                                         [idx]="j"
-                                        [menuitemId]="menuitemId(item, id, i, j)"
+                                        [menuitemId]="menuitemId(item, $id(), i, j)"
                                         [style]="item.style"
-                                        (onMenuItemClick)="itemClick($event, menuitemId(item, id, i, j))"
+                                        (onMenuItemClick)="itemClick($event, menuitemId(item, $id(), i, j))"
                                         pTooltip
                                         [tooltipOptions]="item.tooltipOptions"
                                         [pTooltipUnstyled]="unstyled()"
                                         [unstyled]="unstyled()"
                                         role="menuitem"
                                         [attr.aria-label]="label(item.label)"
-                                        [attr.data-p-focused]="isItemFocused(menuitemId(item, id, i, j))"
+                                        [attr.data-p-focused]="isItemFocused(menuitemId(item, $id(), i, j))"
                                         [attr.data-p-disabled]="disabled(item.disabled)"
                                         [attr.aria-disabled]="disabled(item.disabled)"
-                                        [attr.id]="menuitemId(item, id, i, j)"
+                                        [attr.id]="menuitemId(item, $id(), i, j)"
                                     ></li>
                                 }
                             }
                         }
                     }
                     @if (!hasSubMenu()) {
-                        @for (item of model; track item; let i = $index) {
+                        @for (item of model(); track item; let i = $index) {
                             @if (item.separator && item.visible !== false) {
                                 <li [class]="cx('separator')" [pBind]="ptm('separator')" role="separator" [attr.data-pc-section]="'separator'"></li>
                             }
                             @if (!item.separator && item.visible !== false) {
                                 <li
-                                    [class]="cn(cx('item', { item, id: menuitemId(item, id, i) }), item?.styleClass)"
+                                    [class]="cn(cx('item', { item, id: menuitemId(item, $id(), i) }), item?.styleClass)"
                                     [pBind]="ptm('item')"
                                     [pMenuItemContent]="item"
-                                    [itemTemplate]="itemTemplate() ?? _itemTemplate"
+                                    [itemTemplate]="$itemTemplate()"
                                     [idx]="i"
-                                    [menuitemId]="menuitemId(item, id, i)"
+                                    [menuitemId]="menuitemId(item, $id(), i)"
                                     [ngStyle]="item.style"
-                                    (onMenuItemClick)="itemClick($event, menuitemId(item, id, i))"
+                                    (onMenuItemClick)="itemClick($event, menuitemId(item, $id(), i))"
                                     pTooltip
                                     [tooltipOptions]="item.tooltipOptions"
                                     [unstyled]="unstyled()"
                                     [pTooltipUnstyled]="unstyled()"
                                     role="menuitem"
                                     [attr.aria-label]="label(item.label)"
-                                    [attr.data-p-focused]="isItemFocused(menuitemId(item, id, i))"
+                                    [attr.data-p-focused]="isItemFocused(menuitemId(item, $id(), i))"
                                     [attr.data-p-disabled]="disabled(item.disabled)"
                                     [attr.aria-disabled]="disabled(item.disabled)"
-                                    [attr.id]="menuitemId(item, id, i)"
+                                    [attr.id]="menuitemId(item, $id(), i)"
                                 ></li>
                             }
                         }
                     }
                 </ul>
-                @if (endTemplate() ?? _endTemplate) {
+                @if ($endTemplate()) {
                     <div [class]="cx('end')" [pBind]="ptm('end')" [attr.data-pc-section]="'end'">
-                        <ng-container *ngTemplateOutlet="endTemplate() ?? _endTemplate"></ng-container>
+                        <ng-container *ngTemplateOutlet="$endTemplate()"></ng-container>
                     </div>
                 }
             </div>
@@ -307,111 +304,122 @@ export class MenuItemContent extends BaseComponent {
 
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [MenuStyle, { provide: MENU_INSTANCE, useExisting: Menu }, { provide: PARENT_INSTANCE, useExisting: Menu }],
+    providers: [MenuStyle, { provide: PARENT_INSTANCE, useExisting: Menu }],
     hostDirectives: [Bind]
 })
 export class Menu extends BaseComponent<MenuPassThrough> {
     overlayService = inject(OverlayService);
 
-    componentName = 'Menu';
+    _componentStyle = inject(MenuStyle);
+
+    bindDirectiveInstance = inject(Bind, { self: true });
 
     /**
      * An array of menuitems.
      * @group Props
      */
-    @Input() model: MenuItem[] | undefined;
+    readonly model = input<MenuItem[]>();
+
     /**
      * Defines if menu would displayed as a popup.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) popup: boolean | undefined;
+    readonly popup = input<boolean | undefined, unknown>(undefined, { transform: booleanAttribute });
+
     /**
      * Inline style of the component.
      * @group Props
      */
-    @Input() style: { [klass: string]: any } | null | undefined;
+    readonly style = input<{ [klass: string]: any } | null | undefined>(null);
+
     /**
      * Style class of the component.
      * @group Props
      */
-    @Input() styleClass: string | undefined;
+    readonly styleClass = input<string>();
+
     /**
      * Whether to automatically manage layering.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) autoZIndex: boolean = true;
+    readonly autoZIndex = input<boolean, unknown>(true, { transform: booleanAttribute });
+
     /**
      * Base zIndex value to use in layering.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) baseZIndex: number = 0;
+    readonly baseZIndex = input<number, unknown>(0, { transform: numberAttribute });
+
     /**
      * Transition options of the show animation.
      * @deprecated since v21.0.0, use `motionOptions` instead.
      * @group Props
      */
-    @Input() showTransitionOptions: string = '.12s cubic-bezier(0, 0, 0.2, 1)';
+    readonly showTransitionOptions = input<string>('.12s cubic-bezier(0, 0, 0.2, 1)');
+
     /**
      * Transition options of the hide animation.
      * @deprecated since v21.0.0, use `motionOptions` instead.
      * @group Props
      */
-    @Input() hideTransitionOptions: string = '.1s linear';
+    readonly hideTransitionOptions = input<string>('.1s linear');
 
     /**
      * Defines a string value that labels an interactive element.
      * @group Props
      */
-    @Input() ariaLabel: string | undefined;
+    readonly ariaLabel = input<string>();
+
     /**
      * Identifier of the underlying input element.
      * @group Props
      */
-    @Input() ariaLabelledBy: string | undefined;
+    readonly ariaLabelledBy = input<string>();
+
     /**
      * Current id state as a string.
      * @group Props
      */
-    @Input() id: string | undefined;
+    readonly id = input<string>();
+
     /**
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number = 0;
+    readonly tabindex = input<number, unknown>(0, { transform: numberAttribute });
+
     /**
      * Target element to attach the overlay, valid values are "body" or a local ng-template variable of another element (note: use binding with brackets for template variables, e.g. [appendTo]="mydiv" for a div element having #mydiv as variable name).
      * @defaultValue 'self'
      * @group Props
      */
     appendTo = input<HTMLElement | ElementRef | TemplateRef<any> | 'self' | 'body' | null | undefined | any>(undefined);
+
     /**
      * The motion options.
      * @group Props
      */
     motionOptions = input<MotionOptions | undefined>(undefined);
 
-    computedMotionOptions = computed<MotionOptions>(() => {
-        return {
-            ...this.ptm('motion'),
-            ...this.motionOptions()
-        };
-    });
     /**
      * Callback to invoke when overlay menu is shown.
      * @group Emits
      */
     readonly onShow = output<any>();
+
     /**
      * Callback to invoke when overlay menu is hidden.
      * @group Emits
      */
     readonly onHide = output<any>();
+
     /**
      * Callback to invoke when the list loses focus.
      * @param {Event} event - blur event.
      * @group Emits
      */
     readonly onBlur = output<Event>();
+
     /**
      * Callback to invoke when the list receives focus.
      * @param {Event} event - focus event.
@@ -422,6 +430,45 @@ export class Menu extends BaseComponent<MenuPassThrough> {
     listViewChild = viewChild<ElementRef>('list');
 
     containerViewChild = viewChild<ElementRef>('container');
+
+    /**
+     * Defines template option for start.
+     * @group Templates
+     */
+    readonly startTemplate = contentChild<TemplateRef<void>>('start', { descendants: false });
+
+    /**
+     * Defines template option for end.
+     * @group Templates
+     */
+    readonly endTemplate = contentChild<TemplateRef<void>>('end', { descendants: false });
+
+    /**
+     * Custom item template.
+     * @param {MenuItemTemplateContext} context - item context.
+     * @see {@link MenuItemTemplateContext}
+     * @group Templates
+     */
+    readonly itemTemplate = contentChild<TemplateRef<MenuItemTemplateContext>>('item', { descendants: false });
+
+    /**
+     * Custom submenu header template.
+     * @param {MenuSubmenuHeaderTemplateContext} context - submenu header context.
+     * @see {@link MenuSubmenuHeaderTemplateContext}
+     * @group Templates
+     */
+    readonly submenuHeaderTemplate = contentChild<TemplateRef<MenuSubmenuHeaderTemplateContext>>('submenuheader', { descendants: false });
+
+    readonly templates = contentChildren(PrimeTemplate);
+
+    componentName = 'Menu';
+
+    computedMotionOptions = computed<MotionOptions>(() => {
+        return {
+            ...this.ptm('motion'),
+            ...this.motionOptions()
+        };
+    });
 
     $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
 
@@ -437,7 +484,13 @@ export class Menu extends BaseComponent<MenuPassThrough> {
 
     target: any;
 
-    visible: boolean | undefined;
+    private readonly generatedId = uuid('pn_id_');
+
+    /** Effective id: the `id` input, or a generated unique id. */
+    readonly $id = computed(() => this.id() || this.generatedId);
+
+    /** Whether the popup menu is visible (drives the enter/leave animation). */
+    readonly visible = signal<boolean | undefined>(undefined);
 
     focusedOptionId = computed(() => {
         return this.focusedOptionIndex() !== -1 ? this.focusedOptionIndex() : null;
@@ -447,23 +500,92 @@ export class Menu extends BaseComponent<MenuPassThrough> {
 
     public selectedOptionIndex: any = signal<any>(-1);
 
-    public focused: boolean | undefined = false;
+    readonly focused = signal<boolean>(false);
 
-    public overlayVisible: boolean | undefined = false;
+    /** Whether the popup overlay element is rendered; stays on until the leave animation finishes. */
+    readonly overlayVisible = signal<boolean>(false);
 
-    $pcMenu: Menu | undefined = inject(MENU_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
+    /** Effective start template: the `#start` content child, or the `pTemplate="start"`. */
+    readonly $startTemplate = computed(
+        () =>
+            this.startTemplate() ??
+            this.templates()
+                .filter((item) => item.getType() === 'start')
+                .at(-1)?.template
+    );
 
-    _componentStyle = inject(MenuStyle);
+    /** Effective end template: the `#end` content child, or the `pTemplate="end"`. */
+    readonly $endTemplate = computed(
+        () =>
+            this.endTemplate() ??
+            this.templates()
+                .filter((item) => item.getType() === 'end')
+                .at(-1)?.template
+    );
 
-    bindDirectiveInstance = inject(Bind, { self: true });
+    /**
+     * Effective item template: the `#item` content child, or (legacy behavior) the last projected
+     * pTemplate that is neither `start`, `end` nor `submenuheader`.
+     */
+    readonly $itemTemplate = computed(
+        () =>
+            this.itemTemplate() ??
+            (this.templates()
+                .filter((item) => item.getType() !== 'start' && item.getType() !== 'end' && item.getType() !== 'submenuheader')
+                .at(-1)?.template as TemplateRef<MenuItemTemplateContext> | undefined)
+    );
 
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptm('host'));
+    /** Effective submenu header template: the `#submenuheader` content child, or the `pTemplate="submenuheader"`. */
+    readonly $submenuHeaderTemplate = computed(
+        () =>
+            this.submenuHeaderTemplate() ??
+            (this.templates()
+                .filter((item) => item.getType() === 'submenuheader')
+                .at(-1)?.template as TemplateRef<MenuSubmenuHeaderTemplateContext> | undefined)
+    );
+
+    get dataP() {
+        return this.cn({
+            popup: this.popup()
+        });
     }
 
     constructor() {
         super();
-        this.id = this.id || uuid('pn_id_');
+        // Re-apply the host pass-through section after each render (replaces the former
+        // ngAfterViewChecked hook).
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptm('host'));
+        });
+    }
+
+    onInit() {
+        if (!this.popup()) {
+            this.bindDocumentClickListener();
+        }
+    }
+
+    onDestroy() {
+        if (this.popup()) {
+            if (this.scrollHandler) {
+                this.scrollHandler.destroy();
+                this.scrollHandler = null;
+            }
+
+            if (this.container) {
+                if (this.autoZIndex()) {
+                    ZIndexUtils.clear(this.container);
+                }
+                this.container = undefined;
+            }
+
+            this.restoreOverlayAppend();
+            this.onOverlayHide();
+        }
+
+        if (!this.popup()) {
+            this.unbindDocumentClickListener();
+        }
     }
 
     getPTOptions(key: string, item: any, index: number, id: string) {
@@ -476,17 +598,19 @@ export class Menu extends BaseComponent<MenuPassThrough> {
             }
         });
     }
+
     /**
      * Toggles the visibility of the popup menu.
      * @param {Event} event - Browser event.
      * @group Method
      */
     public toggle(event: Event) {
-        if (this.visible) this.hide();
+        if (this.visible()) this.hide();
         else this.show(event);
 
         this.preventDocumentDefault = true;
     }
+
     /**
      * Displays the popup menu.
      * @param {Event} event - Browser event.
@@ -494,85 +618,19 @@ export class Menu extends BaseComponent<MenuPassThrough> {
      */
     public show(event: any) {
         // Clear container if exists but overlay is not currently visible (fast toggle case)
-        if (this.container && !this.overlayVisible) {
+        if (this.container && !this.overlayVisible()) {
             this.container = undefined;
         }
 
         this.target = event.currentTarget;
-        this.visible = true;
+        this.visible.set(true);
         this.preventDocumentDefault = true;
-        this.overlayVisible = true;
+        this.overlayVisible.set(true);
         this.cd.markForCheck();
     }
 
-    onInit() {
-        if (!this.popup) {
-            this.bindDocumentClickListener();
-        }
-    }
-
-    /**
-     * Defines template option for start.
-     * @group Templates
-     */
-    readonly startTemplate = contentChild<TemplateRef<void>>('start', { descendants: false });
-    _startTemplate: TemplateRef<void> | undefined;
-
-    /**
-     * Defines template option for end.
-     * @group Templates
-     */
-    readonly endTemplate = contentChild<TemplateRef<void>>('end', { descendants: false });
-    _endTemplate: TemplateRef<void> | undefined;
-
-    /**
-     * Custom item template.
-     * @param {MenuItemTemplateContext} context - item context.
-     * @see {@link MenuItemTemplateContext}
-     * @group Templates
-     */
-    readonly itemTemplate = contentChild<TemplateRef<MenuItemTemplateContext>>('item', { descendants: false });
-    _itemTemplate: TemplateRef<MenuItemTemplateContext> | undefined;
-
-    /**
-     * Custom submenu header template.
-     * @param {MenuSubmenuHeaderTemplateContext} context - submenu header context.
-     * @see {@link MenuSubmenuHeaderTemplateContext}
-     * @group Templates
-     */
-    readonly submenuHeaderTemplate = contentChild<TemplateRef<MenuSubmenuHeaderTemplateContext>>('submenuheader', { descendants: false });
-    _submenuHeaderTemplate: TemplateRef<MenuSubmenuHeaderTemplateContext> | undefined;
-
-    readonly templates = contentChildren(PrimeTemplate);
-
-    onAfterContentInit() {
-        this.templates()?.forEach((item) => {
-            switch (item.getType()) {
-                case 'start':
-                    this._startTemplate = item.template;
-                    break;
-
-                case 'end':
-                    this._endTemplate = item.template;
-                    break;
-
-                case 'item':
-                    this._itemTemplate = item.template;
-                    break;
-
-                case 'submenuheader':
-                    this._submenuHeaderTemplate = item.template;
-                    break;
-
-                default:
-                    this._itemTemplate = item.template;
-                    break;
-            }
-        });
-    }
-
     getTabIndexValue(): string | null {
-        return this.tabindex !== undefined ? this.tabindex.toString() : null;
+        return this.tabindex() !== undefined ? this.tabindex().toString() : null;
     }
 
     onOverlayBeforeEnter(event: MotionEvent) {
@@ -596,7 +654,7 @@ export class Menu extends BaseComponent<MenuPassThrough> {
     onOverlayAfterLeave() {
         this.restoreOverlayAppend();
         this.onOverlayHide();
-        this.overlayVisible = false;
+        this.overlayVisible.set(false);
         this.onHide.emit({});
     }
 
@@ -617,22 +675,23 @@ export class Menu extends BaseComponent<MenuPassThrough> {
     }
 
     moveOnTop() {
-        if (this.autoZIndex) {
-            ZIndexUtils.set('menu', this.container, this.baseZIndex + this.config.zIndex.menu);
+        if (this.autoZIndex()) {
+            ZIndexUtils.set('menu', this.container, this.baseZIndex() + this.config.zIndex.menu);
         }
     }
+
     /**
      * Hides the popup menu.
      * @group Method
      */
     public hide() {
-        this.visible = false;
+        this.visible.set(false);
 
         this.cd.markForCheck();
     }
 
     onWindowResize() {
-        if (this.visible && !isTouchDevice()) {
+        if (this.visible() && !isTouchDevice()) {
             this.hide();
         }
     }
@@ -654,20 +713,20 @@ export class Menu extends BaseComponent<MenuPassThrough> {
     }
 
     activedescendant() {
-        return this.focused ? this.focusedOptionId() : undefined;
+        return this.focused() ? this.focusedOptionId() : undefined;
     }
 
     onListFocus(event: Event) {
-        if (!this.focused) {
-            this.focused = true;
-            !this.popup && this.changeFocusedOptionIndex(0);
+        if (!this.focused()) {
+            this.focused.set(true);
+            !this.popup() && this.changeFocusedOptionIndex(0);
             this.onFocus.emit(event);
         }
     }
 
     onListBlur(event: FocusEvent | MouseEvent) {
-        if (this.focused) {
-            this.focused = false;
+        if (this.focused()) {
+            this.focused.set(false);
             this.changeFocusedOptionIndex(-1);
             this.selectedOptionIndex.set(-1);
             this.focusedOptionIndex.set(-1);
@@ -707,11 +766,11 @@ export class Menu extends BaseComponent<MenuPassThrough> {
 
             case 'Escape':
             case 'Tab':
-                if (this.popup) {
+                if (this.popup()) {
                     focus(this.target);
                     this.hide();
                 }
-                this.overlayVisible && this.hide();
+                this.overlayVisible() && this.hide();
                 break;
 
             default:
@@ -726,7 +785,7 @@ export class Menu extends BaseComponent<MenuPassThrough> {
     }
 
     onArrowUpKey(event) {
-        if (event.altKey && this.popup) {
+        if (event.altKey && this.popup()) {
             focus(this.target);
             this.hide();
             event.preventDefault();
@@ -752,7 +811,7 @@ export class Menu extends BaseComponent<MenuPassThrough> {
         const element = <any>findSingle(this.containerViewChild()?.nativeElement, `li[id="${`${this.focusedOptionIndex()}`}"]`);
         const anchorElement = element && (<any>findSingle(element, '[data-pc-section="itemlink"]') || findSingle(element, 'a,button'));
 
-        this.popup && focus(this.target);
+        this.popup() && focus(this.target);
         anchorElement ? anchorElement.click() : element && element.click();
 
         event.preventDefault();
@@ -787,8 +846,8 @@ export class Menu extends BaseComponent<MenuPassThrough> {
     itemClick(event: any, id: string) {
         const { originalEvent, item } = event;
 
-        if (!this.focused) {
-            this.focused = true;
+        if (!this.focused()) {
+            this.focused.set(true);
             this.onFocus.emit(originalEvent);
         }
 
@@ -808,17 +867,17 @@ export class Menu extends BaseComponent<MenuPassThrough> {
             });
         }
 
-        if (this.popup) {
+        if (this.popup()) {
             this.hide();
         }
 
-        if (!this.popup && this.focusedOptionIndex() !== id) {
+        if (!this.popup() && this.focusedOptionIndex() !== id) {
             this.focusedOptionIndex.set(id);
         }
     }
 
     onOverlayClick(event: Event) {
-        if (this.popup) {
+        if (this.popup()) {
             this.overlayService.add({
                 originalEvent: event,
                 target: this.el.nativeElement
@@ -835,10 +894,10 @@ export class Menu extends BaseComponent<MenuPassThrough> {
             this.documentClickListener = this.renderer.listen(documentTarget, 'click', (event) => {
                 const isOutsideContainer = this.containerViewChild()?.nativeElement && !this.containerViewChild()?.nativeElement.contains(event.target);
                 const isOutsideTarget = !(this.target && (this.target === event.target || this.target.contains(event.target)));
-                if (!this.popup && isOutsideContainer && isOutsideTarget) {
+                if (!this.popup() && isOutsideContainer && isOutsideTarget) {
                     this.onListBlur(event);
                 }
-                if (this.preventDocumentDefault && this.overlayVisible && isOutsideContainer && isOutsideTarget) {
+                if (this.preventDocumentDefault && this.overlayVisible() && isOutsideContainer && isOutsideTarget) {
                     this.hide();
                     this.preventDocumentDefault = false;
                 }
@@ -870,7 +929,7 @@ export class Menu extends BaseComponent<MenuPassThrough> {
     bindScrollListener() {
         if (!this.scrollHandler && isPlatformBrowser(this.platformId)) {
             this.scrollHandler = new ConnectedOverlayScrollHandler(this.target, () => {
-                if (this.visible) {
+                if (this.visible()) {
                     this.hide();
                 }
             });
@@ -896,38 +955,15 @@ export class Menu extends BaseComponent<MenuPassThrough> {
             this.target = null;
         }
         if (this.container) {
-            if (this.autoZIndex) {
+            if (this.autoZIndex()) {
                 ZIndexUtils.clear(this.container);
             }
             this.container = undefined;
         }
     }
 
-    onDestroy() {
-        if (this.popup) {
-            if (this.scrollHandler) {
-                this.scrollHandler.destroy();
-                this.scrollHandler = null;
-            }
-
-            if (this.container) {
-                if (this.autoZIndex) {
-                    ZIndexUtils.clear(this.container);
-                }
-                this.container = undefined;
-            }
-
-            this.restoreOverlayAppend();
-            this.onOverlayHide();
-        }
-
-        if (!this.popup) {
-            this.unbindDocumentClickListener();
-        }
-    }
-
     hasSubMenu(): boolean {
-        return this.model?.some((item) => item.items) ?? false;
+        return this.model()?.some((item) => item.items) ?? false;
     }
 
     isItemHidden(item: any): boolean {
@@ -935,12 +971,6 @@ export class Menu extends BaseComponent<MenuPassThrough> {
             return item.visible === false || (item.items && item.items.some((subitem) => subitem.visible !== false));
         }
         return item.visible === false;
-    }
-
-    get dataP() {
-        return this.cn({
-            popup: this.popup
-        });
     }
 }
 

--- a/packages/optimus-ui/src/menu/style/menustyle.ts
+++ b/packages/optimus-ui/src/menu/style/menustyle.ts
@@ -3,14 +3,14 @@ import { style } from '@openng/optimus-ui-styles/menu';
 import { BaseStyle } from '@openng/optimus-ui/base';
 
 const inlineStyles = {
-    root: ({ instance }) => ({ position: instance.popup ? 'absolute' : 'relative' })
+    root: ({ instance }) => ({ position: instance.popup() ? 'absolute' : 'relative' })
 };
 
 const classes = {
     root: ({ instance }) => [
         'p-menu p-component',
         {
-            'p-menu-overlay': instance.popup
+            'p-menu-overlay': instance.popup()
         }
     ],
     start: 'p-menu-start',

--- a/packages/optimus-ui/src/overlaybadge/overlaybadge.test.ts
+++ b/packages/optimus-ui/src/overlaybadge/overlaybadge.test.ts
@@ -1,0 +1,85 @@
+import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Badge } from '@openng/optimus-ui/badge';
+import { OverlayBadge } from './overlaybadge';
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    standalone: true,
+    imports: [OverlayBadge],
+    template: `
+        <p-overlayBadge [value]="value" [severity]="severity" [badgeSize]="badgeSize" [badgeDisabled]="badgeDisabled">
+            <i class="pi pi-bell"></i>
+        </p-overlayBadge>
+    `
+})
+class TestBasicOverlayBadgeComponent {
+    value: string | number | null = '2';
+    severity: 'success' | 'danger' | null = 'danger';
+    badgeSize: 'small' | 'large' | 'xlarge' | null = null;
+    badgeDisabled = false;
+}
+
+describe('OverlayBadge', () => {
+    let component: TestBasicOverlayBadgeComponent;
+    let fixture: ComponentFixture<TestBasicOverlayBadgeComponent>;
+    let overlayBadgeInstance: OverlayBadge;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            imports: [TestBasicOverlayBadgeComponent],
+            providers: [provideZonelessChangeDetection()]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestBasicOverlayBadgeComponent);
+        component = fixture.componentInstance;
+        overlayBadgeInstance = fixture.debugElement.query(By.directive(OverlayBadge)).componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create and project content', () => {
+        expect(overlayBadgeInstance).toBeTruthy();
+        expect(fixture.debugElement.query(By.css('i.pi-bell'))).toBeTruthy();
+    });
+
+    it('should forward its inputs to the inner badge', () => {
+        const badgeInstance: Badge = fixture.debugElement.query(By.directive(Badge)).componentInstance;
+
+        expect(overlayBadgeInstance.value()).toBe('2');
+        expect(overlayBadgeInstance.severity()).toBe('danger');
+        expect(badgeInstance.value()).toBe('2');
+        expect(badgeInstance.severity()).toBe('danger');
+    });
+
+    it('should update the forwarded value dynamically', async () => {
+        component.value = '9+';
+        fixture.changeDetectorRef.markForCheck();
+        await fixture.whenStable();
+
+        const badgeElement = fixture.debugElement.query(By.directive(Badge));
+        expect(overlayBadgeInstance.value()).toBe('9+');
+        expect(badgeElement.nativeElement.textContent.trim()).toBe('9+');
+    });
+
+    it('should transform badgeDisabled as a boolean attribute', async () => {
+        expect(overlayBadgeInstance.badgeDisabled()).toBe(false);
+
+        component.badgeDisabled = true;
+        fixture.changeDetectorRef.markForCheck();
+        await fixture.whenStable();
+
+        expect(overlayBadgeInstance.badgeDisabled()).toBe(true);
+    });
+
+    it('should apply PT sections', () => {
+        const ptFixture = TestBed.createComponent(OverlayBadge);
+        ptFixture.componentRef.setInput('pt', { host: 'HOST_CLASS', root: 'ROOT_CLASS' });
+        ptFixture.detectChanges();
+
+        const hostElement: HTMLElement = ptFixture.nativeElement;
+        expect(hostElement.classList.contains('HOST_CLASS')).toBe(true);
+        // root is the inner wrapper div
+        expect(hostElement.querySelector('div')?.classList.contains('ROOT_CLASS')).toBe(true);
+    });
+});

--- a/packages/optimus-ui/src/overlaybadge/overlaybadge.ts
+++ b/packages/optimus-ui/src/overlaybadge/overlaybadge.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, ViewEncapsulation } from '@angular/core';
+import { afterEveryRender, booleanAttribute, ChangeDetectionStrategy, Component, inject, input, NgModule, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from '@openng/optimus-ui/api';
 import { BadgeModule } from '@openng/optimus-ui/badge';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -6,8 +6,6 @@ import { Bind } from '@openng/optimus-ui/bind';
 import type { BadgeSeverity } from '@openng/optimus-ui/types/badge';
 import { OverlayBadgePassThrough } from '@openng/optimus-ui/types/overlaybadge';
 import { OverlayBadgeStyle } from './style/overlaybadgestyle';
-
-const OVERLAYBADGE_INSTANCE = new InjectionToken<OverlayBadge>('OVERLAYBADGE_INSTANCE');
 
 /**
  * OverlayPanel is a container component positioned as connected to its target.
@@ -20,70 +18,66 @@ const OVERLAYBADGE_INSTANCE = new InjectionToken<OverlayBadge>('OVERLAYBADGE_INS
     template: `
         <div [class]="cx('root')" [pBind]="ptm('root')">
             <ng-content></ng-content>
-            <p-badge [pt]="ptm('pcBadge')" [styleClass]="styleClass" [style]="style" [badgeSize]="badgeSize" [severity]="severity" [value]="value" [badgeDisabled]="badgeDisabled" />
+            <p-badge [pt]="ptm('pcBadge')" [class]="styleClass()" [style]="style()" [badgeSize]="badgeSize()" [severity]="severity()" [value]="value()" [badgeDisabled]="badgeDisabled()" />
         </div>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [OverlayBadgeStyle, { provide: OVERLAYBADGE_INSTANCE, useExisting: OverlayBadge }, { provide: PARENT_INSTANCE, useExisting: OverlayBadge }],
+    providers: [OverlayBadgeStyle, { provide: PARENT_INSTANCE, useExisting: OverlayBadge }],
     hostDirectives: [Bind]
 })
 export class OverlayBadge extends BaseComponent<OverlayBadgePassThrough> {
-    componentName = 'OverlayBadge';
-
-    $pcOverlayBadge: OverlayBadge | undefined = inject(OVERLAYBADGE_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
-
     bindDirectiveInstance = inject(Bind, { self: true });
+
+    _componentStyle = inject(OverlayBadgeStyle);
 
     /**
      * Class of the element.
      * @group Props
      */
-    @Input() styleClass: string | undefined;
+    readonly styleClass = input<string>();
+
     /**
      * Inline style of the element.
      * @group Props
      */
-    @Input() style: { [klass: string]: any } | null | undefined;
+    readonly style = input<{ [klass: string]: any } | null>();
+
     /**
      * Size of the badge, valid options are "large" and "xlarge".
      * @group Props
      */
-    @Input() badgeSize: 'small' | 'large' | 'xlarge' | null | undefined;
+    readonly badgeSize = input<'small' | 'large' | 'xlarge' | null>();
+
     /**
      * Severity type of the badge.
      * @group Props
      */
-    @Input() severity: BadgeSeverity | null | undefined;
+    readonly severity = input<BadgeSeverity | null>();
+
     /**
      * Value to display inside the badge.
      * @group Props
      */
-    @Input() value: string | number | null | undefined;
+    readonly value = input<string | number | null>();
+
     /**
      * When specified, disables the component.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) badgeDisabled: boolean = false;
-    /**
-     * Size of the badge, valid options are "large" and "xlarge".
-     * @group Props
-     * @deprecated use badgeSize instead.
-     */
-    @Input() public set size(value: 'large' | 'xlarge' | 'small' | undefined | null) {
-        this._size = value;
-        !this.badgeSize && this.size && console.log('size property is deprecated and will removed in v18, use badgeSize instead.');
-    }
-    get size() {
-        return this._size;
-    }
-    _size: 'large' | 'xlarge' | 'small' | undefined | null;
+    readonly badgeDisabled = input<boolean, unknown>(false, { transform: booleanAttribute });
 
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptm('host'));
-    }
+    componentName = 'OverlayBadge';
 
-    _componentStyle = inject(OverlayBadgeStyle);
+    constructor() {
+        super();
+        // Re-apply the host pass-through section after each render (replaces the former
+        // ngAfterViewChecked hook). Bind.setAttrs writes into a signal behind an equality check,
+        // so unchanged PT resolutions are no-ops.
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptm('host'));
+        });
+    }
 }
 
 @NgModule({


### PR DESCRIPTION
Migrates Badge and every component that binds styleClass on p-badge in
one branch: Badge's styleClass input is replaced by the native class
attribute, so Breadcrumb, Dock, MegaMenu, Menu and OverlayBadge - whose
templates bound [styleClass] on p-badge - are migrated together to keep
every intermediate state of next compiling. All six components are fully
signal-migrated (input()/output()/linkedSignal/computed/effects), member
ordering applied, tests converted. OverlayBadge additionally drops its
deprecated no-op size alias in favor of badgeSize (covered by the
renamed-inputs ng-update migration).
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5