### PR TITLE
refactor(animateonscroll): migrate to signals

### DIFF
--- a/packages/optimus-ui/src/animateonscroll/animateonscroll.test.ts
+++ b/packages/optimus-ui/src/animateonscroll/animateonscroll.test.ts
@@ -165,12 +165,12 @@ describe('AnimateOnScroll', () => {
         });
 
         it('should have default values', () => {
-            expect(directive.threshold).toBe(0.5);
-            expect(directive.once).toBe(false);
-            expect(directive.enterClass).toBeUndefined();
-            expect(directive.leaveClass).toBeUndefined();
-            expect(directive.root).toBeUndefined();
-            expect(directive.rootMargin).toBeUndefined();
+            expect(directive.threshold()).toBe(0.5);
+            expect(directive.once()).toBe(false);
+            expect(directive.enterClass()).toBeUndefined();
+            expect(directive.leaveClass()).toBeUndefined();
+            expect(directive.root()).toBeUndefined();
+            expect(directive.rootMargin()).toBeUndefined();
         });
 
         it('should apply host class', () => {
@@ -325,7 +325,7 @@ describe('AnimateOnScroll', () => {
             await fixture.whenStable();
 
             directive = fixture.debugElement.query(By.directive(AnimateOnScroll)).injector.get(AnimateOnScroll);
-            expect(directive.options.threshold).toBe(0.8);
+            expect(directive.options().threshold).toBe(0.8);
         });
 
         it('should use custom rootMargin', async () => {
@@ -334,7 +334,7 @@ describe('AnimateOnScroll', () => {
             await fixture.whenStable();
 
             directive = fixture.debugElement.query(By.directive(AnimateOnScroll)).injector.get(AnimateOnScroll);
-            expect(directive.options.rootMargin).toBe('10px');
+            expect(directive.options().rootMargin).toBe('10px');
         });
 
         it('should use custom root element', async () => {
@@ -344,7 +344,7 @@ describe('AnimateOnScroll', () => {
             await fixture.whenStable();
 
             directive = fixture.debugElement.query(By.directive(AnimateOnScroll)).injector.get(AnimateOnScroll);
-            expect(directive.options.root).toBe(rootElement);
+            expect(directive.options().root).toBe(rootElement);
         });
 
         it('should default threshold to 0.5 when undefined', async () => {
@@ -353,7 +353,7 @@ describe('AnimateOnScroll', () => {
             await fixture.whenStable();
 
             directive = fixture.debugElement.query(By.directive(AnimateOnScroll)).injector.get(AnimateOnScroll);
-            expect(directive.options.threshold).toBe(0.5);
+            expect(directive.options().threshold).toBe(0.5);
         });
     });
 
@@ -509,7 +509,7 @@ describe('AnimateOnScroll', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(directive.enterClass).toBe('new-enter-class');
+            expect(directive.enterClass()).toBe('new-enter-class');
         });
 
         it('should handle dynamic threshold changes', async () => {
@@ -517,8 +517,8 @@ describe('AnimateOnScroll', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(directive.threshold).toBe(0.9);
-            expect(directive.options.threshold).toBe(0.9);
+            expect(directive.threshold()).toBe(0.9);
+            expect(directive.options().threshold).toBe(0.9);
         });
 
         it('should handle dynamic once property changes', async () => {
@@ -526,7 +526,7 @@ describe('AnimateOnScroll', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(directive.once).toBe(true);
+            expect(directive.once()).toBe(true);
         });
     });
 
@@ -591,7 +591,7 @@ describe('AnimateOnScroll', () => {
             await fixture.whenStable();
 
             const directive = fixture.debugElement.query(By.directive(AnimateOnScroll)).injector.get(AnimateOnScroll);
-            expect(directive.options.root).toBeNull();
+            expect(directive.options().root).toBeNull();
         });
 
         it('should handle elements with top <= 0', async () => {
@@ -704,7 +704,7 @@ describe('AnimateOnScroll', () => {
         });
 
         it('should return correct options object', () => {
-            const options = directive.options;
+            const options = directive.options();
 
             expect(options.threshold).toBe(0.8);
             expect(options.rootMargin).toBe('10px');

--- a/packages/optimus-ui/src/animateonscroll/animateonscroll.ts
+++ b/packages/optimus-ui/src/animateonscroll/animateonscroll.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { booleanAttribute, Directive, Input, NgModule, numberAttribute } from '@angular/core';
+import { afterNextRender, booleanAttribute, computed, Directive, input, NgModule, numberAttribute } from '@angular/core';
 import { addClass, removeClass } from '@openng/optimus-ui-utils';
 import { BaseComponent } from '@openng/optimus-ui/basecomponent';
 
@@ -25,32 +25,37 @@ export class AnimateOnScroll extends BaseComponent {
      * Selector to define the CSS class for enter animation.
      * @group Props
      */
-    @Input() enterClass: string | undefined;
+    readonly enterClass = input<string>();
+
     /**
      * Selector to define the CSS class for leave animation.
      * @group Props
      */
-    @Input() leaveClass: string | undefined;
+    readonly leaveClass = input<string>();
+
     /**
      * Specifies the root option of the IntersectionObserver API.
      * @group Props
      */
-    @Input() root: HTMLElement | undefined | null;
+    readonly root = input<HTMLElement | null>();
+
     /**
      * Specifies the rootMargin option of the IntersectionObserver API.
      * @group Props
      */
-    @Input() rootMargin: string | undefined;
+    readonly rootMargin = input<string>();
+
     /**
      * Specifies the threshold option of the IntersectionObserver API
      * @group Props
      */
-    @Input({ transform: numberAttribute }) threshold: number | undefined = 0.5;
+    readonly threshold = input<number | undefined, unknown>(0.5, { transform: numberAttribute });
+
     /**
      * Whether the scroll event listener should be removed after initial run.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) once: boolean = false;
+    readonly once = input<boolean, unknown>(false, { transform: booleanAttribute });
 
     observer: IntersectionObserver | undefined;
 
@@ -62,24 +67,30 @@ export class AnimateOnScroll extends BaseComponent {
 
     animationEndListener: VoidFunction | null | undefined;
 
+    readonly options = computed<AnimateOnScrollOptions>(() => ({
+        root: this.root(),
+        rootMargin: this.rootMargin(),
+        threshold: this.threshold() || 0.5
+    }));
+
+    constructor() {
+        super();
+        // Bind the intersection observers once the element is rendered (replaces the former
+        // ngAfterViewInit hook; afterNextRender only runs in the browser).
+        afterNextRender(() => {
+            this.bindIntersectionObserver();
+        });
+    }
+
     onInit() {
         if (isPlatformBrowser(this.platformId)) {
-            this.renderer.setStyle(this.el.nativeElement, 'opacity', this.enterClass ? '0' : '');
+            this.renderer.setStyle(this.el.nativeElement, 'opacity', this.enterClass() ? '0' : '');
         }
     }
 
-    onAfterViewInit() {
-        if (isPlatformBrowser(this.platformId)) {
-            this.bindIntersectionObserver();
-        }
-    }
-
-    get options(): AnimateOnScrollOptions {
-        return {
-            root: this.root,
-            rootMargin: this.rootMargin,
-            threshold: this.threshold || 0.5
-        };
+    onDestroy() {
+        this.unbindAnimationEvents();
+        this.unbindIntersectionObserver();
     }
 
     bindIntersectionObserver() {
@@ -93,7 +104,7 @@ export class AnimateOnScroll extends BaseComponent {
             }
 
             this.isObserverActive = true;
-        }, this.options);
+        }, this.options());
 
         setTimeout(() => this.observer?.observe(this.el.nativeElement), 0);
 
@@ -102,25 +113,25 @@ export class AnimateOnScroll extends BaseComponent {
         this.resetObserver = new IntersectionObserver(
             ([entry]) => {
                 if (entry.boundingClientRect.top > 0 && !entry.isIntersecting) {
-                    this.el.nativeElement.style.opacity = this.enterClass ? '0' : '';
-                    removeClass(this.el.nativeElement, [this.enterClass, this.leaveClass]);
+                    this.el.nativeElement.style.opacity = this.enterClass() ? '0' : '';
+                    removeClass(this.el.nativeElement, [this.enterClass(), this.leaveClass()]);
 
                     this.resetObserver.unobserve(this.el.nativeElement);
                 }
 
                 this.animationState = undefined;
             },
-            { ...this.options, threshold: 0 }
+            { ...this.options(), threshold: 0 }
         );
     }
 
     enter() {
-        if (this.animationState !== 'enter' && this.enterClass) {
+        if (this.animationState !== 'enter' && this.enterClass()) {
             this.el.nativeElement.style.opacity = '';
-            removeClass(this.el.nativeElement, this.leaveClass);
-            addClass(this.el.nativeElement, this.enterClass);
+            removeClass(this.el.nativeElement, this.leaveClass());
+            addClass(this.el.nativeElement, this.enterClass());
 
-            this.once && this.unbindIntersectionObserver();
+            this.once() && this.unbindIntersectionObserver();
 
             this.bindAnimationEvents();
             this.animationState = 'enter';
@@ -128,10 +139,10 @@ export class AnimateOnScroll extends BaseComponent {
     }
 
     leave() {
-        if (this.animationState !== 'leave' && this.leaveClass) {
-            this.el.nativeElement.style.opacity = this.enterClass ? '0' : '';
-            removeClass(this.el.nativeElement, this.enterClass);
-            addClass(this.el.nativeElement, this.leaveClass);
+        if (this.animationState !== 'leave' && this.leaveClass()) {
+            this.el.nativeElement.style.opacity = this.enterClass() ? '0' : '';
+            removeClass(this.el.nativeElement, this.enterClass());
+            addClass(this.el.nativeElement, this.leaveClass());
 
             this.bindAnimationEvents();
             this.animationState = 'leave';
@@ -141,8 +152,8 @@ export class AnimateOnScroll extends BaseComponent {
     bindAnimationEvents() {
         if (!this.animationEndListener) {
             this.animationEndListener = this.renderer.listen(this.el.nativeElement, 'animationend', () => {
-                removeClass(this.el.nativeElement, [this.enterClass, this.leaveClass]);
-                !this.once && this.resetObserver.observe(this.el.nativeElement);
+                removeClass(this.el.nativeElement, [this.enterClass(), this.leaveClass()]);
+                !this.once() && this.resetObserver.observe(this.el.nativeElement);
                 this.unbindAnimationEvents();
             });
         }
@@ -159,11 +170,6 @@ export class AnimateOnScroll extends BaseComponent {
         this.observer?.unobserve(this.el.nativeElement);
         this.resetObserver?.unobserve(this.el.nativeElement);
         this.isObserverActive = false;
-    }
-
-    onDestroy() {
-        this.unbindAnimationEvents();
-        this.unbindIntersectionObserver();
     }
 }
 


### PR DESCRIPTION
Converts the component to the signal-based APIs: @Input()/@Output() to
input()/output()/model(), getter/setter inputs to input() + linkedSignal
mirrors keeping the legacy private state names, ngOnChanges branches to
effects in declaration order, and view/content queries to viewChild/
contentChild/contentChildren. Class members are reordered to the project
convention (inject, input, output, viewChild, viewChildren, contentChild,
contentChildren, other properties, constructor, lifecycle hooks,
functions) and the tests are converted to setInput/signal reads.
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5