### PR TITLE
refactor(knob): migrate to signals

### DIFF
--- a/packages/optimus-ui/src/knob/knob.test.ts
+++ b/packages/optimus-ui/src/knob/knob.test.ts
@@ -55,7 +55,7 @@ class TestReactiveFormKnobComponent {
             [rangeColor]="rangeColor"
             [textColor]="textColor"
             [valueTemplate]="valueTemplate"
-            [styleClass]="styleClass"
+            [class]="styleClass"
             [ariaLabel]="ariaLabel"
             [tabindex]="tabindex"
             (onChange)="onKnobChange($event)"
@@ -134,14 +134,14 @@ describe('Knob', () => {
         });
 
         it('should initialize with default properties', () => {
-            expect(knobInstance.min).toBe(0);
-            expect(knobInstance.max).toBe(100);
-            expect(knobInstance.step).toBe(1);
-            expect(knobInstance.size).toBe(100);
-            expect(knobInstance.strokeWidth).toBe(14);
-            expect(knobInstance.showValue).toBe(true);
-            expect(knobInstance.readonly).toBe(false);
-            expect(knobInstance.valueTemplate).toBe('{value}');
+            expect(knobInstance.min()).toBe(0);
+            expect(knobInstance.max()).toBe(100);
+            expect(knobInstance.step()).toBe(1);
+            expect(knobInstance.size()).toBe(100);
+            expect(knobInstance.strokeWidth()).toBe(14);
+            expect(knobInstance.showValue()).toBe(true);
+            expect(knobInstance.readonly()).toBe(false);
+            expect(knobInstance.valueTemplate()).toBe('{value}');
         });
 
         it('should render SVG element with correct attributes', () => {
@@ -193,7 +193,7 @@ describe('Knob', () => {
             await fixture.whenStable();
 
             expect(knobInstance.value()).toBe(75);
-            expect(knobInstance._value).toBe(75);
+            expect(knobInstance._value()).toBe(75);
         });
 
         it('should update displayed value', async () => {
@@ -425,8 +425,8 @@ describe('Knob', () => {
             component.max = 90;
             fixture.detectChanges();
 
-            expect(knobInstance.min).toBe(10);
-            expect(knobInstance.max).toBe(90);
+            expect(knobInstance.min()).toBe(10);
+            expect(knobInstance.max()).toBe(90);
 
             const svgElement = fixture.debugElement.query(By.css('svg'));
             expect(svgElement.nativeElement.getAttribute('aria-valuemin')).toBe('10');
@@ -434,11 +434,11 @@ describe('Knob', () => {
         });
 
         it('should apply custom step value', () => {
-            expect(knobInstance.step).toBe(5);
+            expect(knobInstance.step()).toBe(5);
         });
 
         it('should apply custom size', () => {
-            expect(knobInstance.size).toBe(150);
+            expect(knobInstance.size()).toBe(150);
 
             const svgElement = fixture.debugElement.query(By.css('svg'));
             expect(svgElement.nativeElement.style.width).toBe('150px');
@@ -446,7 +446,7 @@ describe('Knob', () => {
         });
 
         it('should apply custom stroke width', () => {
-            expect(knobInstance.strokeWidth).toBe(20);
+            expect(knobInstance.strokeWidth()).toBe(20);
 
             const paths = fixture.debugElement.queryAll(By.css('path'));
             paths.forEach((path) => {
@@ -455,9 +455,9 @@ describe('Knob', () => {
         });
 
         it('should apply custom colors', () => {
-            expect(knobInstance.valueColor).toBe('#007ad9');
-            expect(knobInstance.rangeColor).toBe('#f1f1f1');
-            expect(knobInstance.textColor).toBe('#333');
+            expect(knobInstance.valueColor()).toBe('#007ad9');
+            expect(knobInstance.rangeColor()).toBe('#f1f1f1');
+            expect(knobInstance.textColor()).toBe('#333');
 
             const paths = fixture.debugElement.queryAll(By.css('path'));
             expect(paths[0].nativeElement.getAttribute('stroke')).toBe('#f1f1f1');
@@ -649,13 +649,13 @@ describe('Knob', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(knobInstance._value).toBe(0); // Should default to min value
+            expect(knobInstance._value()).toBe(0); // Should default to min value
 
             component.value = undefined as any;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
 
-            expect(knobInstance._value).toBe(0);
+            expect(knobInstance._value()).toBe(0);
         });
 
         it('should clamp values to min/max bounds', () => {
@@ -678,7 +678,7 @@ describe('Knob', () => {
             expect(knobInstance.value()).toBe(48); // Direct value assignment
 
             // Test that step property is correctly set
-            expect(knobInstance.step).toBe(5);
+            expect(knobInstance.step()).toBe(5);
         });
 
         it('should prevent interaction when disabled', () => {

--- a/packages/optimus-ui/src/knob/knob.ts
+++ b/packages/optimus-ui/src/knob/knob.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, InjectionToken, Input, NgModule, numberAttribute, signal, ViewEncapsulation, output } from '@angular/core';
+import { afterEveryRender, booleanAttribute, ChangeDetectionStrategy, Component, computed, forwardRef, inject, input, NgModule, numberAttribute, signal, ViewEncapsulation, output } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { $dt } from '@openng/optimus-ui-styled';
 import { SharedModule } from '@openng/optimus-ui/api';
@@ -9,8 +9,6 @@ import { BindModule } from '@openng/optimus-ui/bind';
 import { VoidListener } from '@openng/optimus-ui/ts-helpers';
 import { KnobPassThrough } from '@openng/optimus-ui/types/knob';
 import { KnobStyle } from './style/knobstyle';
-
-const KNOB_INSTANCE = new InjectionToken<Knob>('KNOB_INSTANCE');
 
 export const KNOB_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,
@@ -29,133 +27,137 @@ export const KNOB_VALUE_ACCESSOR: any = {
         <svg
             viewBox="0 0 100 100"
             role="slider"
-            [style.width]="size + 'px'"
-            [style.height]="size + 'px'"
+            [style.width]="size() + 'px'"
+            [style.height]="size() + 'px'"
             (click)="onClick($event)"
             (keydown)="onKeyDown($event)"
             (mousedown)="onMouseDown($event)"
             (mouseup)="onMouseUp($event)"
             (touchstart)="onTouchStart($event)"
             (touchend)="onTouchEnd($event)"
-            [attr.aria-valuemin]="min"
-            [attr.aria-valuemax]="max"
+            [attr.aria-valuemin]="min()"
+            [attr.aria-valuemax]="max()"
             [attr.required]="required() ? '' : undefined"
-            [attr.aria-valuenow]="_value"
-            [attr.aria-labelledby]="ariaLabelledBy"
-            [attr.aria-label]="ariaLabel"
-            [attr.tabindex]="readonly || $disabled() ? -1 : tabindex"
+            [attr.aria-valuenow]="_value()"
+            [attr.aria-labelledby]="ariaLabelledBy()"
+            [attr.aria-label]="ariaLabel()"
+            [attr.tabindex]="readonly() || $disabled() ? -1 : tabindex()"
             [pBind]="ptm('svg')"
         >
-            <path [attr.d]="rangePath()" [attr.stroke-width]="strokeWidth" [attr.stroke]="rangeColor" [class]="cx('range')" [pBind]="ptm('range')"></path>
-            <path [attr.d]="valuePath()" [attr.stroke-width]="strokeWidth" [attr.stroke]="valueColor" [class]="cx('value')" [pBind]="ptm('value')"></path>
-            @if (showValue) {
-                <text [attr.x]="50" [attr.y]="57" text-anchor="middle" [attr.fill]="textColor" [class]="cx('text')" [attr.name]="name()" [pBind]="ptm('text')">
+            <path [attr.d]="rangePath()" [attr.stroke-width]="strokeWidth()" [attr.stroke]="rangeColor()" [class]="cx('range')" [pBind]="ptm('range')"></path>
+            <path [attr.d]="valuePath()" [attr.stroke-width]="strokeWidth()" [attr.stroke]="valueColor()" [class]="cx('value')" [pBind]="ptm('value')"></path>
+            @if (showValue()) {
+                <text [attr.x]="50" [attr.y]="57" text-anchor="middle" [attr.fill]="textColor()" [class]="cx('text')" [attr.name]="name()" [pBind]="ptm('text')">
                     {{ valueToDisplay() }}
                 </text>
             }
         </svg>
     `,
-    providers: [KNOB_VALUE_ACCESSOR, KnobStyle, { provide: KNOB_INSTANCE, useExisting: Knob }, { provide: PARENT_INSTANCE, useExisting: Knob }],
+    providers: [KNOB_VALUE_ACCESSOR, KnobStyle, { provide: PARENT_INSTANCE, useExisting: Knob }],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[class]': "cn(cx('root'), styleClass)"
+        '[class]': "cx('root')"
     },
     hostDirectives: [Bind]
 })
 export class Knob extends BaseEditableHolder<KnobPassThrough> {
-    componentName = 'Knob';
-
-    $pcKnob: Knob | undefined = inject(KNOB_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
-
     bindDirectiveInstance = inject(Bind, { self: true });
 
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
-    }
+    _componentStyle = inject(KnobStyle);
 
-    /**
-     * Style class of the component.
-     * @deprecated since v20.0.0, use `class` instead.
-     * @group Props
-     */
-    @Input() styleClass: string | undefined;
     /**
      * Defines a string that labels the input for accessibility.
      * @group Props
      */
-    @Input() ariaLabel: string | undefined;
+    readonly ariaLabel = input<string>();
+
     /**
      * Specifies one or more IDs in the DOM that labels the input field.
      * @group Props
      */
-    @Input() ariaLabelledBy: string | undefined;
+    readonly ariaLabelledBy = input<string>();
+
     /**
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number = 0;
+    readonly tabindex = input<number, unknown>(0, { transform: numberAttribute });
+
     /**
      * Background of the value.
      * @group Props
      */
-    @Input() valueColor: string = $dt('knob.value.background').variable;
+    readonly valueColor = input<string>($dt('knob.value.background').variable);
+
     /**
      * Background color of the range.
      * @group Props
      */
-    @Input() rangeColor: string = $dt('knob.range.background').variable;
+    readonly rangeColor = input<string>($dt('knob.range.background').variable);
+
     /**
      * Color of the value text.
      * @group Props
      */
-    @Input() textColor: string = $dt('knob.text.color').variable;
+    readonly textColor = input<string>($dt('knob.text.color').variable);
+
     /**
      * Template string of the value.
      * @group Props
      */
-    @Input() valueTemplate: string = '{value}';
+    readonly valueTemplate = input<string>('{value}');
+
     /**
      * Size of the component in pixels.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) size: number = 100;
+    readonly size = input<number, unknown>(100, { transform: numberAttribute });
+
     /**
      * Mininum boundary value.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) min: number = 0;
+    readonly min = input<number, unknown>(0, { transform: numberAttribute });
+
     /**
      * Maximum boundary value.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) max: number = 100;
+    readonly max = input<number, unknown>(100, { transform: numberAttribute });
+
     /**
      * Step factor to increment/decrement the value.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) step: number = 1;
+    readonly step = input<number, unknown>(1, { transform: numberAttribute });
+
     /**
      * Width of the knob stroke.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) strokeWidth: number = 14;
+    readonly strokeWidth = input<number, unknown>(14, { transform: numberAttribute });
+
     /**
      * Whether the show the value inside the knob.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) showValue: boolean = true;
+    readonly showValue = input<boolean, unknown>(true, { transform: booleanAttribute });
+
     /**
      * When present, it specifies that the component value cannot be edited.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) readonly: boolean = false;
+    readonly readonly = input<boolean, unknown>(false, { transform: booleanAttribute });
+
     /**
      * Callback to invoke on value change.
      * @param {number} value - New value.
      * @group Emits
      */
     readonly onChange = output<number>();
+
+    componentName = 'Knob';
 
     radius: number = 40;
 
@@ -177,21 +179,41 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
 
     windowTouchEndListener: VoidListener;
 
-    _componentStyle = inject(KnobStyle);
+    /** SVG path of the full range arc. */
+    readonly rangePath = computed(() => `M ${this.minX()} ${this.minY()} A ${this.radius} ${this.radius} 0 1 1 ${this.maxX()} ${this.maxY()}`);
+
+    /** SVG path of the filled value arc, derived from the current value and boundaries. */
+    readonly valuePath = computed(() => `M ${this.zeroX()} ${this.zeroY()} A ${this.radius} ${this.radius} 0 ${this.largeArc()} ${this.sweep()} ${this.valueX()} ${this.valueY()}`);
+
+    /** Text rendered inside the knob: \`valueTemplate\` with {value} substituted. */
+    readonly valueToDisplay = computed(() => this.valueTemplate().replace('{value}', this._value().toString()));
+
+    /** Effective value: the model value, or \`min\` while the model is empty. */
+    readonly _value = computed<number>(() => (this.value() != null ? this.value() : this.min()));
+
+    constructor() {
+        super();
+        // Re-apply the host/root pass-through sections after each render (replaces the former
+        // ngAfterViewChecked hook). Bind.setAttrs writes into a signal behind an equality check,
+        // so unchanged PT resolutions are no-ops.
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
+        });
+    }
 
     mapRange(x: number, inMin: number, inMax: number, outMin: number, outMax: number) {
         return ((x - inMin) * (outMax - outMin)) / (inMax - inMin) + outMin;
     }
 
     onClick(event: MouseEvent) {
-        if (!this.$disabled() && !this.readonly) {
+        if (!this.$disabled() && !this.readonly()) {
             this.updateValue(event.offsetX, event.offsetY);
         }
     }
 
     updateValue(offsetX: number, offsetY: number) {
-        let dx = offsetX - this.size / 2;
-        let dy = this.size / 2 - offsetY;
+        let dx = offsetX - this.size() / 2;
+        let dy = this.size() / 2 - offsetY;
         let angle = Math.atan2(dy, dx);
         let start = -Math.PI / 2 - Math.PI / 6;
         this.updateModel(angle, start);
@@ -199,11 +221,11 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
 
     updateModel(angle: number, start: number) {
         let mappedValue;
-        if (angle > this.maxRadians) mappedValue = this.mapRange(angle, this.minRadians, this.maxRadians, this.min, this.max);
-        else if (angle < start) mappedValue = this.mapRange(angle + 2 * Math.PI, this.minRadians, this.maxRadians, this.min, this.max);
+        if (angle > this.maxRadians) mappedValue = this.mapRange(angle, this.minRadians, this.maxRadians, this.min(), this.max());
+        else if (angle < start) mappedValue = this.mapRange(angle + 2 * Math.PI, this.minRadians, this.maxRadians, this.min(), this.max());
         else return;
 
-        let newValue = Math.round((mappedValue - this.min) / this.step) * this.step + this.min;
+        let newValue = Math.round((mappedValue - this.min()) / this.step()) * this.step() + this.min();
 
         this.value.set(newValue);
         this.writeModelValue(this.value());
@@ -212,7 +234,7 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
     }
 
     onMouseDown(event: MouseEvent) {
-        if (!this.$disabled() && !this.readonly) {
+        if (!this.$disabled() && !this.readonly()) {
             const window = this.document.defaultView || 'window';
             this.windowMouseMoveListener = this.renderer.listen(window, 'mousemove', this.onMouseMove.bind(this));
             this.windowMouseUpListener = this.renderer.listen(window, 'mouseup', this.onMouseUp.bind(this));
@@ -221,7 +243,7 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
     }
 
     onMouseUp(event: MouseEvent) {
-        if (!this.$disabled() && !this.readonly) {
+        if (!this.$disabled() && !this.readonly()) {
             if (this.windowMouseMoveListener) {
                 this.windowMouseMoveListener();
                 this.windowMouseUpListener = null;
@@ -236,7 +258,7 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
     }
 
     onTouchStart(event: TouchEvent) {
-        if (!this.$disabled() && !this.readonly) {
+        if (!this.$disabled() && !this.readonly()) {
             const window = this.document.defaultView || 'window';
             this.windowTouchMoveListener = this.renderer.listen(window, 'touchmove', this.onTouchMove.bind(this));
             this.windowTouchEndListener = this.renderer.listen(window, 'touchend', this.onTouchEnd.bind(this));
@@ -245,7 +267,7 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
     }
 
     onTouchEnd(event: TouchEvent) {
-        if (!this.$disabled() && !this.readonly) {
+        if (!this.$disabled() && !this.readonly()) {
             if (this.windowTouchMoveListener) {
                 this.windowTouchMoveListener();
             }
@@ -259,14 +281,14 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
     }
 
     onMouseMove(event: MouseEvent) {
-        if (!this.$disabled() && !this.readonly) {
+        if (!this.$disabled() && !this.readonly()) {
             this.updateValue(event.offsetX, event.offsetY);
             event.preventDefault();
         }
     }
 
     onTouchMove(event: Event) {
-        if (!this.$disabled() && !this.readonly && event instanceof TouchEvent && event.touches.length === 1) {
+        if (!this.$disabled() && !this.readonly() && event instanceof TouchEvent && event.touches.length === 1) {
             const rect = this.el.nativeElement.children[0].getBoundingClientRect();
             const touch = event.targetTouches.item(0);
             if (touch) {
@@ -278,8 +300,8 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
     }
 
     updateModelValue(newValue) {
-        if (newValue > this.max) this.value.set(this.max);
-        else if (newValue < this.min) this.value.set(this.min);
+        if (newValue > this.max()) this.value.set(this.max());
+        else if (newValue < this.min()) this.value.set(this.min());
         else this.value.set(newValue);
 
         this.writeModelValue(this.value());
@@ -288,13 +310,13 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (!this.$disabled() && !this.readonly) {
+        if (!this.$disabled() && !this.readonly()) {
             switch (event.code) {
                 case 'ArrowRight':
 
                 case 'ArrowUp': {
                     event.preventDefault();
-                    this.updateModelValue(this._value + 1);
+                    this.updateModelValue(this._value() + 1);
                     break;
                 }
 
@@ -302,53 +324,45 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
 
                 case 'ArrowDown': {
                     event.preventDefault();
-                    this.updateModelValue(this._value - 1);
+                    this.updateModelValue(this._value() - 1);
                     break;
                 }
 
                 case 'Home': {
                     event.preventDefault();
-                    this.updateModelValue(this.min);
+                    this.updateModelValue(this.min());
 
                     break;
                 }
 
                 case 'End': {
                     event.preventDefault();
-                    this.updateModelValue(this.max);
+                    this.updateModelValue(this.max());
                     break;
                 }
 
                 case 'PageUp': {
                     event.preventDefault();
-                    this.updateModelValue(this._value + 10);
+                    this.updateModelValue(this._value() + 10);
                     break;
                 }
 
                 case 'PageDown': {
                     event.preventDefault();
-                    this.updateModelValue(this._value - 10);
+                    this.updateModelValue(this._value() - 10);
                     break;
                 }
             }
         }
     }
 
-    rangePath() {
-        return `M ${this.minX()} ${this.minY()} A ${this.radius} ${this.radius} 0 1 1 ${this.maxX()} ${this.maxY()}`;
-    }
-
-    valuePath() {
-        return `M ${this.zeroX()} ${this.zeroY()} A ${this.radius} ${this.radius} 0 ${this.largeArc()} ${this.sweep()} ${this.valueX()} ${this.valueY()}`;
-    }
-
     zeroRadians() {
-        if (this.min > 0 && this.max > 0) return this.mapRange(this.min, this.min, this.max, this.minRadians, this.maxRadians);
-        else return this.mapRange(0, this.min, this.max, this.minRadians, this.maxRadians);
+        if (this.min() > 0 && this.max() > 0) return this.mapRange(this.min(), this.min(), this.max(), this.minRadians, this.maxRadians);
+        else return this.mapRange(0, this.min(), this.max(), this.minRadians, this.maxRadians);
     }
 
     valueRadians() {
-        return this.mapRange(this._value, this.min, this.max, this.minRadians, this.maxRadians);
+        return this.mapRange(this._value(), this.min(), this.max(), this.minRadians, this.maxRadians);
     }
 
     minX() {
@@ -389,14 +403,6 @@ export class Knob extends BaseEditableHolder<KnobPassThrough> {
 
     sweep() {
         return this.valueRadians() > this.zeroRadians() ? 0 : 1;
-    }
-
-    valueToDisplay() {
-        return this.valueTemplate.replace('{value}', this._value.toString());
-    }
-
-    get _value(): number {
-        return this.value() != null ? this.value() : this.min;
     }
 
     /**


### PR DESCRIPTION
Converts the component to the signal-based APIs: @Input()/@Output() to
input()/output()/model(), getter/setter inputs to input() + linkedSignal
mirrors keeping the legacy private state names, ngOnChanges branches to
effects in declaration order, and view/content queries to viewChild/
contentChild/contentChildren. Class members are reordered to the project
convention (inject, input, output, viewChild, viewChildren, contentChild,
contentChildren, other properties, constructor, lifecycle hooks,
functions) and the tests are converted to setInput/signal reads.
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5