### PR TITLE
refactor(tag): migrate to signals

### DIFF
--- a/packages/optimus-ui/src/tag/style/tagstyle.ts
+++ b/packages/optimus-ui/src/tag/style/tagstyle.ts
@@ -6,13 +6,13 @@ const classes = {
     root: ({ instance }) => [
         'p-tag p-component',
         {
-            'p-tag-info': instance.severity === 'info',
-            'p-tag-success': instance.severity === 'success',
-            'p-tag-warn': instance.severity === 'warn',
-            'p-tag-danger': instance.severity === 'danger',
-            'p-tag-secondary': instance.severity === 'secondary',
-            'p-tag-contrast': instance.severity === 'contrast',
-            'p-tag-rounded': instance.rounded
+            'p-tag-info': instance.severity() === 'info',
+            'p-tag-success': instance.severity() === 'success',
+            'p-tag-warn': instance.severity() === 'warn',
+            'p-tag-danger': instance.severity() === 'danger',
+            'p-tag-secondary': instance.severity() === 'secondary',
+            'p-tag-contrast': instance.severity() === 'contrast',
+            'p-tag-rounded': instance.rounded()
         }
     ],
     icon: 'p-tag-icon',

--- a/packages/optimus-ui/src/tag/tag.test.ts
+++ b/packages/optimus-ui/src/tag/tag.test.ts
@@ -2,12 +2,13 @@ import { ChangeDetectionStrategy, Component, DebugElement, input, provideZoneles
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
+import { PrimeTemplate } from '@openng/optimus-ui/api';
 import { Tag } from './tag';
 
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
-    template: ` <p-tag [value]="value" [icon]="icon" [severity]="severity" [rounded]="rounded" [styleClass]="styleClass"> </p-tag> `
+    template: ` <p-tag [value]="value" [icon]="icon" [severity]="severity" [rounded]="rounded" [class]="styleClass"> </p-tag> `
 })
 class TestBasicTagComponent {
     value: string | undefined = 'Test Tag';
@@ -41,25 +42,29 @@ class TestIconTemplateTagComponent {}
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
     template: `
-        <p-tag value="PTemplate Tag">
+        <p-tag [value]="value">
             <ng-template pTemplate="icon">
                 <span class="p-template-icon">⭐</span>
             </ng-template>
         </p-tag>
     `
 })
-class TestPTemplateTagComponent {}
+class TestPTemplateTagComponent {
+    value = 'PTemplate Tag';
+}
 
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
     template: `
-        <p-tag>
+        <p-tag [value]="value">
             <span class="content-projection">Custom Content</span>
         </p-tag>
     `
 })
-class TestContentProjectionTagComponent {}
+class TestContentProjectionTagComponent {
+    value: string | undefined;
+}
 
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -71,7 +76,7 @@ class TestSeverityTagComponent {}
 @Component({
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
-    template: ` <p-tag [value]="value" [severity]="severity" [style]="style" [styleClass]="styleClass"> </p-tag> `
+    template: ` <p-tag [value]="value" [severity]="severity" [style]="style" [class]="styleClass"> </p-tag> `
 })
 class TestStyleTagComponent {
     value = 'Styled Tag';
@@ -105,7 +110,7 @@ describe('Tag', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             declarations: [TestBasicTagComponent, TestIconTagComponent, TestIconTemplateTagComponent, TestPTemplateTagComponent, TestContentProjectionTagComponent, TestSeverityTagComponent, TestStyleTagComponent, TestMultipleIconTemplatesComponent],
-            imports: [Tag],
+            imports: [Tag, PrimeTemplate],
             providers: [provideZonelessChangeDetection()]
         }).compileComponents();
 
@@ -133,11 +138,10 @@ describe('Tag', () => {
 
             const freshTag = freshFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
-            expect(freshTag.value).toBeUndefined();
-            expect(freshTag.icon).toBeUndefined();
-            expect(freshTag.severity).toBeUndefined();
-            expect(freshTag.rounded).toBeFalsy(); // booleanAttribute transforms undefined to false
-            expect(freshTag.styleClass).toBeUndefined();
+            expect(freshTag.value()).toBeUndefined();
+            expect(freshTag.icon()).toBeUndefined();
+            expect(freshTag.severity()).toBeUndefined();
+            expect(freshTag.rounded()).toBeFalsy(); // booleanAttribute transforms undefined to false
         });
 
         it('should accept custom values', async () => {
@@ -150,11 +154,11 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.value).toBe('Custom Tag');
-            expect(tagInstance.icon).toBe('pi pi-star');
-            expect(tagInstance.severity).toBe('success');
-            expect(tagInstance.rounded).toBe(true);
-            expect(tagInstance.styleClass).toBe('custom-class');
+            expect(tagInstance.value()).toBe('Custom Tag');
+            expect(tagInstance.icon()).toBe('pi pi-star');
+            expect(tagInstance.severity()).toBe('success');
+            expect(tagInstance.rounded()).toBe(true);
+            expect(tagElement.nativeElement.classList.contains('custom-class')).toBe(true);
         });
 
         it('should have required dependencies injected', () => {
@@ -162,9 +166,9 @@ describe('Tag', () => {
             expect(tagInstance).toBeInstanceOf(Tag);
         });
 
-        it('should initialize templates properties', () => {
+        it('should initialize template queries', () => {
             expect(tagInstance.templates()).toBeDefined();
-            expect(tagInstance._iconTemplate).toBeUndefined();
+            expect(tagInstance.$iconTemplate()).toBeUndefined();
         });
     });
 
@@ -174,7 +178,7 @@ describe('Tag', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.value).toBe('Updated Value');
+            expect(tagInstance.value()).toBe('Updated Value');
         });
 
         it('should update icon input', async () => {
@@ -182,7 +186,7 @@ describe('Tag', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.icon).toBe('pi pi-tag');
+            expect(tagInstance.icon()).toBe('pi pi-tag');
         });
 
         it('should update severity input', async () => {
@@ -190,7 +194,7 @@ describe('Tag', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.severity).toBe('danger');
+            expect(tagInstance.severity()).toBe('danger');
         });
 
         it('should update rounded input with booleanAttribute transform', async () => {
@@ -198,21 +202,21 @@ describe('Tag', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.rounded).toBe(true);
+            expect(tagInstance.rounded()).toBe(true);
 
             component.rounded = false;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.rounded).toBe(false);
+            expect(tagInstance.rounded()).toBe(false);
         });
 
-        it('should update styleClass input', async () => {
+        it('should apply a custom class on the host', async () => {
             component.styleClass = 'test-class';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.styleClass).toBe('test-class');
+            expect(tagElement.nativeElement.classList.contains('test-class')).toBe(true);
         });
 
         it('should handle all severity types', async () => {
@@ -223,7 +227,7 @@ describe('Tag', () => {
                 fixture.changeDetectorRef.markForCheck();
                 await fixture.whenStable();
                 fixture.detectChanges();
-                expect(tagInstance.severity).toBe(severity as any);
+                expect(tagInstance.severity()).toBe(severity as any);
             }
         });
 
@@ -232,13 +236,13 @@ describe('Tag', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.severity).toBeUndefined();
+            expect(tagInstance.severity()).toBeUndefined();
 
             component.severity = null as any;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.severity).toBeNull();
+            expect(tagInstance.severity()).toBeNull();
         });
 
         it('should handle string severity values', async () => {
@@ -246,7 +250,7 @@ describe('Tag', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.severity).toBe('custom-severity' as any);
+            expect(tagInstance.severity()).toBe('custom-severity' as any);
         });
     });
 
@@ -314,7 +318,7 @@ describe('Tag', () => {
             } else {
                 // Icon may not render in test environment, just verify component has icon property
                 const tagInstance = iconFixture.debugElement.query(By.directive(Tag)).componentInstance;
-                expect(tagInstance.icon).toBe('pi pi-check');
+                expect(tagInstance.icon()).toBe('pi pi-check');
             }
         });
 
@@ -345,12 +349,12 @@ describe('Tag', () => {
                 expect(iconSpan.nativeElement.classList.contains('pi-star')).toBe(false);
             } else {
                 // Icon may not render in test environment, just verify property updates
-                expect(tagInstance.icon).toBe('pi pi-star');
+                expect(tagInstance.icon()).toBe('pi pi-star');
                 component.icon = 'pi pi-heart';
                 fixture.changeDetectorRef.markForCheck();
                 await fixture.whenStable();
                 fixture.detectChanges();
-                expect(tagInstance.icon).toBe('pi pi-heart');
+                expect(tagInstance.icon()).toBe('pi pi-heart');
             }
         });
 
@@ -367,7 +371,7 @@ describe('Tag', () => {
                 expect(iconSpan.nativeElement.classList.contains('custom-icon-class')).toBe(true);
             } else {
                 // Icon may not render in test environment, just verify icon property is set
-                expect(tagInstance.icon).toBe('pi pi-check custom-icon-class');
+                expect(tagInstance.icon()).toBe('pi pi-check custom-icon-class');
             }
         });
     });
@@ -381,8 +385,8 @@ describe('Tag', () => {
 
             const iconTemplateTag = iconTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
-            expect(() => iconTemplateTag.ngAfterContentInit()).not.toThrow();
-            expect(iconTemplateTag.iconTemplate).toBeDefined();
+            expect(iconTemplateTag.iconTemplate()).toBeDefined();
+            expect(iconTemplateTag.$iconTemplate()).toBe(iconTemplateTag.iconTemplate());
 
             // Check if icon section exists, may be rendered differently in test environment
             const iconContainer = iconTemplateFixture.debugElement.query(By.css('span:nth-child(2)'));
@@ -390,7 +394,7 @@ describe('Tag', () => {
                 expect(iconContainer).toBeTruthy();
             } else {
                 // Template processing might not work fully in test environment
-                expect(iconTemplateTag.iconTemplate).toBeDefined();
+                expect(iconTemplateTag.iconTemplate()).toBeDefined();
             }
         });
 
@@ -402,8 +406,8 @@ describe('Tag', () => {
 
             const pTemplateTag = pTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
-            expect(() => pTemplateTag.ngAfterContentInit()).not.toThrow();
-            expect(pTemplateTag.templates).toBeDefined();
+            expect(pTemplateTag.templates().length).toBe(1);
+            expect(pTemplateTag.$iconTemplate()).toBeDefined();
 
             // Check if icon section exists, may be rendered differently in test environment
             const iconContainer = pTemplateFixture.debugElement.query(By.css('span:nth-child(2)'));
@@ -411,7 +415,7 @@ describe('Tag', () => {
                 expect(iconContainer).toBeTruthy();
             } else {
                 // Template processing might not work fully in test environment
-                expect(pTemplateTag.templates).toBeDefined();
+                expect(pTemplateTag.$iconTemplate()).toBeDefined();
             }
         });
 
@@ -428,7 +432,7 @@ describe('Tag', () => {
             } else {
                 // If template processing doesn't work in test environment, just verify component exists
                 const tagComponent = iconTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
-                expect(tagComponent.iconTemplate).toBeDefined();
+                expect(tagComponent.iconTemplate()).toBeDefined();
             }
         });
 
@@ -445,11 +449,11 @@ describe('Tag', () => {
             } else {
                 // If template processing doesn't work in test environment, just verify component exists
                 const tagComponent = pTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
-                expect(tagComponent.templates).toBeDefined();
+                expect(tagComponent.$iconTemplate()).toBeDefined();
             }
         });
 
-        it('should prioritize iconTemplate over _iconTemplate', async () => {
+        it('should prioritize the #icon content child over pTemplate="icon"', async () => {
             const multipleFixture = TestBed.createComponent(TestMultipleIconTemplatesComponent);
             multipleFixture.detectChanges();
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -457,13 +461,10 @@ describe('Tag', () => {
 
             const multipleTag = multipleFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
-            // Both templates should be processed
-            expect(multipleTag.iconTemplate).toBeDefined();
-            expect(() => multipleTag.ngAfterContentInit()).not.toThrow();
-
-            // Component should exist and have templates
-            expect(multipleTag).toBeTruthy();
-            expect(multipleTag.templates).toBeDefined();
+            // Both templates are present; the #icon content child wins
+            expect(multipleTag.iconTemplate()).toBeDefined();
+            expect(multipleTag.templates().length).toBe(1);
+            expect(multipleTag.$iconTemplate()).toBe(multipleTag.iconTemplate());
         });
 
         it('should not show icon span when template is used', () => {
@@ -476,7 +477,7 @@ describe('Tag', () => {
 
             // But template icon container should be present or component should have template
             const tagComponent = iconTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
-            expect(tagComponent.iconTemplate).toBeDefined();
+            expect(tagComponent.iconTemplate()).toBeDefined();
         });
 
         it('should pass correct template context', async () => {
@@ -488,7 +489,7 @@ describe('Tag', () => {
             const iconTemplateTag = iconTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
             // Verify template is processed correctly
-            expect(iconTemplateTag.iconTemplate).toBeDefined();
+            expect(iconTemplateTag.iconTemplate()).toBeDefined();
 
             // Template processing might work differently in test environment
             expect(iconTemplateTag).toBeTruthy();
@@ -503,16 +504,16 @@ describe('Tag', () => {
             const pTemplateTag = pTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
             // Change component properties
-            pTemplateTag.value = 'Updated Template Tag';
-            pTemplateFixture.detectChanges();
-            await new Promise((resolve) => setTimeout(resolve, 100));
+            pTemplateFixture.componentInstance.value = 'Updated Template Tag';
+            pTemplateFixture.changeDetectorRef.markForCheck();
             await pTemplateFixture.whenStable();
+            pTemplateFixture.detectChanges();
 
             // Template should still be processed correctly
-            expect(pTemplateTag.templates).toBeDefined();
+            expect(pTemplateTag.$iconTemplate()).toBeDefined();
 
             // Verify the value property was updated
-            expect(pTemplateTag.value).toBe('Updated Template Tag');
+            expect(pTemplateTag.value()).toBe('Updated Template Tag');
         });
     });
 
@@ -544,7 +545,7 @@ describe('Tag', () => {
             const complexTag = complexFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
             // Add value to see both content projection and label
-            complexTag.value = 'With Content';
+            complexFixture.componentInstance.value = 'With Content';
             complexFixture.changeDetectorRef.markForCheck();
             await complexFixture.whenStable();
             complexFixture.detectChanges();
@@ -557,13 +558,13 @@ describe('Tag', () => {
                 expect(labelSpan).toBeTruthy();
                 expect(labelSpan.nativeElement.textContent.trim()).toBe('With Content');
             } else {
-                expect(complexTag.value).toBe('With Content');
+                expect(complexTag.value()).toBe('With Content');
             }
         });
     });
 
     describe('CSS Classes and Styling', () => {
-        it('should apply styleClass to root element', async () => {
+        it('should apply a custom class to the root element via class binding', async () => {
             component.styleClass = 'custom-tag-class';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
@@ -641,7 +642,7 @@ describe('Tag', () => {
                 expect(iconSpan).toBeTruthy();
             } else {
                 // Icon may not render if template processing is different in test environment
-                expect(tagInstance.icon).toBe('pi pi-tag');
+                expect(tagInstance.icon()).toBe('pi pi-tag');
             }
         });
     });
@@ -653,7 +654,7 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.severity).toBe('success');
+            expect(tagInstance.severity()).toBe('success');
         });
 
         it('should handle secondary severity', async () => {
@@ -662,7 +663,7 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.severity).toBe('secondary');
+            expect(tagInstance.severity()).toBe('secondary');
         });
 
         it('should handle info severity', async () => {
@@ -671,7 +672,7 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.severity).toBe('info');
+            expect(tagInstance.severity()).toBe('info');
         });
 
         it('should handle warn severity', async () => {
@@ -680,7 +681,7 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.severity).toBe('warn');
+            expect(tagInstance.severity()).toBe('warn');
         });
 
         it('should handle danger severity', async () => {
@@ -689,7 +690,7 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.severity).toBe('danger');
+            expect(tagInstance.severity()).toBe('danger');
         });
 
         it('should handle contrast severity', async () => {
@@ -698,7 +699,7 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.severity).toBe('contrast');
+            expect(tagInstance.severity()).toBe('contrast');
         });
 
         it('should handle custom string severity', async () => {
@@ -707,14 +708,14 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.severity).toBe('my-custom-severity' as any);
+            expect(tagInstance.severity()).toBe('my-custom-severity' as any);
         });
 
         it('should work without severity', () => {
             component.severity = undefined as any;
             fixture.detectChanges();
 
-            expect(tagInstance.severity).toBeUndefined();
+            expect(tagInstance.severity()).toBeUndefined();
             expect(() => fixture.detectChanges()).not.toThrow();
         });
     });
@@ -726,7 +727,7 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.rounded).toBe(true);
+            expect(tagInstance.rounded()).toBe(true);
         });
 
         it('should handle rounded false', async () => {
@@ -735,14 +736,14 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.rounded).toBe(false);
+            expect(tagInstance.rounded()).toBe(false);
         });
 
         it('should handle rounded undefined', () => {
             component.rounded = undefined as any;
             fixture.detectChanges();
 
-            expect(tagInstance.rounded).toBeFalsy(); // booleanAttribute transforms undefined to false
+            expect(tagInstance.rounded()).toBeFalsy(); // booleanAttribute transforms undefined to false
         });
 
         it('should use booleanAttribute transform', async () => {
@@ -751,35 +752,31 @@ describe('Tag', () => {
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.rounded).toBe(true);
+            expect(tagInstance.rounded()).toBe(true);
 
             component.rounded = false;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.rounded).toBe(false);
+            expect(tagInstance.rounded()).toBe(false);
 
             // booleanAttribute converts non-boolean values
             component.rounded = null as any;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.rounded).toBe(false);
+            expect(tagInstance.rounded()).toBe(false);
 
             component.rounded = undefined as any;
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(tagInstance.rounded).toBe(false);
+            expect(tagInstance.rounded()).toBe(false);
         });
     });
 
     describe('Template Processing Tests', () => {
-        it('should have ngAfterContentInit method', () => {
-            expect(typeof tagInstance.ngAfterContentInit).toBe('function');
-        });
-
-        it('should process templates in ngAfterContentInit', async () => {
+        it('should resolve a pTemplate="icon" through $iconTemplate', async () => {
             const pTemplateFixture = TestBed.createComponent(TestPTemplateTagComponent);
             pTemplateFixture.detectChanges();
             await new Promise((resolve) => setTimeout(resolve, 100));
@@ -787,26 +784,12 @@ describe('Tag', () => {
 
             const pTemplateTag = pTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
-            expect(pTemplateTag).toBeTruthy();
-            expect(typeof pTemplateTag.ngAfterContentInit).toBe('function');
-            expect(() => pTemplateTag.ngAfterContentInit()).not.toThrow();
+            expect(pTemplateTag.iconTemplate()).toBeUndefined();
+            expect(pTemplateTag.$iconTemplate()).toBeDefined();
         });
 
-        it('should set _iconTemplate when processing PrimeTemplate', async () => {
-            const pTemplateFixture = TestBed.createComponent(TestPTemplateTagComponent);
-            pTemplateFixture.detectChanges();
-            await new Promise((resolve) => setTimeout(resolve, 100));
-            await pTemplateFixture.whenStable();
-
-            const pTemplateTag = pTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
-
-            expect(pTemplateTag).toBeTruthy();
-            expect(pTemplateTag.templates !== undefined || pTemplateTag._iconTemplate !== undefined).toBe(true);
-        });
-
-        it('should handle missing templates gracefully', () => {
-            expect(() => tagInstance.ngAfterContentInit()).not.toThrow();
-            expect(tagInstance._iconTemplate).toBeUndefined();
+        it('should have no effective icon template without icon content', () => {
+            expect(tagInstance.$iconTemplate()).toBeUndefined();
         });
 
         it('should handle templates without icon type', async () => {
@@ -817,8 +800,8 @@ describe('Tag', () => {
 
             const basicTag = basicFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
-            expect(() => basicTag.ngAfterContentInit()).not.toThrow();
-            expect(basicTag._iconTemplate).toBeUndefined();
+            expect(basicTag.templates().length).toBe(0);
+            expect(basicTag.$iconTemplate()).toBeUndefined();
         });
     });
 
@@ -834,11 +817,10 @@ describe('Tag', () => {
             fixture.detectChanges();
 
             expect(() => fixture.detectChanges()).not.toThrow();
-            expect(tagInstance.value).toBeUndefined();
-            expect(tagInstance.icon).toBeUndefined();
-            expect(tagInstance.severity).toBeUndefined();
-            expect(tagInstance.rounded).toBeFalsy(); // booleanAttribute transforms undefined to false
-            expect(tagInstance.styleClass).toBeUndefined();
+            expect(tagInstance.value()).toBeUndefined();
+            expect(tagInstance.icon()).toBeUndefined();
+            expect(tagInstance.severity()).toBeUndefined();
+            expect(tagInstance.rounded()).toBeFalsy(); // booleanAttribute transforms undefined to false
         });
 
         it('should handle empty string values', async () => {
@@ -851,10 +833,9 @@ describe('Tag', () => {
             fixture.detectChanges();
 
             expect(() => fixture.detectChanges()).not.toThrow();
-            expect(tagInstance.value).toBe('' as any);
-            expect(tagInstance.icon).toBe('' as any);
-            expect(tagInstance.severity).toBe('' as any);
-            expect(tagInstance.styleClass).toBe('' as any);
+            expect(tagInstance.value()).toBe('' as any);
+            expect(tagInstance.icon()).toBe('' as any);
+            expect(tagInstance.severity()).toBe('' as any);
         });
 
         it('should handle special characters in value', async () => {
@@ -866,7 +847,7 @@ describe('Tag', () => {
                 await fixture.whenStable();
                 fixture.detectChanges();
 
-                expect(tagInstance.value).toBe(value);
+                expect(tagInstance.value()).toBe(value);
                 expect(() => fixture.detectChanges()).not.toThrow();
             }
         });
@@ -878,12 +859,12 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.value).toBe(longValue);
+            expect(tagInstance.value()).toBe(longValue);
             const labelSpan = fixture.debugElement.query(By.css('span:last-child'));
             if (labelSpan) {
                 expect(labelSpan.nativeElement.textContent.trim()).toBe(longValue);
             } else {
-                expect(tagInstance.value).toBe(longValue);
+                expect(tagInstance.value()).toBe(longValue);
             }
         });
 
@@ -899,9 +880,9 @@ describe('Tag', () => {
                 await fixture.whenStable();
                 fixture.detectChanges();
 
-                expect(tagInstance.value).toBe(values[index]);
-                expect(tagInstance.severity).toBe(severities[index] as any);
-                expect(tagInstance.rounded).toBe(index % 2 === 0);
+                expect(tagInstance.value()).toBe(values[index]);
+                expect(tagInstance.severity()).toBe(severities[index] as any);
+                expect(tagInstance.rounded()).toBe(index % 2 === 0);
             }
         });
 
@@ -934,10 +915,10 @@ describe('Tag', () => {
             const instance1 = fixture1.debugElement.query(By.directive(Tag)).componentInstance;
             const instance2 = fixture2.debugElement.query(By.directive(Tag)).componentInstance;
 
-            expect(instance1.value).toBe('Tag 1');
-            expect(instance1.severity).toBe('success');
-            expect(instance2.value).toBe('Tag 2');
-            expect(instance2.severity).toBe('danger');
+            expect(instance1.value()).toBe('Tag 1');
+            expect(instance1.severity()).toBe('success');
+            expect(instance2.value()).toBe('Tag 2');
+            expect(instance2.severity()).toBe('danger');
             expect(instance1).not.toBe(instance2);
         });
     });
@@ -949,10 +930,10 @@ describe('Tag', () => {
 
             const severityTag = severityFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
-            expect(severityTag.value).toBe('Success Tag');
-            expect(severityTag.severity).toBe('success');
-            expect(severityTag.icon).toBe('pi pi-check');
-            expect(severityTag.rounded).toBe(true);
+            expect(severityTag.value()).toBe('Success Tag');
+            expect(severityTag.severity()).toBe('success');
+            expect(severityTag.icon()).toBe('pi pi-check');
+            expect(severityTag.rounded()).toBe(true);
         });
 
         it('should work with styled component', () => {
@@ -961,9 +942,9 @@ describe('Tag', () => {
 
             const styleTag = styleFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
-            expect(styleTag.value).toBe('Styled Tag');
-            expect(styleTag.severity).toBe('info');
-            expect(styleTag.styleClass).toBe('custom-tag-class');
+            expect(styleTag.value()).toBe('Styled Tag');
+            expect(styleTag.severity()).toBe('info');
+            expect(styleFixture.debugElement.query(By.directive(Tag)).nativeElement.classList.contains('custom-tag-class')).toBe(true);
         });
 
         it('should maintain state across property changes', async () => {
@@ -973,8 +954,8 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.value).toBe('Initial');
-            expect(tagInstance.severity).toBe('info');
+            expect(tagInstance.value()).toBe('Initial');
+            expect(tagInstance.severity()).toBe('info');
 
             component.value = 'Updated';
             component.severity = 'success';
@@ -983,9 +964,9 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.value).toBe('Updated');
-            expect(tagInstance.severity).toBe('success');
-            expect(tagInstance.rounded).toBe(true);
+            expect(tagInstance.value()).toBe('Updated');
+            expect(tagInstance.severity()).toBe('success');
+            expect(tagInstance.rounded()).toBe(true);
         });
 
         it('should render correctly without any input properties set', () => {
@@ -1003,10 +984,10 @@ describe('Tag', () => {
             const minimalTag = minimalFixture.debugElement.query(By.directive(Tag)).componentInstance;
 
             expect(minimalTag).toBeTruthy();
-            expect(minimalTag.value).toBeUndefined();
-            expect(minimalTag.icon).toBeUndefined();
-            expect(minimalTag.severity).toBeUndefined();
-            expect(minimalTag.rounded).toBeFalsy(); // booleanAttribute transforms undefined to false
+            expect(minimalTag.value()).toBeUndefined();
+            expect(minimalTag.icon()).toBeUndefined();
+            expect(minimalTag.severity()).toBeUndefined();
+            expect(minimalTag.rounded()).toBeFalsy(); // booleanAttribute transforms undefined to false
         });
 
         it('should work with all features combined', async () => {
@@ -1019,11 +1000,10 @@ describe('Tag', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            expect(tagInstance.value).toBe('Complete Tag');
-            expect(tagInstance.icon).toBe('pi pi-check-circle');
-            expect(tagInstance.severity).toBe('success');
-            expect(tagInstance.rounded).toBe(true);
-            expect(tagInstance.styleClass).toBe('complete-tag');
+            expect(tagInstance.value()).toBe('Complete Tag');
+            expect(tagInstance.icon()).toBe('pi pi-check-circle');
+            expect(tagInstance.severity()).toBe('success');
+            expect(tagInstance.rounded()).toBe(true);
 
             // Verify properties are set correctly on the component
             expect(tagInstance).toBeTruthy();
@@ -1033,31 +1013,28 @@ describe('Tag', () => {
         });
     });
 
-    describe('Public Methods', () => {
-        it('should have ngAfterContentInit method', () => {
-            expect(typeof tagInstance.ngAfterContentInit).toBe('function');
-        });
-
-        it('should call ngAfterContentInit without errors', () => {
-            expect(() => tagInstance.ngAfterContentInit()).not.toThrow();
-        });
-
-        it('should process icon templates correctly', async () => {
+    describe('Derived State', () => {
+        it('should expose the effective icon template as a computed', async () => {
             const pTemplateFixture = TestBed.createComponent(TestPTemplateTagComponent);
             pTemplateFixture.detectChanges();
-
-            const pTemplateTag = pTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
-
-            // Manually call ngAfterContentInit to test processing
-            expect(() => pTemplateTag.ngAfterContentInit()).not.toThrow();
-
-            // Check if _iconTemplate is set after processing
-            pTemplateTag.ngAfterContentInit();
             await new Promise((resolve) => setTimeout(resolve, 100));
             await pTemplateFixture.whenStable();
 
-            // Template processing should work without errors
-            expect(pTemplateTag).toBeTruthy();
+            const pTemplateTag = pTemplateFixture.debugElement.query(By.directive(Tag)).componentInstance;
+
+            expect(pTemplateTag.$iconTemplate()).toBeDefined();
+        });
+
+        it('should compute data-p from rounded and severity', async () => {
+            component.severity = 'success';
+            component.rounded = true;
+            fixture.changeDetectorRef.markForCheck();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(tagInstance.dataP()).toContain('rounded');
+            expect(tagInstance.dataP()).toContain('success');
+            expect(tagElement.nativeElement.getAttribute('data-p')).toContain('rounded');
         });
     });
 
@@ -1239,7 +1216,7 @@ describe('Tag', () => {
 
                 fixture.componentRef.setInput('pt', {
                     host: ({ instance }: any) => ({
-                        class: instance?.value ? 'HAS_VALUE' : 'NO_VALUE'
+                        class: instance?.value() ? 'HAS_VALUE' : 'NO_VALUE'
                     })
                 });
                 fixture.detectChanges();
@@ -1253,7 +1230,7 @@ describe('Tag', () => {
 
                 fixture.componentRef.setInput('pt', {
                     root: ({ instance }: any) => ({
-                        class: instance?.severity === 'success' ? 'SUCCESS_CLASS' : 'OTHER_CLASS'
+                        class: instance?.severity() === 'success' ? 'SUCCESS_CLASS' : 'OTHER_CLASS'
                     })
                 });
                 fixture.detectChanges();
@@ -1267,7 +1244,7 @@ describe('Tag', () => {
 
                 fixture.componentRef.setInput('pt', {
                     label: ({ instance }: any) => ({
-                        class: instance?.rounded ? 'ROUNDED_CLASS' : 'NOT_ROUNDED_CLASS'
+                        class: instance?.rounded() ? 'ROUNDED_CLASS' : 'NOT_ROUNDED_CLASS'
                     })
                 });
                 fixture.detectChanges();

--- a/packages/optimus-ui/src/tag/tag.ts
+++ b/packages/optimus-ui/src/tag/tag.ts
@@ -1,13 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { AfterContentInit, booleanAttribute, ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, TemplateRef, ViewEncapsulation, contentChild, contentChildren } from '@angular/core';
+import { afterEveryRender, booleanAttribute, ChangeDetectionStrategy, Component, NgModule, TemplateRef, ViewEncapsulation, computed, contentChild, contentChildren, inject, input } from '@angular/core';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
 import type { BadgeSeverity } from '@openng/optimus-ui/types/badge';
 import { TagPassThrough } from '@openng/optimus-ui/types/tag';
 import { TagStyle } from './style/tagstyle';
-
-const TAG_INSTANCE = new InjectionToken<Tag>('TAG_INSTANCE');
 
 /**
  * Tag component is used to categorize content.
@@ -19,63 +17,52 @@ const TAG_INSTANCE = new InjectionToken<Tag>('TAG_INSTANCE');
     imports: [CommonModule, SharedModule, Bind],
     template: `
         <ng-content></ng-content>
-        @if (!iconTemplate() && !_iconTemplate) {
-            @if (icon) {
-                <span [class]="cx('icon')" [ngClass]="icon" [pBind]="ptm('icon')"></span>
-            }
-        }
-        @if (iconTemplate() || _iconTemplate) {
+        @if ($iconTemplate(); as iconTemplate) {
             <span [class]="cx('icon')" [pBind]="ptm('icon')">
-                <ng-template *ngTemplateOutlet="iconTemplate() || _iconTemplate"></ng-template>
+                <ng-template *ngTemplateOutlet="iconTemplate"></ng-template>
             </span>
+        } @else if (icon()) {
+            <span [class]="cx('icon')" [ngClass]="icon()" [pBind]="ptm('icon')"></span>
         }
-        <span [class]="cx('label')" [pBind]="ptm('label')">{{ value }}</span>
+        <span [class]="cx('label')" [pBind]="ptm('label')">{{ value() }}</span>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [TagStyle, { provide: TAG_INSTANCE, useExisting: Tag }, { provide: PARENT_INSTANCE, useExisting: Tag }],
+    providers: [TagStyle, { provide: PARENT_INSTANCE, useExisting: Tag }],
     host: {
-        '[class]': "cn(cx('root'), styleClass)",
-        '[attr.data-p]': 'dataP'
+        '[class]': "cx('root')",
+        '[attr.data-p]': 'dataP()'
     },
     hostDirectives: [Bind]
 })
-export class Tag extends BaseComponent<TagPassThrough> implements AfterContentInit {
-    componentName = 'Tag';
-    $pcTag: Tag | undefined = inject(TAG_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
-
+export class Tag extends BaseComponent<TagPassThrough> {
     bindDirectiveInstance = inject(Bind, { self: true });
 
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
-    }
+    _componentStyle = inject(TagStyle);
 
-    /**
-     * Style class of the component.
-     * @deprecated since v20.0.0, use `class` instead.
-     * @group Props
-     */
-    @Input() styleClass: string | undefined;
     /**
      * Severity type of the tag.
      * @group Props
      */
-    @Input() severity: BadgeSeverity | undefined | null;
+    readonly severity = input<BadgeSeverity | undefined | null>();
+
     /**
      * Value to display inside the tag.
      * @group Props
      */
-    @Input() value: string | undefined;
+    readonly value = input<string>();
+
     /**
      * Icon of the tag to display next to the value.
      * @group Props
      */
-    @Input() icon: string | undefined;
+    readonly icon = input<string>();
+
     /**
      * Whether the corners of the tag are rounded.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) rounded: boolean | undefined;
+    readonly rounded = input<boolean | undefined, unknown>(undefined, { transform: booleanAttribute });
 
     /**
      * Custom icon template.
@@ -85,24 +72,25 @@ export class Tag extends BaseComponent<TagPassThrough> implements AfterContentIn
 
     readonly templates = contentChildren(PrimeTemplate);
 
-    _iconTemplate: TemplateRef<void> | undefined;
+    componentName = 'Tag';
 
-    _componentStyle = inject(TagStyle);
+    /** Effective icon template: the \`#icon\` content child, or a legacy \`pTemplate="icon"\`. */
+    readonly $iconTemplate = computed(() => this.iconTemplate() ?? this.templates().find((item) => item.getType() === 'icon')?.template);
 
-    onAfterContentInit() {
-        this.templates()?.forEach((item) => {
-            switch (item.getType()) {
-                case 'icon':
-                    this._iconTemplate = item.template;
-                    break;
-            }
-        });
-    }
+    readonly dataP = computed(() =>
+        this.cn({
+            rounded: this.rounded(),
+            [this.severity() as string]: this.severity()
+        })
+    );
 
-    get dataP() {
-        return this.cn({
-            rounded: this.rounded,
-            [this.severity as string]: this.severity
+    constructor() {
+        super();
+        // Re-apply the host/root pass-through sections after each render (replaces the former
+        // ngAfterViewChecked hook). Bind.setAttrs writes into a signal behind an equality check,
+        // so unchanged PT resolutions are no-ops.
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
         });
     }
 }


### PR DESCRIPTION
Converts the component to the signal-based APIs: @Input()/@Output() to
input()/output()/model(), getter/setter inputs to input() + linkedSignal
mirrors keeping the legacy private state names, ngOnChanges branches to
effects in declaration order, and view/content queries to viewChild/
contentChild/contentChildren. Class members are reordered to the project
convention (inject, input, output, viewChild, viewChildren, contentChild,
contentChildren, other properties, constructor, lifecycle hooks,
functions) and the tests are converted to setInput/signal reads.
---
Part of the 3.0 signals migration (one PR per component, all targeting `next`, branches are file-disjoint so they can merge in any order unless noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfaVxzugb2e8jXucdaoKh5