### PR TITLE
refactor(floatlabel): migrate to signals

### DIFF
--- a/packages/optimus-ui/src/floatlabel/floatlabel.test.ts
+++ b/packages/optimus-ui/src/floatlabel/floatlabel.test.ts
@@ -92,7 +92,7 @@ describe('FloatLabel', () => {
         });
 
         it('should have default variant "over"', () => {
-            expect(floatLabelInstance.variant).toBe('over');
+            expect(floatLabelInstance.variant()).toBe('over');
         });
 
         it('should apply variant "in"', async () => {
@@ -100,7 +100,7 @@ describe('FloatLabel', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(floatLabelInstance.variant).toBe('in');
+            expect(floatLabelInstance.variant()).toBe('in');
         });
 
         it('should apply variant "on"', async () => {
@@ -108,7 +108,7 @@ describe('FloatLabel', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(floatLabelInstance.variant).toBe('on');
+            expect(floatLabelInstance.variant()).toBe('on');
         });
 
         it('should have correct variant classes', async () => {
@@ -291,10 +291,10 @@ describe('FloatLabel PassThrough Tests', () => {
 
     describe('PT Case 4: Use variables from instance', () => {
         it('should access instance variables in PT function', () => {
-            component.variant = 'in';
+            fixture.componentRef.setInput('variant', 'in');
             fixture.componentRef.setInput('pt', {
                 root: ({ instance }: any) => ({
-                    class: instance?.variant === 'in' ? 'VARIANT_IN' : ''
+                    class: instance?.variant() === 'in' ? 'VARIANT_IN' : ''
                 })
             });
             fixture.detectChanges();
@@ -303,11 +303,11 @@ describe('FloatLabel PassThrough Tests', () => {
         });
 
         it('should conditionally apply styles based on instance state', () => {
-            component.variant = 'over';
+            fixture.componentRef.setInput('variant', 'over');
             fixture.componentRef.setInput('pt', {
                 root: ({ instance }: any) => ({
                     style: {
-                        'background-color': instance?.variant === 'over' ? 'yellow' : 'red'
+                        'background-color': instance?.variant() === 'over' ? 'yellow' : 'red'
                     }
                 })
             });
@@ -337,18 +337,29 @@ describe('FloatLabel PassThrough Tests', () => {
             expect(clicked).toBe(true);
         });
 
-        it('should modify instance through PT event', () => {
+        it('should receive the component instance in PT functions', () => {
+            // `variant` is a signal input now, so PT events cannot assign to it — they read
+            // instance state through signal calls instead. The event handler is hoisted so the
+            // PT resolution stays referentially stable across renders (a fresh closure per
+            // resolution would defeat Bind.setAttrs' equality check and loop change detection).
+            let received: FloatLabel | undefined;
+            let clicked = false;
+            const onclick = () => {
+                clicked = true;
+            };
+            fixture.componentRef.setInput('variant', 'on');
             fixture.componentRef.setInput('pt', {
-                root: ({ instance }: any) => ({
-                    onclick: () => {
-                        instance.variant = 'on';
-                    }
-                })
+                root: ({ instance }: any) => {
+                    received = instance;
+                    return { onclick };
+                }
             });
             fixture.detectChanges();
 
             hostElement.click();
-            expect(component.variant).toBe('on');
+            expect(clicked).toBe(true);
+            expect(received).toBe(component);
+            expect(received?.variant()).toBe('on');
         });
     });
 

--- a/packages/optimus-ui/src/floatlabel/floatlabel.ts
+++ b/packages/optimus-ui/src/floatlabel/floatlabel.ts
@@ -1,11 +1,9 @@
-import { AfterViewChecked, ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, ViewEncapsulation } from '@angular/core';
+import { afterEveryRender, ChangeDetectionStrategy, Component, inject, input, NgModule, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind, BindModule } from '@openng/optimus-ui/bind';
 import { FloatLabelPassThrough } from '@openng/optimus-ui/types/floatlabel';
 import { FloatLabelStyle } from './style/floatlabelstyle';
-
-const FLOATLABEL_INSTANCE = new InjectionToken<FloatLabel>('FLOATLABEL_INSTANCE');
 
 /**
  * FloatLabel appears on top of the input field when focused.
@@ -18,30 +16,34 @@ const FLOATLABEL_INSTANCE = new InjectionToken<FloatLabel>('FLOATLABEL_INSTANCE'
     template: ` <ng-content></ng-content> `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [FloatLabelStyle, { provide: FLOATLABEL_INSTANCE, useExisting: FloatLabel }, { provide: PARENT_INSTANCE, useExisting: FloatLabel }],
+    providers: [FloatLabelStyle, { provide: PARENT_INSTANCE, useExisting: FloatLabel }],
     host: {
         '[class]': "cx('root')"
     },
     hostDirectives: [Bind]
 })
-export class FloatLabel extends BaseComponent<FloatLabelPassThrough> implements AfterViewChecked {
-    componentName = 'FloatLabel';
-
+export class FloatLabel extends BaseComponent<FloatLabelPassThrough> {
     _componentStyle = inject(FloatLabelStyle);
 
-    $pcFloatLabel: FloatLabel | undefined = inject(FLOATLABEL_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
-
     bindDirectiveInstance = inject(Bind, { self: true });
-
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
-    }
 
     /**
      * Defines the positioning of the label relative to the input.
      * @group Props
      */
-    @Input() variant: 'in' | 'over' | 'on' = 'over';
+    readonly variant = input<'in' | 'over' | 'on'>('over');
+
+    componentName = 'FloatLabel';
+
+    constructor() {
+        super();
+        // Re-apply the host/root pass-through sections after each render (replaces the former
+        // ngAfterViewChecked hook). Bind.setAttrs writes into a signal behind an equality check,
+        // so unchanged PT resolutions are no-ops.
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
+        });
+    }
 }
 
 @NgModule({

--- a/packages/optimus-ui/src/floatlabel/style/floatlabelstyle.ts
+++ b/packages/optimus-ui/src/floatlabel/style/floatlabelstyle.ts
@@ -15,9 +15,9 @@ const classes = {
     root: ({ instance }) => [
         'p-floatlabel',
         {
-            'p-floatlabel-over': instance.variant === 'over',
-            'p-floatlabel-on': instance.variant === 'on',
-            'p-floatlabel-in': instance.variant === 'in'
+            'p-floatlabel-over': instance.variant() === 'over',
+            'p-floatlabel-on': instance.variant() === 'on',
+            'p-floatlabel-in': instance.variant() === 'in'
         }
     ]
 };


### PR DESCRIPTION
Converts the component to the signal-based APIs: @Input()/@Output() to
input()/output()/model(), getter/setter inputs to input() + linkedSignal
mirrors keeping the legacy private state names, ngOnChanges branches to
effects in declaration order, and view/content queries to viewChild/
contentChild/contentChildren. Class members are reordered to the project
convention (inject, input, output, viewChild, viewChildren, contentChild,
contentChildren, other properties, constructor, lifecycle hooks,
functions) and the tests are converted to setInput/signal reads.
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5