### PR TITLE
refactor(autofocus): migrate to signals

### DIFF
--- a/packages/optimus-ui/src/autofocus/autofocus.test.ts
+++ b/packages/optimus-ui/src/autofocus/autofocus.test.ts
@@ -253,7 +253,7 @@ describe('AutoFocus', () => {
         it('should have default values', () => {
             // pAutoFocus without value defaults to empty string in template, which is truthy
             // But the component Input transforms it to false
-            expect(directive.focused).toBe(false);
+            expect(directive.focused()).toBe(false);
         });
 
         it('should inject platform ID and document', () => {
@@ -262,8 +262,8 @@ describe('AutoFocus', () => {
         });
 
         it('should inject host element reference', () => {
-            expect(directive.host).toBeDefined();
-            expect(directive.host.nativeElement).toBe(element);
+            expect(directive.el).toBeDefined();
+            expect(directive.el.nativeElement).toBe(element);
         });
     });
 
@@ -332,7 +332,7 @@ describe('AutoFocus', () => {
             await new Promise((resolve) => setTimeout(resolve, 10)); // Wait for setTimeout
 
             const directive = fixture.debugElement.query(By.directive(AutoFocus)).injector.get(AutoFocus);
-            expect(directive.focused).toBe(true);
+            expect(directive.focused()).toBe(true);
         });
 
         it('should not focus when autofocus is disabled', async () => {
@@ -357,7 +357,7 @@ describe('AutoFocus', () => {
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             const directive = fixture.debugElement.query(By.directive(AutoFocus)).injector.get(AutoFocus);
-            expect(directive.focused).toBe(true);
+            expect(directive.focused()).toBe(true);
         });
 
         it('should focus div with tabindex when autofocus is enabled', async () => {
@@ -370,7 +370,7 @@ describe('AutoFocus', () => {
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             const directive = fixture.debugElement.query(By.directive(AutoFocus)).injector.get(AutoFocus);
-            expect(directive.focused).toBe(true);
+            expect(directive.focused()).toBe(true);
         });
     });
 
@@ -389,7 +389,7 @@ describe('AutoFocus', () => {
             expect(element.focus).not.toHaveBeenCalled();
 
             const directive = fixture.debugElement.query(By.directive(AutoFocus)).injector.get(AutoFocus);
-            expect(directive.focused).toBe(false);
+            expect(directive.focused()).toBe(false);
         });
     });
 
@@ -445,47 +445,34 @@ describe('AutoFocus', () => {
         });
     });
 
-    describe('Lifecycle Hooks', () => {
+    describe('Render-driven focus (replaces the former ngAfterContentChecked/ngAfterViewChecked hooks)', () => {
         let fixture: ComponentFixture<TestAutofocusEnabledComponent>;
         let directive: AutoFocus;
 
         beforeEach(async () => {
             fixture = TestBed.createComponent(TestAutofocusEnabledComponent);
             await fixture.whenStable();
+            // let the pending focus timeout settle so `focused` reaches its steady state
+            await new Promise((resolve) => setTimeout(resolve, 10));
             directive = fixture.debugElement.query(By.directive(AutoFocus)).injector.get(AutoFocus);
         });
 
-        it('should call autoFocus in ngAfterContentChecked', () => {
+        it('should attempt focus after a render when not focused', async () => {
+            directive.focused.set(false);
             vi.spyOn(directive, 'autoFocus').mockImplementation(() => {});
 
-            directive.ngAfterContentChecked();
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
 
             expect(directive.autoFocus).toHaveBeenCalled();
         });
 
-        it('should call autoFocus in ngAfterViewChecked when not focused', () => {
-            directive.focused = false;
+        it('should not attempt focus after a render when already focused', async () => {
+            directive.focused.set(true);
             vi.spyOn(directive, 'autoFocus').mockImplementation(() => {});
 
-            directive.ngAfterViewChecked();
-
-            expect(directive.autoFocus).toHaveBeenCalled();
-        });
-
-        it('should not call autoFocus in ngAfterViewChecked when already focused', () => {
-            directive.focused = true;
-            vi.spyOn(directive, 'autoFocus').mockImplementation(() => {});
-
-            directive.ngAfterViewChecked();
-
-            expect(directive.autoFocus).not.toHaveBeenCalled();
-        });
-
-        it('should not call autoFocus in ngAfterContentChecked when already focused', () => {
-            directive.focused = true;
-            vi.spyOn(directive, 'autoFocus').mockImplementation(() => {});
-
-            directive.ngAfterContentChecked();
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
 
             expect(directive.autoFocus).not.toHaveBeenCalled();
         });
@@ -507,14 +494,15 @@ describe('AutoFocus', () => {
             await fixture.whenStable();
 
             // Reset focused state to allow refocusing
-            directive.focused = false;
+            directive.focused.set(false);
 
             const input = fixture.debugElement.query(By.css('.dynamic-input'));
             if (input) {
                 vi.spyOn(input.nativeElement, 'focus').mockImplementation(() => {});
 
-                // Trigger ngAfterContentChecked
-                directive.ngAfterContentChecked();
+                // Trigger a render — afterEveryRender re-attempts the focus
+                fixture.changeDetectorRef.markForCheck();
+                await fixture.whenStable();
                 await new Promise((resolve) => setTimeout(resolve, 10));
 
                 // The input should be focused
@@ -534,12 +522,13 @@ describe('AutoFocus', () => {
             component.showButton = true;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            directive.focused = false;
+            directive.focused.set(false);
 
             const button = fixture.debugElement.query(By.css('.dynamic-button'));
             if (button) {
                 vi.spyOn(button.nativeElement, 'focus').mockImplementation(() => {});
-                directive.ngAfterContentChecked();
+                fixture.changeDetectorRef.markForCheck();
+                await fixture.whenStable();
                 await new Promise((resolve) => setTimeout(resolve, 10));
                 expect(button.nativeElement.focus).toHaveBeenCalled();
             }
@@ -548,12 +537,13 @@ describe('AutoFocus', () => {
             component.showInput = true;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            directive.focused = false;
+            directive.focused.set(false);
 
             const input = fixture.debugElement.query(By.css('.dynamic-input'));
             if (input) {
                 vi.spyOn(input.nativeElement, 'focus').mockImplementation(() => {});
-                directive.ngAfterContentChecked();
+                fixture.changeDetectorRef.markForCheck();
+                await fixture.whenStable();
                 await new Promise((resolve) => setTimeout(resolve, 10));
                 expect(input.nativeElement.focus).toHaveBeenCalled();
             }
@@ -615,7 +605,7 @@ describe('AutoFocus', () => {
             const directive = fixture.debugElement.query(By.directive(AutoFocus)).injector.get(AutoFocus);
 
             // Mock null host
-            directive.host = null as any;
+            directive.el = null as any;
 
             expect(() => {
                 directive.autoFocus();
@@ -644,7 +634,7 @@ describe('AutoFocus', () => {
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             const directive = fixture.debugElement.query(By.directive(AutoFocus)).injector.get(AutoFocus);
-            expect(directive.focused).toBe(true);
+            expect(directive.focused()).toBe(true);
         });
 
         it('should handle autofocus when element is not in DOM', () => {
@@ -666,12 +656,12 @@ describe('AutoFocus', () => {
             const fixture = TestBed.createComponent(TestAutofocusEnabledComponent);
             const directive = fixture.debugElement.query(By.directive(AutoFocus)).injector.get(AutoFocus);
 
-            expect(directive.focused).toBe(false);
+            expect(directive.focused()).toBe(false);
 
             await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
 
-            expect(directive.focused).toBe(true);
+            expect(directive.focused()).toBe(true);
         });
 
         it('should not focus again when already focused', async () => {
@@ -682,7 +672,7 @@ describe('AutoFocus', () => {
             vi.spyOn(element, 'focus').mockImplementation(() => {});
 
             // Set focused flag manually to simulate already focused state
-            directive.focused = true;
+            directive.focused.set(true);
             await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -705,7 +695,7 @@ describe('AutoFocus', () => {
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             expect(element.focus).not.toHaveBeenCalled();
-            expect(directive.focused).toBe(false);
+            expect(directive.focused()).toBe(false);
 
             // Enable autofocus
             component.autofocusEnabled = true;
@@ -714,7 +704,7 @@ describe('AutoFocus', () => {
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             expect(element.focus).toHaveBeenCalled();
-            expect(directive.focused).toBe(true);
+            expect(directive.focused()).toBe(true);
         });
     });
 
@@ -766,12 +756,13 @@ describe('AutoFocus', () => {
             vi.spyOn(dialogInput.nativeElement, 'focus').mockImplementation(() => {});
 
             // Simulate what happens when autofocus directive detects new content
-            dialogInputDirective.focused = false; // Reset focused state
-            dialogInputDirective.ngAfterContentChecked();
+            dialogInputDirective.focused.set(false); // Reset focused state
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             expect(dialogInput.nativeElement.focus).toHaveBeenCalled();
-            expect(dialogInputDirective.focused).toBe(true);
+            expect(dialogInputDirective.focused()).toBe(true);
         });
 
         it('should focus select when drawer is dynamically rendered', async () => {
@@ -796,12 +787,13 @@ describe('AutoFocus', () => {
             vi.spyOn(drawerSelect.nativeElement, 'focus').mockImplementation(() => {});
 
             // Simulate what happens when autofocus directive detects new content
-            drawerSelectDirective.focused = false; // Reset focused state
-            drawerSelectDirective.ngAfterContentChecked();
+            drawerSelectDirective.focused.set(false); // Reset focused state
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             expect(drawerSelect.nativeElement.focus).toHaveBeenCalled();
-            expect(drawerSelectDirective.focused).toBe(true);
+            expect(drawerSelectDirective.focused()).toBe(true);
         });
 
         it('should handle multiple dialog opens/closes correctly', async () => {
@@ -815,11 +807,12 @@ describe('AutoFocus', () => {
             let directive = dialogInput.injector.get(AutoFocus);
             vi.spyOn(dialogInput.nativeElement, 'focus').mockImplementation(() => {});
 
-            directive.focused = false; // Reset state
-            directive.ngAfterContentChecked();
+            directive.focused.set(false); // Reset state
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
             expect(dialogInput.nativeElement.focus).toHaveBeenCalled();
-            expect(directive.focused).toBe(true);
+            expect(directive.focused()).toBe(true);
 
             // Close dialog
             component.closeDialog();
@@ -840,8 +833,9 @@ describe('AutoFocus', () => {
             directive = dialogInput.injector.get(AutoFocus);
             vi.spyOn(dialogInput.nativeElement, 'focus').mockImplementation(() => {});
 
-            directive.focused = false; // Reset state for new instance
-            directive.ngAfterContentChecked();
+            directive.focused.set(false); // Reset state for new instance
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
             expect(dialogInput.nativeElement.focus).toHaveBeenCalled();
         });
@@ -865,8 +859,9 @@ describe('AutoFocus', () => {
             vi.spyOn(dialogTextarea.nativeElement, 'focus').mockImplementation(() => {});
 
             // Initially input should be focused
-            inputDirective.focused = false; // Reset state to allow focusing
-            inputDirective.ngAfterContentChecked();
+            inputDirective.focused.set(false); // Reset state to allow focusing
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
             expect(dialogInput.nativeElement.focus).toHaveBeenCalled();
 
@@ -877,14 +872,16 @@ describe('AutoFocus', () => {
             await fixture.whenStable();
 
             // Reset focused states to allow refocusing
-            inputDirective.focused = false;
-            textareaDirective.focused = false;
+            inputDirective.focused.set(false);
+            textareaDirective.focused.set(false);
 
             // Input should not be called since shouldAutoFocus is now false
-            expect(inputDirective.autofocus).toBe(false);
-            expect(textareaDirective.autofocus).toBe(true);
+            expect(inputDirective.autofocus()).toBe(false);
+            expect(textareaDirective.autofocus()).toBe(true);
 
-            textareaDirective.ngAfterContentChecked();
+            fixture.changeDetectorRef.markForCheck();
+
+            await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
             expect(dialogTextarea.nativeElement.focus).toHaveBeenCalled();
         });
@@ -911,12 +908,9 @@ describe('AutoFocus', () => {
             vi.spyOn(dialogInput.nativeElement, 'focus').mockImplementation(() => {});
             vi.spyOn(dialogTextarea.nativeElement, 'focus').mockImplementation(() => {});
 
-            // Manually trigger lifecycle hooks - should not focus anything
-            const inputDirective = dialogInput.injector.get(AutoFocus);
-            const textareaDirective = dialogTextarea.injector.get(AutoFocus);
-
-            inputDirective.ngAfterContentChecked();
-            textareaDirective.ngAfterContentChecked();
+            // Trigger a render - should not focus anything
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             expect(dialogInput.nativeElement.focus).not.toHaveBeenCalled();
@@ -947,12 +941,13 @@ describe('AutoFocus', () => {
             vi.spyOn(dialogInput.nativeElement, 'focus').mockImplementation(() => {});
 
             // Reset focused state to allow focusing
-            directive.focused = false;
-            directive.ngAfterContentChecked();
+            directive.focused.set(false);
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             expect(dialogInput.nativeElement.focus).toHaveBeenCalled();
-            expect(directive.focused).toBe(true);
+            expect(directive.focused()).toBe(true);
         });
     });
 });

--- a/packages/optimus-ui/src/autofocus/autofocus.ts
+++ b/packages/optimus-ui/src/autofocus/autofocus.ts
@@ -1,5 +1,5 @@
-import { DOCUMENT, isPlatformBrowser } from '@angular/common';
-import { Directive, ElementRef, inject, Input, NgModule, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { afterEveryRender, Directive, input, NgModule, signal } from '@angular/core';
 import { BaseComponent } from '@openng/optimus-ui/basecomponent';
 import { DomHandler } from '@openng/optimus-ui/dom';
 
@@ -9,55 +9,50 @@ import { DomHandler } from '@openng/optimus-ui/dom';
  */
 @Directive({
     selector: '[pAutoFocus]',
-    standalone: true
+    standalone: true,
+    host: {
+        // This sets the `attr.autofocus` which is different than the Input `autofocus` attribute.
+        '[attr.autofocus]': 'autofocus() ? true : null'
+    }
 })
 export class AutoFocus extends BaseComponent {
     /**
      * When present, it specifies that the component should automatically get focus on load.
      * @group Props
      */
-    @Input('pAutoFocus') autofocus: boolean = false;
+    readonly autofocus = input<boolean>(false, { alias: 'pAutoFocus' });
 
-    focused: boolean = false;
+    readonly focused = signal(false);
 
-    platformId = inject(PLATFORM_ID);
-
-    document: Document = inject(DOCUMENT);
-
-    host: ElementRef = inject(ElementRef);
-
-    onAfterContentChecked() {
-        // This sets the `attr.autofocus` which is different than the Input `autofocus` attribute.
-        if (this.autofocus === false) {
-            this.host.nativeElement.removeAttribute('autofocus');
-        } else {
-            this.host.nativeElement.setAttribute('autofocus', true);
-        }
-
-        if (!this.focused) {
-            this.autoFocus();
-        }
-    }
-
-    onAfterViewChecked() {
-        if (!this.focused) {
-            this.autoFocus();
-        }
+    constructor() {
+        super();
+        // Keep attempting to focus until it succeeds — content projected or rendered later
+        // (dialogs, drawers) becomes focusable on a subsequent render (replaces the former
+        // ngAfterContentChecked/ngAfterViewChecked hooks).
+        afterEveryRender(() => {
+            if (!this.focused()) {
+                this.autoFocus();
+            }
+        });
     }
 
     autoFocus() {
-        if (isPlatformBrowser(this.platformId) && this.autofocus) {
+        if (isPlatformBrowser(this.platformId) && this.autofocus()) {
             setTimeout(() => {
-                const focusableElements = DomHandler.getFocusableElements(this.host?.nativeElement);
+                const host = this.el?.nativeElement;
+                if (!host) {
+                    return;
+                }
+                const focusableElements = DomHandler.getFocusableElements(host);
 
                 if (focusableElements.length === 0) {
-                    this.host.nativeElement.focus();
+                    host.focus?.();
                 }
                 if (focusableElements.length > 0) {
                     focusableElements[0].focus();
                 }
 
-                this.focused = true;
+                this.focused.set(true);
             });
         }
     }


### PR DESCRIPTION
Converts the component to the signal-based APIs: @Input()/@Output() to
input()/output()/model(), getter/setter inputs to input() + linkedSignal
mirrors keeping the legacy private state names, ngOnChanges branches to
effects in declaration order, and view/content queries to viewChild/
contentChild/contentChildren. Class members are reordered to the project
convention (inject, input, output, viewChild, viewChildren, contentChild,
contentChildren, other properties, constructor, lifecycle hooks,
functions) and the tests are converted to setInput/signal reads.
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5