### PR TITLE
refactor(skeleton): migrate to signals

### DIFF
--- a/apps/docs/doc/skeleton/pt/PTViewer.ts
+++ b/apps/docs/doc/skeleton/pt/PTViewer.ts
@@ -10,10 +10,10 @@ import { SkeletonModule } from '@openng/optimus-ui/skeleton';
     template: `
         <app-docptviewer [docs]="docs">
             <div class="w-full">
-                <p-skeleton styleClass="mb-2"></p-skeleton>
-                <p-skeleton width="10rem" styleClass="mb-2"></p-skeleton>
-                <p-skeleton width="5rem" styleClass="mb-2"></p-skeleton>
-                <p-skeleton height="2rem" styleClass="mb-2"></p-skeleton>
+                <p-skeleton class="mb-2"></p-skeleton>
+                <p-skeleton width="10rem" class="mb-2"></p-skeleton>
+                <p-skeleton width="5rem" class="mb-2"></p-skeleton>
+                <p-skeleton height="2rem" class="mb-2"></p-skeleton>
                 <p-skeleton width="10rem" height="4rem"></p-skeleton>
             </div>
         </app-docptviewer>

--- a/packages/optimus-ui/src/skeleton/skeleton.test.ts
+++ b/packages/optimus-ui/src/skeleton/skeleton.test.ts
@@ -60,7 +60,7 @@ class TestSkeletonAnimationsComponent {
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
     selector: 'test-skeleton-styling',
-    template: ` <p-skeleton [styleClass]="styleClass" [shape]="shape" [borderRadius]="borderRadius"> </p-skeleton> `
+    template: ` <p-skeleton [class]="styleClass" [shape]="shape" [borderRadius]="borderRadius"> </p-skeleton> `
 })
 class TestSkeletonStylingComponent {
     styleClass = 'custom-skeleton';
@@ -76,9 +76,9 @@ class TestSkeletonStylingComponent {
         <div class="card-skeleton">
             <p-skeleton shape="circle" size="4rem"></p-skeleton>
             <div class="content">
-                <p-skeleton width="10rem" styleClass="mb-2"></p-skeleton>
-                <p-skeleton width="8rem" styleClass="mb-2"></p-skeleton>
-                <p-skeleton height="0.5rem" styleClass="mb-2"></p-skeleton>
+                <p-skeleton width="10rem" class="mb-2"></p-skeleton>
+                <p-skeleton width="8rem" class="mb-2"></p-skeleton>
+                <p-skeleton height="0.5rem" class="mb-2"></p-skeleton>
             </div>
         </div>
     `
@@ -92,14 +92,14 @@ class TestSkeletonCardLayoutComponent {}
     template: `
         <div class="table-skeleton">
             <div class="table-header">
-                <p-skeleton width="100%" height="2rem" styleClass="mb-2"></p-skeleton>
+                <p-skeleton width="100%" height="2rem" class="mb-2"></p-skeleton>
             </div>
             <div class="table-rows">
                 @for (row of rows; track trackByFn($index, row)) {
                     <div class="table-row">
-                        <p-skeleton width="25%" height="1.5rem" styleClass="mr-2"></p-skeleton>
-                        <p-skeleton width="25%" height="1.5rem" styleClass="mr-2"></p-skeleton>
-                        <p-skeleton width="25%" height="1.5rem" styleClass="mr-2"></p-skeleton>
+                        <p-skeleton width="25%" height="1.5rem" class="mr-2"></p-skeleton>
+                        <p-skeleton width="25%" height="1.5rem" class="mr-2"></p-skeleton>
+                        <p-skeleton width="25%" height="1.5rem" class="mr-2"></p-skeleton>
                         <p-skeleton width="25%" height="1.5rem"></p-skeleton>
                     </div>
                 }
@@ -127,7 +127,7 @@ class TestSkeletonEmptyComponent {}
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
     selector: 'test-skeleton-dynamic',
-    template: ` <p-skeleton [shape]="dynamicShape" [animation]="dynamicAnimation" [width]="dynamicWidth" [height]="dynamicHeight" [size]="dynamicSize" [borderRadius]="dynamicBorderRadius" [styleClass]="dynamicStyleClass"> </p-skeleton> `
+    template: ` <p-skeleton [shape]="dynamicShape" [animation]="dynamicAnimation" [width]="dynamicWidth" [height]="dynamicHeight" [size]="dynamicSize" [borderRadius]="dynamicBorderRadius" [class]="dynamicStyleClass"> </p-skeleton> `
 })
 class TestSkeletonDynamicComponent {
     dynamicShape = 'rectangle';
@@ -181,19 +181,19 @@ describe('Skeleton', () => {
             const newFixture = TestBed.createComponent(TestBasicSkeletonComponent);
             const newSkeleton = newFixture.debugElement.query(By.directive(Skeleton)).componentInstance;
 
-            expect(newSkeleton.shape).toBe('rectangle');
-            expect(newSkeleton.animation).toBe('wave');
-            expect(newSkeleton.width).toBe('100%');
-            expect(newSkeleton.height).toBe('1rem');
-            expect(newSkeleton.borderRadius).toBeUndefined();
-            expect(newSkeleton.size).toBeUndefined();
+            expect(newSkeleton.shape()).toBe('rectangle');
+            expect(newSkeleton.animation()).toBe('wave');
+            expect(newSkeleton.width()).toBe('100%');
+            expect(newSkeleton.height()).toBe('1rem');
+            expect(newSkeleton.borderRadius()).toBeUndefined();
+            expect(newSkeleton.size()).toBeUndefined();
         });
 
         it('should accept custom values', () => {
-            expect(skeleton.shape).toBe(component.shape);
-            expect(skeleton.animation).toBe(component.animation);
-            expect(skeleton.width).toBe(component.width);
-            expect(skeleton.height).toBe(component.height);
+            expect(skeleton.shape()).toBe(component.shape);
+            expect(skeleton.animation()).toBe(component.animation);
+            expect(skeleton.width()).toBe(component.width);
+            expect(skeleton.height()).toBe(component.height);
         });
 
         it('should extend BaseComponent', () => {
@@ -228,7 +228,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.shape).toBe('rectangle');
+            expect(skeleton.shape()).toBe('rectangle');
         });
 
         it('should handle circle shape', async () => {
@@ -237,7 +237,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.shape).toBe('circle');
+            expect(skeleton.shape()).toBe('circle');
         });
 
         it('should handle square shape', async () => {
@@ -246,7 +246,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.shape).toBe('square');
+            expect(skeleton.shape()).toBe('square');
         });
 
         it('should handle custom shapes', async () => {
@@ -255,7 +255,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.shape).toBe('custom-shape');
+            expect(skeleton.shape()).toBe('custom-shape');
         });
 
         it('should apply border radius correctly', async () => {
@@ -264,8 +264,8 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.borderRadius).toBe('10px');
-            expect(skeleton.containerStyle.borderRadius).toBe('10px');
+            expect(skeleton.borderRadius()).toBe('10px');
+            expect(skeleton.containerStyle()!.borderRadius).toBe('10px');
         });
 
         it('should handle size property for square elements', async () => {
@@ -275,9 +275,9 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.size).toBe('50px');
-            expect(skeleton.containerStyle.width).toBe('50px');
-            expect(skeleton.containerStyle.height).toBe('50px');
+            expect(skeleton.size()).toBe('50px');
+            expect(skeleton.containerStyle()!.width).toBe('50px');
+            expect(skeleton.containerStyle()!.height).toBe('50px');
         });
     });
 
@@ -295,11 +295,11 @@ describe('Skeleton', () => {
         });
 
         it('should apply custom width and height', () => {
-            expect(skeleton.width).toBe(component.width);
-            expect(skeleton.height).toBe(component.height);
+            expect(skeleton.width()).toBe(component.width);
+            expect(skeleton.height()).toBe(component.height);
 
-            expect(skeleton.containerStyle.width).toBe('200px');
-            expect(skeleton.containerStyle.height).toBe('50px');
+            expect(skeleton.containerStyle()!.width).toBe('200px');
+            expect(skeleton.containerStyle()!.height).toBe('50px');
         });
 
         it('should prioritize size over width/height when size is provided', async () => {
@@ -308,8 +308,8 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.containerStyle.width).toBe('100px');
-            expect(skeleton.containerStyle.height).toBe('100px');
+            expect(skeleton.containerStyle()!.width).toBe('100px');
+            expect(skeleton.containerStyle()!.height).toBe('100px');
         });
 
         it('should use width/height when size is not provided', async () => {
@@ -320,8 +320,8 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.containerStyle.width).toBe('300px');
-            expect(skeleton.containerStyle.height).toBe('40px');
+            expect(skeleton.containerStyle()!.width).toBe('300px');
+            expect(skeleton.containerStyle()!.height).toBe('40px');
         });
 
         it('should handle percentage values', async () => {
@@ -331,8 +331,8 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.containerStyle.width).toBe('75%');
-            expect(skeleton.containerStyle.height).toBe('2em');
+            expect(skeleton.containerStyle()!.width).toBe('75%');
+            expect(skeleton.containerStyle()!.height).toBe('2em');
         });
 
         it('should handle viewport units', async () => {
@@ -342,8 +342,8 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.containerStyle.width).toBe('50vw');
-            expect(skeleton.containerStyle.height).toBe('10vh');
+            expect(skeleton.containerStyle()!.width).toBe('50vw');
+            expect(skeleton.containerStyle()!.height).toBe('10vh');
         });
 
         it('should handle rem and em units', async () => {
@@ -353,8 +353,8 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.containerStyle.width).toBe('20rem');
-            expect(skeleton.containerStyle.height).toBe('3em');
+            expect(skeleton.containerStyle()!.width).toBe('20rem');
+            expect(skeleton.containerStyle()!.height).toBe('3em');
         });
     });
 
@@ -377,7 +377,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.animation).toBe('wave');
+            expect(skeleton.animation()).toBe('wave');
         });
 
         it('should handle pulse animation', async () => {
@@ -386,7 +386,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.animation).toBe('pulse');
+            expect(skeleton.animation()).toBe('pulse');
         });
 
         it('should handle none animation', async () => {
@@ -395,7 +395,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.animation).toBe('none');
+            expect(skeleton.animation()).toBe('none');
         });
 
         it('should handle custom animation types', async () => {
@@ -404,7 +404,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.animation).toBe('custom-animation');
+            expect(skeleton.animation()).toBe('custom-animation');
         });
     });
 
@@ -434,7 +434,7 @@ describe('Skeleton', () => {
         });
 
         it('should merge inline styles with component styles', () => {
-            const containerStyle = skeleton.containerStyle;
+            const containerStyle = skeleton.containerStyle()!;
             expect(containerStyle).toBeTruthy();
             expect(containerStyle.borderRadius).toBe('8px');
         });
@@ -450,20 +450,20 @@ describe('Skeleton', () => {
     });
 
     describe('Container Style Calculation', () => {
-        let fixture: ComponentFixture<TestSkeletonDimensionsComponent>;
+        let fixture: ComponentFixture<Skeleton>;
         let skeleton: Skeleton;
 
         beforeEach(() => {
-            fixture = TestBed.createComponent(TestSkeletonDimensionsComponent);
+            fixture = TestBed.createComponent(Skeleton);
+            skeleton = fixture.componentInstance;
             fixture.detectChanges();
-            skeleton = fixture.debugElement.query(By.directive(Skeleton)).componentInstance;
         });
 
         it('should calculate container style with size property', () => {
-            skeleton.size = '80px';
-            skeleton.borderRadius = '5px';
+            fixture.componentRef.setInput('size', '80px');
+            fixture.componentRef.setInput('borderRadius', '5px');
 
-            const style = skeleton.containerStyle;
+            const style = skeleton.containerStyle()!;
 
             expect(style.width).toBe('80px');
             expect(style.height).toBe('80px');
@@ -471,12 +471,11 @@ describe('Skeleton', () => {
         });
 
         it('should calculate container style with width and height', () => {
-            skeleton.size = undefined as any;
-            skeleton.width = '150px';
-            skeleton.height = '30px';
-            skeleton.borderRadius = '3px';
+            fixture.componentRef.setInput('width', '150px');
+            fixture.componentRef.setInput('height', '30px');
+            fixture.componentRef.setInput('borderRadius', '3px');
 
-            const style = skeleton.containerStyle;
+            const style = skeleton.containerStyle()!;
 
             expect(style.width).toBe('150px');
             expect(style.height).toBe('30px');
@@ -484,7 +483,7 @@ describe('Skeleton', () => {
         });
 
         it('should merge with component inline styles', () => {
-            const style = skeleton.containerStyle;
+            const style = skeleton.containerStyle()!;
 
             // Should have component inline styles merged
             expect(style).toBeTruthy();
@@ -492,9 +491,7 @@ describe('Skeleton', () => {
         });
 
         it('should handle missing borderRadius', () => {
-            skeleton.borderRadius = undefined as any;
-
-            const style = skeleton.containerStyle;
+            const style = skeleton.containerStyle()!;
 
             expect(style.borderRadius).toBeUndefined();
         });
@@ -537,13 +534,13 @@ describe('Skeleton', () => {
             expect(skeletons.length).toBe(4); // 1 circle + 3 rectangles
 
             // Circle avatar skeleton
-            expect(skeletons[0].componentInstance.shape).toBe('circle');
-            expect(skeletons[0].componentInstance.size).toBe('4rem');
+            expect(skeletons[0].componentInstance.shape()).toBe('circle');
+            expect(skeletons[0].componentInstance.size()).toBe('4rem');
 
             // Content skeletons
-            expect(skeletons[1].componentInstance.width).toBe('10rem');
-            expect(skeletons[2].componentInstance.width).toBe('8rem');
-            expect(skeletons[3].componentInstance.height).toBe('0.5rem');
+            expect(skeletons[1].componentInstance.width()).toBe('10rem');
+            expect(skeletons[2].componentInstance.width()).toBe('8rem');
+            expect(skeletons[3].componentInstance.height()).toBe('0.5rem');
         });
 
         it('should work in data table layout', () => {
@@ -554,12 +551,12 @@ describe('Skeleton', () => {
             expect(skeletons.length).toBe(21); // 1 header + 20 cells (5 rows * 4 columns)
 
             // Header skeleton
-            expect(skeletons[0].componentInstance.width).toBe('100%');
-            expect(skeletons[0].componentInstance.height).toBe('2rem');
+            expect(skeletons[0].componentInstance.width()).toBe('100%');
+            expect(skeletons[0].componentInstance.height()).toBe('2rem');
 
             // Row cell skeletons
-            expect(skeletons[1].componentInstance.width).toBe('25%');
-            expect(skeletons[1].componentInstance.height).toBe('1.5rem');
+            expect(skeletons[1].componentInstance.width()).toBe('25%');
+            expect(skeletons[1].componentInstance.height()).toBe('1.5rem');
         });
     });
 
@@ -581,7 +578,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.shape).toBe('circle');
+            expect(skeleton.shape()).toBe('circle');
         });
 
         it('should update animation dynamically', async () => {
@@ -590,7 +587,7 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.animation).toBe('pulse');
+            expect(skeleton.animation()).toBe('pulse');
         });
 
         it('should update dimensions dynamically', async () => {
@@ -600,10 +597,10 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.width).toBe('250px');
-            expect(skeleton.height).toBe('60px');
-            expect(skeleton.containerStyle.width).toBe('250px');
-            expect(skeleton.containerStyle.height).toBe('60px');
+            expect(skeleton.width()).toBe('250px');
+            expect(skeleton.height()).toBe('60px');
+            expect(skeleton.containerStyle()!.width).toBe('250px');
+            expect(skeleton.containerStyle()!.height).toBe('60px');
         });
 
         it('should update size dynamically', async () => {
@@ -612,9 +609,9 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.size).toBe('120px');
-            expect(skeleton.containerStyle.width).toBe('120px');
-            expect(skeleton.containerStyle.height).toBe('120px');
+            expect(skeleton.size()).toBe('120px');
+            expect(skeleton.containerStyle()!.width).toBe('120px');
+            expect(skeleton.containerStyle()!.height).toBe('120px');
         });
 
         it('should update border radius dynamically', async () => {
@@ -623,8 +620,8 @@ describe('Skeleton', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(skeleton.borderRadius).toBe('15px');
-            expect(skeleton.containerStyle.borderRadius).toBe('15px');
+            expect(skeleton.borderRadius()).toBe('15px');
+            expect(skeleton.containerStyle()!.borderRadius).toBe('15px');
         });
 
         it('should update styleClass dynamically', async () => {
@@ -639,96 +636,90 @@ describe('Skeleton', () => {
     });
 
     describe('Edge Cases', () => {
-        let fixture: ComponentFixture<TestSkeletonEmptyComponent>;
+        let fixture: ComponentFixture<Skeleton>;
         let skeleton: Skeleton;
 
         beforeEach(() => {
-            fixture = TestBed.createComponent(TestSkeletonEmptyComponent);
+            fixture = TestBed.createComponent(Skeleton);
+            skeleton = fixture.componentInstance;
             fixture.detectChanges();
-            skeleton = fixture.debugElement.query(By.directive(Skeleton)).componentInstance;
         });
 
         it('should handle empty/default configuration', () => {
             expect(skeleton).toBeTruthy();
-            expect(skeleton.shape).toBe('rectangle');
-            expect(skeleton.animation).toBe('wave');
-            expect(skeleton.width).toBe('100%');
-            expect(skeleton.height).toBe('1rem');
+            expect(skeleton.shape()).toBe('rectangle');
+            expect(skeleton.animation()).toBe('wave');
+            expect(skeleton.width()).toBe('100%');
+            expect(skeleton.height()).toBe('1rem');
         });
 
         it('should handle zero dimensions', () => {
-            skeleton.width = '0px';
-            skeleton.height = '0px';
+            fixture.componentRef.setInput('width', '0px');
+            fixture.componentRef.setInput('height', '0px');
 
-            const style = skeleton.containerStyle;
+            const style = skeleton.containerStyle()!;
             expect(style.width).toBe('0px');
             expect(style.height).toBe('0px');
         });
 
         it('should handle very large dimensions', () => {
-            skeleton.width = '9999px';
-            skeleton.height = '9999px';
+            fixture.componentRef.setInput('width', '9999px');
+            fixture.componentRef.setInput('height', '9999px');
 
-            const style = skeleton.containerStyle;
+            const style = skeleton.containerStyle()!;
             expect(style.width).toBe('9999px');
             expect(style.height).toBe('9999px');
         });
 
         it('should handle empty strings', () => {
-            skeleton.width = '';
-            skeleton.height = '';
+            fixture.componentRef.setInput('width', '');
+            fixture.componentRef.setInput('height', '');
 
-            const style = skeleton.containerStyle;
+            const style = skeleton.containerStyle()!;
             expect(style.width).toBe('' as any);
             expect(style.height).toBe('' as any);
         });
 
         it('should handle null/undefined values gracefully', () => {
-            skeleton.borderRadius = undefined as any;
-            skeleton.size = undefined as any;
+            fixture.componentRef.setInput('borderRadius', undefined);
+            fixture.componentRef.setInput('size', undefined);
 
             expect(() => {
-                const style = skeleton.containerStyle;
+                const style = skeleton.containerStyle()!;
                 expect(style).toBeTruthy();
             }).not.toThrow();
         });
 
         it('should handle invalid CSS values', () => {
-            skeleton.width = 'invalid-value';
-            skeleton.height = 'another-invalid';
+            fixture.componentRef.setInput('width', 'invalid-value');
+            fixture.componentRef.setInput('height', 'another-invalid');
 
-            const style = skeleton.containerStyle;
+            const style = skeleton.containerStyle()!;
             expect(style.width).toBe('invalid-value');
             expect(style.height).toBe('another-invalid');
         });
 
         it('should handle rapid property updates', async () => {
-            skeleton.shape = 'rectangle';
-            skeleton.cd.markForCheck();
+            fixture.componentRef.setInput('shape', 'rectangle');
             fixture.detectChanges();
-            await new Promise((resolve) => setTimeout(resolve, 100));
             await fixture.whenStable();
 
-            skeleton.shape = 'circle';
-            skeleton.cd.markForCheck();
+            fixture.componentRef.setInput('shape', 'circle');
             fixture.detectChanges();
-            await new Promise((resolve) => setTimeout(resolve, 100));
             await fixture.whenStable();
 
-            skeleton.shape = 'square';
-            skeleton.cd.markForCheck();
+            fixture.componentRef.setInput('shape', 'square');
             fixture.detectChanges();
-            await new Promise((resolve) => setTimeout(resolve, 100));
             await fixture.whenStable();
 
-            expect(skeleton.shape).toBe('square');
+            expect(skeleton.shape()).toBe('square');
         });
 
         it('should handle complex CSS calc expressions', () => {
-            skeleton.width = 'calc(100% - 20px)';
-            skeleton.height = 'calc(50vh - 10px)';
+            fixture.componentRef.setInput('width', 'calc(100% - 20px)');
+            fixture.componentRef.setInput('height', 'calc(50vh - 10px)');
 
-            const style = skeleton.containerStyle;
+            const style = skeleton.containerStyle()!;
             expect(style.width).toBe('calc(100% - 20px)');
             expect(style.height).toBe('calc(50vh - 10px)');
         });
@@ -816,7 +807,7 @@ describe('Skeleton', () => {
                             <p-skeleton width="100%" height="10rem"></p-skeleton>
                         </div>
                         <div class="footer">
-                            <p-skeleton width="4rem" height="2rem" styleClass="mr-2"></p-skeleton>
+                            <p-skeleton width="4rem" height="2rem" class="mr-2"></p-skeleton>
                             <p-skeleton width="4rem" height="2rem"></p-skeleton>
                         </div>
                     </div>
@@ -837,11 +828,11 @@ describe('Skeleton', () => {
             expect(skeletons.length).toBe(6);
 
             // Verify different configurations
-            expect(skeletons[0].componentInstance.shape).toBe('circle');
-            expect(skeletons[0].componentInstance.size).toBe('3rem');
+            expect(skeletons[0].componentInstance.shape()).toBe('circle');
+            expect(skeletons[0].componentInstance.size()).toBe('3rem');
 
-            expect(skeletons[3].componentInstance.width).toBe('100%');
-            expect(skeletons[3].componentInstance.height).toBe('10rem');
+            expect(skeletons[3].componentInstance.width()).toBe('100%');
+            expect(skeletons[3].componentInstance.height()).toBe('10rem');
         });
 
         it('should work with conditional rendering', async () => {
@@ -1139,8 +1130,8 @@ describe('Skeleton', () => {
                 host: ({ instance }: any) => {
                     return {
                         class: {
-                            SHAPE_CIRCLE: instance?.shape === 'circle',
-                            SHAPE_RECTANGLE: instance?.shape === 'rectangle'
+                            SHAPE_CIRCLE: instance?.shape() === 'circle',
+                            SHAPE_RECTANGLE: instance?.shape() === 'rectangle'
                         }
                     };
                 }
@@ -1163,7 +1154,7 @@ describe('Skeleton', () => {
                 root: ({ instance }: any) => {
                     return {
                         style: {
-                            opacity: instance?.animation === 'pulse' ? '0.8' : '1'
+                            opacity: instance?.animation() === 'pulse' ? '0.8' : '1'
                         }
                     };
                 }

--- a/packages/optimus-ui/src/skeleton/skeleton.ts
+++ b/packages/optimus-ui/src/skeleton/skeleton.ts
@@ -1,11 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, ViewEncapsulation } from '@angular/core';
+import { afterEveryRender, ChangeDetectionStrategy, Component, computed, inject, input, NgModule, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
 import { SkeletonPassThrough } from '@openng/optimus-ui/types/skeleton';
 import { SkeletonStyle } from './style/skeletonstyle';
-
-const SKELETON_INSTANCE = new InjectionToken<Skeleton>('SKELETON_INSTANCE');
 
 /**
  * Skeleton is a placeholder to display instead of the actual content.
@@ -18,78 +16,83 @@ const SKELETON_INSTANCE = new InjectionToken<Skeleton>('SKELETON_INSTANCE');
     template: ``,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [SkeletonStyle, { provide: SKELETON_INSTANCE, useExisting: Skeleton }, { provide: PARENT_INSTANCE, useExisting: Skeleton }],
+    providers: [SkeletonStyle, { provide: PARENT_INSTANCE, useExisting: Skeleton }],
     host: {
         '[attr.aria-hidden]': 'true',
-        '[class]': "cn(cx('root'), styleClass)",
-        '[style]': 'containerStyle',
-        '[attr.data-p]': 'dataP'
+        '[class]': "cx('root')",
+        '[style]': 'containerStyle()',
+        '[attr.data-p]': 'dataP()'
     },
     hostDirectives: [Bind]
 })
 export class Skeleton extends BaseComponent<SkeletonPassThrough> {
-    componentName = 'Skeleton';
-    $pcSkeleton: Skeleton | undefined = inject(SKELETON_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
-
     bindDirectiveInstance = inject(Bind, { self: true });
 
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
-    }
+    _componentStyle = inject(SkeletonStyle);
 
-    /**
-     * Class of the element.
-     * @deprecated since v20.0.0, use `class` instead.
-     * @group Props
-     */
-    @Input() styleClass: string | undefined;
     /**
      * Shape of the element.
      * @group Props
      */
-    @Input() shape: string = 'rectangle';
+    readonly shape = input<string>('rectangle');
+
     /**
      * Type of the animation.
-     * @gruop Props
+     * @group Props
      */
-    @Input() animation: string = 'wave';
+    readonly animation = input<string>('wave');
+
     /**
      * Border radius of the element, defaults to value from theme.
      * @group Props
      */
-    @Input() borderRadius: string | undefined;
+    readonly borderRadius = input<string>();
+
     /**
      * Size of the skeleton.
      * @group Props
      */
-    @Input() size: string | undefined;
+    readonly size = input<string>();
+
     /**
      * Width of the element.
      * @group Props
      */
-    @Input() width: string = '100%';
+    readonly width = input<string>('100%');
+
     /**
      * Height of the element.
      * @group Props
      */
-    @Input() height: string = '1rem';
+    readonly height = input<string>('1rem');
 
-    _componentStyle = inject(SkeletonStyle);
+    componentName = 'Skeleton';
 
-    get containerStyle() {
+    readonly containerStyle = computed(() => {
         const inlineStyles = this._componentStyle?.inlineStyles['root'];
         let style;
         if (!this.$unstyled()) {
-            if (this.size) style = { ...inlineStyles, width: this.size, height: this.size, borderRadius: this.borderRadius };
-            else style = { ...inlineStyles, width: this.width, height: this.height, borderRadius: this.borderRadius };
+            const size = this.size();
+            if (size) style = { ...inlineStyles, width: size, height: size, borderRadius: this.borderRadius() };
+            else style = { ...inlineStyles, width: this.width(), height: this.height(), borderRadius: this.borderRadius() };
         }
 
         return style;
-    }
+    });
 
-    get dataP() {
-        return this.cn({
-            [this.shape]: this.shape
+    readonly dataP = computed(() =>
+        this.cn({
+            [this.shape()]: this.shape()
+        })
+    );
+
+    constructor() {
+        super();
+        // Re-apply the host/root pass-through sections after each render (replaces the former
+        // ngAfterViewChecked hook). Bind.setAttrs writes into a signal behind an equality check,
+        // so unchanged PT resolutions are no-ops.
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
         });
     }
 }

--- a/packages/optimus-ui/src/skeleton/style/skeletonstyle.ts
+++ b/packages/optimus-ui/src/skeleton/style/skeletonstyle.ts
@@ -10,8 +10,8 @@ const classes = {
     root: ({ instance }) => [
         'p-skeleton p-component',
         {
-            'p-skeleton-circle': instance.shape === 'circle',
-            'p-skeleton-animation-none': instance.animation === 'none'
+            'p-skeleton-circle': instance.shape() === 'circle',
+            'p-skeleton-animation-none': instance.animation() === 'none'
         }
     ]
 };


### PR DESCRIPTION
Converts the component to the signal-based APIs: @Input()/@Output() to
input()/output()/model(), getter/setter inputs to input() + linkedSignal
mirrors keeping the legacy private state names, ngOnChanges branches to
effects in declaration order, and view/content queries to viewChild/
contentChild/contentChildren. Class members are reordered to the project
convention (inject, input, output, viewChild, viewChildren, contentChild,
contentChildren, other properties, constructor, lifecycle hooks,
functions) and the tests are converted to setInput/signal reads.
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5