### PR TITLE
fix(chart): declare chart.js as an optional peer dependency

### DIFF
--- a/packages/optimus-ui/package.json
+++ b/packages/optimus-ui/package.json
@@ -77,6 +77,7 @@
         "@angular/forms": "catalog:angular22",
         "@angular/platform-browser": "catalog:angular22",
         "@angular/router": "catalog:angular22",
+        "chart.js": "^4.0.0",
         "rxjs": "^6.0.0 || ^7.8.1"
     },
     "dependencies": {
@@ -84,5 +85,10 @@
         "@openng/optimus-ui-styled": "workspace:*",
         "@openng/optimus-ui-styles": "workspace:*",
         "@openng/optimus-ui-utils": "workspace:*"
+    },
+    "peerDependenciesMeta": {
+        "chart.js": {
+            "optional": true
+        }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,6 +328,9 @@ importers:
       '@openng/optimus-ui-utils':
         specifier: workspace:*
         version: link:../optimus-ui-utils
+      chart.js:
+        specifier: ^4.0.0
+        version: 4.5.1
       rxjs:
         specifier: ^6.0.0 || ^7.8.1
         version: 7.8.2


### PR DESCRIPTION
## Problem

`packages/optimus-ui/src/chart/chart.ts` does `import Chart from 'chart.js/auto'`, but `@openng/optimus-ui` declares `chart.js` neither as a dependency nor as a peer dependency. The published `package.json` lists only the Angular packages and `rxjs` as peers.

**Reproduction:** an Angular 22 app that imports `ChartModule` from `@openng/optimus-ui/chart`, installed with pnpm 11 and `enableGlobalVirtualStore: true`. `chart.js` is present in the app's `package.json`; esbuild resolves the import relative to the library file in the store and never finds it. pnpm's resolution is more strict and only allows resolving libraries if set in package.json.

## Fix
Declare `chart.js` as an **optional** peer dependency (`^4.0.0`, matching the `4.5.1` used by `apps/docs`) via `peerDependencies` + `peerDependenciesMeta`.

- Optional, so consumers that never use `p-chart` are not forced to install it and get no missing-peer warning.
- Only `package.json` and the lockfile change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Chart.js support for Optimus UI integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->