### PR TITLE
refactor(styleclass): migrate to signals

### DIFF
--- a/packages/optimus-ui/src/styleclass/styleclass.test.ts
+++ b/packages/optimus-ui/src/styleclass/styleclass.test.ts
@@ -138,17 +138,17 @@ describe('StyleClass', () => {
         });
 
         it('should initialize with undefined values', () => {
-            expect(styleClassInstance.selector).toBe('@next');
-            expect(styleClassInstance.enterFromClass).toBeUndefined();
-            expect(styleClassInstance.enterActiveClass).toBeUndefined();
-            expect(styleClassInstance.enterToClass).toBeUndefined();
-            expect(styleClassInstance.leaveFromClass).toBeUndefined();
-            expect(styleClassInstance.leaveActiveClass).toBeUndefined();
-            expect(styleClassInstance.leaveToClass).toBeUndefined();
-            expect(styleClassInstance.hideOnOutsideClick).toBeFalsy();
-            expect(styleClassInstance.hideOnEscape).toBeFalsy();
-            expect(styleClassInstance.hideOnResize).toBeFalsy();
-            expect(styleClassInstance.toggleClass).toBeUndefined();
+            expect(styleClassInstance.selector()).toBe('@next');
+            expect(styleClassInstance.enterFromClass()).toBeUndefined();
+            expect(styleClassInstance.enterActiveClass()).toBeUndefined();
+            expect(styleClassInstance.enterToClass()).toBeUndefined();
+            expect(styleClassInstance.leaveFromClass()).toBeUndefined();
+            expect(styleClassInstance.leaveActiveClass()).toBeUndefined();
+            expect(styleClassInstance.leaveToClass()).toBeUndefined();
+            expect(styleClassInstance.hideOnOutsideClick()).toBeFalsy();
+            expect(styleClassInstance.hideOnEscape()).toBeFalsy();
+            expect(styleClassInstance.hideOnResize()).toBeFalsy();
+            expect(styleClassInstance.toggleClass()).toBeUndefined();
         });
 
         it('should initialize listeners as undefined', () => {
@@ -162,99 +162,99 @@ describe('StyleClass', () => {
 
     describe('Input Properties', () => {
         it('should update selector input', () => {
-            expect(styleClassInstance.selector).toBe('@next');
+            expect(styleClassInstance.selector()).toBe('@next');
         });
 
         it('should update enterFromClass input', async () => {
             component.enterFromClass = 'hidden';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.enterFromClass).toBe('hidden');
+            expect(styleClassInstance.enterFromClass()).toBe('hidden');
         });
 
         it('should update enterActiveClass input', async () => {
             component.enterActiveClass = 'fade-in';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.enterActiveClass).toBe('fade-in');
+            expect(styleClassInstance.enterActiveClass()).toBe('fade-in');
         });
 
         it('should update enterToClass input', async () => {
             component.enterToClass = 'visible';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.enterToClass).toBe('visible');
+            expect(styleClassInstance.enterToClass()).toBe('visible');
         });
 
         it('should update leaveFromClass input', async () => {
             component.leaveFromClass = 'visible';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.leaveFromClass).toBe('visible');
+            expect(styleClassInstance.leaveFromClass()).toBe('visible');
         });
 
         it('should update leaveActiveClass input', async () => {
             component.leaveActiveClass = 'fade-out';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.leaveActiveClass).toBe('fade-out');
+            expect(styleClassInstance.leaveActiveClass()).toBe('fade-out');
         });
 
         it('should update leaveToClass input', async () => {
             component.leaveToClass = 'hidden';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.leaveToClass).toBe('hidden');
+            expect(styleClassInstance.leaveToClass()).toBe('hidden');
         });
 
         it('should update hideOnOutsideClick with booleanAttribute transform', async () => {
             component.hideOnOutsideClick = true;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.hideOnOutsideClick).toBe(true);
+            expect(styleClassInstance.hideOnOutsideClick()).toBe(true);
 
             component.hideOnOutsideClick = false;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.hideOnOutsideClick).toBe(false);
+            expect(styleClassInstance.hideOnOutsideClick()).toBe(false);
         });
 
         it('should update hideOnEscape with booleanAttribute transform', async () => {
             component.hideOnEscape = true;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.hideOnEscape).toBe(true);
+            expect(styleClassInstance.hideOnEscape()).toBe(true);
 
             component.hideOnEscape = false;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.hideOnEscape).toBe(false);
+            expect(styleClassInstance.hideOnEscape()).toBe(false);
         });
 
         it('should update hideOnResize with booleanAttribute transform', async () => {
             component.hideOnResize = true;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.hideOnResize).toBe(true);
+            expect(styleClassInstance.hideOnResize()).toBe(true);
 
             component.hideOnResize = false;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.hideOnResize).toBe(false);
+            expect(styleClassInstance.hideOnResize()).toBe(false);
         });
 
         it('should update toggleClass input', async () => {
             component.toggleClass = 'active';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.toggleClass).toBe('active');
+            expect(styleClassInstance.toggleClass()).toBe('active');
         });
 
         it('should update resizeSelector input', async () => {
             component.resizeSelector = '#resize-target';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
-            expect(styleClassInstance.resizeSelector).toBe('#resize-target');
+            expect(styleClassInstance.resizeSelector()).toBe('#resize-target');
         });
     });
 
@@ -612,7 +612,7 @@ describe('StyleClass', () => {
             await fixture.whenStable();
 
             // Change selector to CSS selector
-            styleClassInstance.selector = '.target-element';
+            vi.spyOn(styleClassInstance, 'selector').mockReturnValue('.target-element');
 
             buttonElement.nativeElement.click();
 
@@ -764,7 +764,7 @@ describe('StyleClass', () => {
             vi.spyOn(resizeInstance, 'bindElementResizeListener').mockImplementation(() => {});
             vi.spyOn(resizeInstance, 'bindWindowResizeListener').mockImplementation(() => {});
 
-            resizeInstance.resizeSelector = '#resize-target';
+            vi.spyOn(resizeInstance, 'resizeSelector').mockReturnValue('#resize-target');
             resizeInstance.bindResizeListener();
 
             expect(resizeInstance.bindElementResizeListener).toHaveBeenCalled();
@@ -877,7 +877,7 @@ describe('StyleClass', () => {
 
     describe('Edge Cases', () => {
         it('should handle null/undefined selector', () => {
-            styleClassInstance.selector = undefined as any;
+            vi.spyOn(styleClassInstance, 'selector').mockReturnValue(undefined as any);
 
             expect(() => buttonElement.nativeElement.click()).not.toThrow();
         });
@@ -961,8 +961,8 @@ describe('StyleClass', () => {
             animationButton.nativeElement.click();
 
             expect(animationInstance.target).toBeTruthy();
-            expect(animationInstance.hideOnOutsideClick).toBe(true);
-            expect(animationInstance.hideOnEscape).toBe(true);
+            expect(animationInstance.hideOnOutsideClick()).toBe(true);
+            expect(animationInstance.hideOnEscape()).toBe(true);
         });
 
         it('should work with slidedown component', async () => {
@@ -976,7 +976,7 @@ describe('StyleClass', () => {
             slidedownButton.nativeElement.click();
 
             expect(slidedownInstance.target).toBeTruthy();
-            expect(slidedownInstance.enterActiveClass).toBe('slidedown');
+            expect(slidedownInstance.enterActiveClass()).toBe('slidedown');
         });
 
         it('should maintain state across multiple interactions', async () => {

--- a/packages/optimus-ui/src/styleclass/styleclass.ts
+++ b/packages/optimus-ui/src/styleclass/styleclass.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, ElementRef, HostListener, Input, NgModule, NgZone, OnDestroy, Renderer2, inject } from '@angular/core';
+import { booleanAttribute, Directive, ElementRef, HostListener, input, NgModule, NgZone, OnDestroy, Renderer2, inject } from '@angular/core';
 import { addClass, getTargetElement, hasClass, isElement, removeClass } from '@openng/optimus-ui-utils';
 import { VoidListener } from '@openng/optimus-ui/ts-helpers';
 
@@ -12,69 +12,82 @@ import { VoidListener } from '@openng/optimus-ui/ts-helpers';
 })
 export class StyleClass implements OnDestroy {
     el = inject(ElementRef);
+
     renderer = inject(Renderer2);
+
     private zone = inject(NgZone);
 
     /**
      * Selector to define the target element. Available selectors are '@next', '@prev', '@parent' and '@grandparent'.
      * @group Props
      */
-    @Input('pStyleClass') selector: string | undefined;
+    readonly selector = input<string | undefined>(undefined, { alias: 'pStyleClass' });
+
     /**
      * Style class to add when item begins to get displayed.
      * @group Props
      */
-    @Input() enterFromClass: string | undefined;
+    readonly enterFromClass = input<string>();
+
     /**
      * Style class to add during enter animation.
      * @group Props
      */
-    @Input() enterActiveClass: string | undefined;
+    readonly enterActiveClass = input<string>();
+
     /**
      * Style class to add when item begins to get displayed.
      * @group Props
      */
-    @Input() enterToClass: string | undefined;
+    readonly enterToClass = input<string>();
+
     /**
      * Style class to add when item begins to get hidden.
      * @group Props
      */
-    @Input() leaveFromClass: string | undefined;
+    readonly leaveFromClass = input<string>();
+
     /**
      * Style class to add during leave animation.
      * @group Props
      */
-    @Input() leaveActiveClass: string | undefined;
+    readonly leaveActiveClass = input<string>();
+
     /**
      * Style class to add when leave animation is completed.
      * @group Props
      */
-    @Input() leaveToClass: string | undefined;
+    readonly leaveToClass = input<string>();
+
     /**
      * Whether to trigger leave animation when outside of the element is clicked.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) hideOnOutsideClick: boolean | undefined;
+    readonly hideOnOutsideClick = input<boolean | undefined, unknown>(undefined, { transform: booleanAttribute });
+
     /**
      * Adds or removes a class when no enter-leave animation is required.
      * @group Props
      */
-    @Input() toggleClass: string | undefined;
+    readonly toggleClass = input<string>();
+
     /**
      * Whether to trigger leave animation when escape key pressed.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) hideOnEscape: boolean | undefined;
+    readonly hideOnEscape = input<boolean | undefined, unknown>(undefined, { transform: booleanAttribute });
+
     /**
      * Whether to trigger leave animation when the target element resized.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) hideOnResize: boolean | undefined;
+    readonly hideOnResize = input<boolean | undefined, unknown>(undefined, { transform: booleanAttribute });
+
     /**
      * Target element to listen resize. Valid values are "window", "document" or target element selector.
      * @group Props
      */
-    @Input() resizeSelector: string | undefined;
+    readonly resizeSelector = input<string>();
 
     eventListener: VoidListener;
 
@@ -94,17 +107,25 @@ export class StyleClass implements OnDestroy {
 
     animating: boolean | undefined;
 
-    _enterClass: string | undefined;
-
-    _leaveClass: string | undefined;
-
     _resizeTarget: any;
+
+    ngOnDestroy() {
+        this.target = null;
+        this._resizeTarget = null;
+
+        if (this.eventListener) {
+            this.eventListener();
+        }
+        this.unbindDocumentClickListener();
+        this.unbindDocumentKeydownListener();
+        this.unbindResizeListener();
+    }
 
     @HostListener('click')
     clickListener() {
-        this.target ||= getTargetElement(this.selector, this.el.nativeElement) as HTMLElement;
+        this.target ||= getTargetElement(this.selector(), this.el.nativeElement) as HTMLElement;
 
-        if (this.toggleClass) {
+        if (this.toggleClass()) {
             this.toggle();
         } else {
             if ((this.target as HTMLElement)?.offsetParent === null) this.enter();
@@ -113,101 +134,101 @@ export class StyleClass implements OnDestroy {
     }
 
     toggle() {
-        if (hasClass(this.target!, this.toggleClass as string)) removeClass(this.target!, this.toggleClass as string);
-        else addClass(this.target!, this.toggleClass as string);
+        if (hasClass(this.target!, this.toggleClass() as string)) removeClass(this.target!, this.toggleClass() as string);
+        else addClass(this.target!, this.toggleClass() as string);
     }
 
     enter() {
-        if (this.enterActiveClass) {
+        if (this.enterActiveClass()) {
             if (!this.animating) {
                 this.animating = true;
 
-                if (this.enterActiveClass.includes('slidedown')) {
+                if (this.enterActiveClass()!.includes('slidedown')) {
                     (this.target as HTMLElement).style.height = '0px';
-                    removeClass(this.target!, this.enterFromClass || 'hidden');
+                    removeClass(this.target!, this.enterFromClass() || 'hidden');
                     (this.target as HTMLElement).style.maxHeight = (this.target as HTMLElement).scrollHeight + 'px';
-                    addClass(this.target!, this.enterFromClass || 'hidden');
+                    addClass(this.target!, this.enterFromClass() || 'hidden');
                     (this.target as HTMLElement).style.height = '';
                 }
 
-                addClass(this.target!, this.enterActiveClass);
-                if (this.enterFromClass) {
-                    removeClass(this.target!, this.enterFromClass);
+                addClass(this.target!, this.enterActiveClass()!);
+                if (this.enterFromClass()) {
+                    removeClass(this.target!, this.enterFromClass());
                 }
 
                 this.enterListener = this.renderer.listen(this.target!, 'animationend', () => {
-                    removeClass(this.target!, this.enterActiveClass as string);
-                    if (this.enterToClass) {
-                        addClass(this.target!, this.enterToClass);
+                    removeClass(this.target!, this.enterActiveClass() as string);
+                    if (this.enterToClass()) {
+                        addClass(this.target!, this.enterToClass());
                     }
                     this.enterListener && this.enterListener();
 
-                    if (this.enterActiveClass?.includes('slidedown')) {
+                    if (this.enterActiveClass()?.includes('slidedown')) {
                         (this.target as HTMLElement).style.maxHeight = '';
                     }
                     this.animating = false;
                 });
             }
         } else {
-            if (this.enterFromClass) {
-                removeClass(this.target!, this.enterFromClass);
+            if (this.enterFromClass()) {
+                removeClass(this.target!, this.enterFromClass());
             }
 
-            if (this.enterToClass) {
-                addClass(this.target!, this.enterToClass);
+            if (this.enterToClass()) {
+                addClass(this.target!, this.enterToClass());
             }
         }
 
-        if (this.hideOnOutsideClick) {
+        if (this.hideOnOutsideClick()) {
             this.bindDocumentClickListener();
         }
 
-        if (this.hideOnEscape) {
+        if (this.hideOnEscape()) {
             this.bindDocumentKeydownListener();
         }
 
-        if (this.hideOnResize) {
+        if (this.hideOnResize()) {
             this.bindResizeListener();
         }
     }
 
     leave() {
-        if (this.leaveActiveClass) {
+        if (this.leaveActiveClass()) {
             if (!this.animating) {
                 this.animating = true;
-                addClass(this.target!, this.leaveActiveClass);
-                if (this.leaveFromClass) {
-                    removeClass(this.target!, this.leaveFromClass);
+                addClass(this.target!, this.leaveActiveClass()!);
+                if (this.leaveFromClass()) {
+                    removeClass(this.target!, this.leaveFromClass());
                 }
 
                 this.leaveListener = this.renderer.listen(this.target!, 'animationend', () => {
-                    removeClass(this.target!, this.leaveActiveClass as string);
-                    if (this.leaveToClass) {
-                        addClass(this.target!, this.leaveToClass);
+                    removeClass(this.target!, this.leaveActiveClass() as string);
+                    if (this.leaveToClass()) {
+                        addClass(this.target!, this.leaveToClass());
                     }
                     this.leaveListener && this.leaveListener();
                     this.animating = false;
                 });
             }
         } else {
-            if (this.leaveFromClass) {
-                removeClass(this.target!, this.leaveFromClass);
+            if (this.leaveFromClass()) {
+                removeClass(this.target!, this.leaveFromClass());
             }
 
-            if (this.leaveToClass) {
-                addClass(this.target!, this.leaveToClass);
+            if (this.leaveToClass()) {
+                addClass(this.target!, this.leaveToClass());
             }
         }
 
-        if (this.hideOnOutsideClick) {
+        if (this.hideOnOutsideClick()) {
             this.unbindDocumentClickListener();
         }
 
-        if (this.hideOnEscape) {
+        if (this.hideOnEscape()) {
             this.unbindDocumentKeydownListener();
         }
 
-        if (this.hideOnResize) {
+        if (this.hideOnResize()) {
             this.unbindResizeListener();
         }
     }
@@ -256,7 +277,7 @@ export class StyleClass implements OnDestroy {
     }
 
     bindResizeListener() {
-        this._resizeTarget = getTargetElement(this.resizeSelector);
+        this._resizeTarget = getTargetElement(this.resizeSelector());
         if (isElement(this._resizeTarget)) {
             this.bindElementResizeListener();
         } else {
@@ -312,18 +333,6 @@ export class StyleClass implements OnDestroy {
             this.resizeObserver.disconnect();
             this.resizeObserver = undefined;
         }
-    }
-
-    ngOnDestroy() {
-        this.target = null;
-        this._resizeTarget = null;
-
-        if (this.eventListener) {
-            this.eventListener();
-        }
-        this.unbindDocumentClickListener();
-        this.unbindDocumentKeydownListener();
-        this.unbindResizeListener();
     }
 }
 


### PR DESCRIPTION
Converts the component to the signal-based APIs: @Input()/@Output() to
input()/output()/model(), getter/setter inputs to input() + linkedSignal
mirrors keeping the legacy private state names, ngOnChanges branches to
effects in declaration order, and view/content queries to viewChild/
contentChild/contentChildren. Class members are reordered to the project
convention (inject, input, output, viewChild, viewChildren, contentChild,
contentChildren, other properties, constructor, lifecycle hooks,
functions) and the tests are converted to setInput/signal reads.
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5