### PR TITLE
fix(table): prevent duplicate lazy load emission when filter on input

### DIFF
--- a/packages/optimus-ui/src/table/table.test.ts
+++ b/packages/optimus-ui/src/table/table.test.ts
@@ -377,6 +377,34 @@ describe('Table', () => {
         ];
     }
 
+    @Component({
+        changeDetection: ChangeDetectionStrategy.Eager,
+        standalone: false,
+        template: `
+            <p-table [value]="[]" [lazy]="true" [totalRecords]="0" (onLazyLoad)="onLazyLoad($event)">
+                <ng-template #header>
+                    <tr>
+                        <th>
+                            <p-columnFilter type="text" field="name" [filterOn]="filterOn" />
+                        </th>
+                        <th>
+                            <p-columnFilter type="numeric" field="age" [filterOn]="filterOn" />
+                        </th>
+                    </tr>
+                </ng-template>
+                <ng-template #body></ng-template>
+            </p-table>
+        `
+    })
+    class TestLazyFilterComponent {
+        filterOn = 'enter';
+        lazyLoadCount = 0;
+
+        onLazyLoad(_event: any) {
+            this.lazyLoadCount++;
+        }
+    }
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             declarations: [
@@ -391,7 +419,8 @@ describe('Table', () => {
                 TestScrollableNonVirtualTableComponent,
                 TestVirtualScrollFlexHeightTableComponent,
                 TestLazyLoadTableComponent,
-                TestTemplatesTableComponent
+                TestTemplatesTableComponent,
+                TestLazyFilterComponent
             ],
             imports: [CommonModule, FormsModule, TableModule, SharedModule, Select],
             providers: [TableService, provideZonelessChangeDetection()]
@@ -654,6 +683,62 @@ describe('Table', () => {
 
             tableInstance.onLazyLoad.emit({ first: 0, rows: 10 });
             expect(testComponent.loadProducts).toHaveBeenCalled();
+        });
+    });
+
+    describe('Lazy Filter Double-Emit', () => {
+        let testComponent: TestLazyFilterComponent;
+        let testFixture: ComponentFixture<TestLazyFilterComponent>;
+
+        beforeEach(async () => {
+            testFixture = TestBed.createComponent(TestLazyFilterComponent);
+            testComponent = testFixture.componentInstance;
+            await testFixture.whenStable();
+            testFixture.detectChanges();
+        });
+
+        it('should emit onLazyLoad once when filterOn is input and Enter is pressed after typing', () => {
+            testComponent.filterOn = 'input';
+            testFixture.detectChanges();
+
+            const filterFormEl = testFixture.debugElement.query(By.css('p-columnFilterFormElement'));
+            const filterFormInstance = filterFormEl.componentInstance;
+
+            testComponent.lazyLoadCount = 0;
+
+            filterFormInstance.onModelChange('test');
+            filterFormInstance.onTextInputEnterKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+            expect(testComponent.lazyLoadCount).toBe(1);
+        });
+
+        it('should emit onLazyLoad once when filterOn is enter and Enter is pressed', () => {
+            testComponent.filterOn = 'enter';
+            testFixture.detectChanges();
+
+            const filterFormEl = testFixture.debugElement.query(By.css('p-columnFilterFormElement'));
+            const filterFormInstance = filterFormEl.componentInstance;
+
+            testComponent.lazyLoadCount = 0;
+
+            filterFormInstance.onTextInputEnterKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+            expect(testComponent.lazyLoadCount).toBe(1);
+        });
+
+        it('should emit onLazyLoad once for numeric filter when filterOn is input and Enter is pressed', () => {
+            testComponent.filterOn = 'input';
+            testFixture.detectChanges();
+
+            const filterFormEls = testFixture.debugElement.queryAll(By.css('p-columnFilterFormElement'));
+            const numericFilterInstance = filterFormEls[1].componentInstance;
+
+            testComponent.lazyLoadCount = 0;
+
+            numericFilterInstance.onModelChange(42);
+            numericFilterInstance.onNumericInputKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+            expect(testComponent.lazyLoadCount).toBe(1);
         });
     });
 

--- a/packages/optimus-ui/src/table/table.ts
+++ b/packages/optimus-ui/src/table/table.ts
@@ -6630,13 +6630,17 @@ export class ColumnFilterFormElement extends BaseComponent<ColumnFilterPassThrou
     }
 
     onTextInputEnterKeyDown(event: KeyboardEvent) {
-        this.dataTable._filter();
+        if (this.filterOn !== 'input') {
+            this.dataTable._filter();
+        }
         event.preventDefault();
     }
 
     onNumericInputKeyDown(event: KeyboardEvent) {
         if (event.key === 'Enter') {
-            this.dataTable._filter();
+            if (this.filterOn !== 'input') {
+                this.dataTable._filter();
+            }
             event.preventDefault();
         }
     }


### PR DESCRIPTION
## Description

When `<p-columnFilter>` is configured with `[filterOn]="'input'"`, typing triggers `onModelChange()`, which immediately calls `dataTable._filter()`. Pressing **Enter** subsequently fired `onTextInputEnterKeyDown` or `onNumericInputKeyDown`, which unconditionally invoked `dataTable._filter()` a second time, resulting in duplicate `onLazyLoad` event emissions.

**Changes:**
- Guarded `onTextInputEnterKeyDown` and `onNumericInputKeyDown` in `ColumnFilterFormElement` to bypass `_filter()` when `filterOn === 'input'`.
- Preserved standard Enter key filtering behavior when `filterOn === 'enter'`.
- Added unit test coverage verifying a single `onLazyLoad` emission across text and numeric filters.

## Related issues

Fixes #884

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [x] `npm test` (ran `pnpm --filter @openng/optimus-ui test:unit` - 3 new tests passed)
- [x] `npm run lint` (`npx eslint` passed with 0 errors)
- [x] Verified unit tests covering both text and numeric lazy filter double-emission scenarios.

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [x] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Prevents unnecessary backend network roundtrips triggered by duplicate `onLazyLoad` emissions on server-side paginated/filtered tables.
