### PR TITLE
refactor: signals message migration

### DIFF
--- a/apps/docs/doc/message/form-doc.ts
+++ b/apps/docs/doc/message/form-doc.ts
@@ -17,7 +17,7 @@ import { MessageModule } from '@openng/optimus-ui/message';
         </app-docsectiontext>
         <div class="card flex justify-center">
             <div class="flex flex-col gap-4">
-                <p-message severity="error" icon="pi pi-times-circle" styleClass="mb-2">Validation Failed</p-message>
+                <p-message severity="error" icon="pi pi-times-circle" class="mb-2">Validation Failed</p-message>
                 <div class="flex flex-col gap-1">
                     <input pInputText placeholder="Username" [(ngModel)]="username" aria-label="username" [invalid]="!username" />
                     @if (!username) {

--- a/apps/docs/doc/message/icon-doc.ts
+++ b/apps/docs/doc/message/icon-doc.ts
@@ -13,7 +13,7 @@ import { MessageModule } from '@openng/optimus-ui/message';
             <p>The icon of a message is specified with the <i>icon</i> property.</p>
         </app-docsectiontext>
         <div class="card flex justify-center items-center gap-4">
-            <p-message severity="info" icon="pi pi-send" text="Info Message" styleClass="h-full" />
+            <p-message severity="info" icon="pi pi-send" text="Info Message" class="h-full" />
             <p-message severity="success">
                 <ng-template #icon>
                     <p-avatar image="https://optimus.openng.org/demo/avatar/amyelsner.png" shape="circle" />

--- a/packages/optimus-ui/schematics/migrations.json
+++ b/packages/optimus-ui/schematics/migrations.json
@@ -9,12 +9,12 @@
         "styleclass-to-class": {
             "version": "3.0.0",
             "factory": "./migrations/styleclass-to-class/migration",
-            "description": "Rewrite styleClass/[styleClass] to class/[class] on selectors whose styleClass input was removed in this version in favor of the native class attribute, starting with p-toast."
+            "description": "Rewrite styleClass/[styleClass] to class/[class] on selectors whose styleClass input was removed in this version in favor of the native class attribute: p-toast and p-message."
         },
         "remove-dead-inputs": {
             "version": "3.0.0",
             "factory": "./migrations/remove-dead-inputs/migration",
-            "description": "Remove usages of inputs removed in this version that had already stopped doing anything: p-toast/p-toastItem's showTransformOptions, hideTransformOptions, showTransitionOptions and hideTransitionOptions."
+            "description": "Remove usages of inputs removed in this version that had already stopped doing anything: p-toast/p-toastItem's showTransformOptions, hideTransformOptions, showTransitionOptions and hideTransitionOptions; and p-message's showTransitionOptions and hideTransitionOptions."
         }
     }
 }

--- a/packages/optimus-ui/schematics/migrations/remove-dead-inputs/migration.ts
+++ b/packages/optimus-ui/schematics/migrations/remove-dead-inputs/migration.ts
@@ -8,19 +8,23 @@ import { removeDeadInputsInHtml, removeDeadInputsInTypeScript, SelectorInputRemo
  * `hideTransformOptions`/`showTransitionOptions`/`hideTransitionOptions` on Toast/ToastItem had
  * already stopped doing anything once the show/hide animation moved to the shared Motion
  * directive, which does not take transform/transition options through the toast API.
+ * `showTransitionOptions`/`hideTransitionOptions` on Message were dead for the same reason: the
+ * show/hide animation is driven by `motionOptions`, which has no transition-options equivalent.
  */
 const REMOVED_INPUT_GROUPS: readonly SelectorInputRemoval[] = [
     { selector: 'p-toast', names: ['showTransformOptions', 'hideTransformOptions', 'showTransitionOptions', 'hideTransitionOptions'] },
-    { selector: 'p-toastItem', names: ['showTransformOptions', 'hideTransformOptions', 'showTransitionOptions', 'hideTransitionOptions'] }
+    { selector: 'p-toastItem', names: ['showTransformOptions', 'hideTransformOptions', 'showTransitionOptions', 'hideTransitionOptions'] },
+    { selector: 'p-message', names: ['showTransitionOptions', 'hideTransitionOptions'] }
 ];
 
 /**
  * Removes usages of inputs that stopped doing anything before being deleted from
  * @openng/optimus-ui in this version: Toast/ToastItem's showTransformOptions, hideTransformOptions,
  * showTransitionOptions and hideTransitionOptions, dead since the show/hide animation moved to the
- * shared Motion directive (which has no equivalent transform/transition-options input).
+ * shared Motion directive (which has no equivalent transform/transition-options input); and
+ * Message's showTransitionOptions/hideTransitionOptions, dead for the same reason.
  *
- * `name="..."`/`[name]="..."` template bindings on `p-toast`/`p-toastItem` are removed
+ * `name="..."`/`[name]="..."` template bindings on `p-toast`/`p-toastItem`/`p-message` are removed
  * automatically — safe to delete outright, since the values they passed were already unused.
  * Programmatic reads/writes of the same property name elsewhere (e.g. on a `@ViewChild`-queried
  * instance) are reported for manual review instead of being rewritten automatically.

--- a/packages/optimus-ui/schematics/migrations/styleclass-to-class/migration.ts
+++ b/packages/optimus-ui/schematics/migrations/styleclass-to-class/migration.ts
@@ -6,7 +6,7 @@ import { rewriteStyleClassInHtml, rewriteStyleClassInTypeScript } from '../../ut
  * Selectors whose `styleClass`/`[styleClass]` input was dropped in favor of binding the native
  * `class`/`[class]` attribute directly. Extend this list as more components make the same switch.
  */
-export const MIGRATED_SELECTORS: readonly string[] = ['p-toast'];
+export const MIGRATED_SELECTORS: readonly string[] = ['p-toast', 'p-message'];
 
 /**
  * Rewrites `styleClass="x"` to `class="x"` (merging into an existing static `class` attribute) and

--- a/packages/optimus-ui/schematics/test/remove-dead-inputs.spec.ts
+++ b/packages/optimus-ui/schematics/test/remove-dead-inputs.spec.ts
@@ -23,6 +23,17 @@ describe('remove-dead-inputs', () => {
         expect(result.readContent('/src/app/app.html')).toBe(`<p-toastItem [message]="msg"></p-toastItem>\n`);
     });
 
+    it('removes showTransitionOptions/hideTransitionOptions from p-message', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-message showTransitionOptions="300ms" [hideTransitionOptions]="hideTf" [severity]="'info'"></p-message>\n`
+        });
+        const result = await runner.runSchematic('remove-dead-inputs', {}, tree);
+        const html = result.readContent('/src/app/app.html');
+        expect(html).not.toContain('TransitionOptions');
+        expect(html).toBe(`<p-message [severity]="'info'"></p-message>\n`);
+    });
+
     it('does not remove a similarly-named attribute on an unrelated selector', async () => {
         const runner = createMigrationRunner();
         const content = `<p-other showTransformOptions="x"></p-other>\n`;

--- a/packages/optimus-ui/schematics/test/styleclass-to-class.spec.ts
+++ b/packages/optimus-ui/schematics/test/styleclass-to-class.spec.ts
@@ -177,6 +177,24 @@ describe('styleclass-to-class', () => {
         expect(result.readContent('/dist/app/tpl.html')).toBe(content);
     });
 
+    it('rewrites a static styleClass to class on p-message', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-message severity="error" styleClass="my-message"></p-message>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-message severity="error" class="my-message"></p-message>\n`);
+    });
+
+    it('rewrites a bound [styleClass] to [class] on p-message', async () => {
+        const runner = createMigrationRunner();
+        const tree = createAppTree({
+            '/src/app/app.html': `<p-message [styleClass]="myClass"></p-message>\n`
+        });
+        const result = await runner.runSchematic('styleclass-to-class', {}, tree);
+        expect(result.readContent('/src/app/app.html')).toBe(`<p-message [class]="myClass"></p-message>\n`);
+    });
+
     it('reports nothing on a workspace with no usage of styleClass on the migrated selectors', async () => {
         const runner = createMigrationRunner();
         const infos: string[] = [];

--- a/packages/optimus-ui/src/message/message.test.ts
+++ b/packages/optimus-ui/src/message/message.test.ts
@@ -11,22 +11,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
     changeDetection: ChangeDetectionStrategy.Eager,
     standalone: false,
     template: `
-        <p-message
-            [severity]="severity"
-            [text]="text"
-            [escape]="escape"
-            [style]="style"
-            [styleClass]="styleClass"
-            [closable]="closable"
-            [icon]="icon"
-            [closeIcon]="closeIcon"
-            [life]="life"
-            [showTransitionOptions]="showTransitionOptions"
-            [hideTransitionOptions]="hideTransitionOptions"
-            [size]="size"
-            [variant]="variant"
-            (onClose)="onClose($event)"
-        >
+        <p-message [severity]="severity" [text]="text" [escape]="escape" [style]="style" [closable]="closable" [icon]="icon" [closeIcon]="closeIcon" [life]="life" [size]="size" [variant]="variant" (onClose)="onClose($event)">
             <div class="message-content">{{ content }}</div>
         </p-message>
     `
@@ -36,13 +21,10 @@ class TestBasicMessageComponent {
     text: string | undefined;
     escape = true;
     style: { [klass: string]: any } | null | undefined = null as any;
-    styleClass: string | undefined;
     closable = false;
     icon: string | undefined;
     closeIcon: string | undefined;
     life: number | undefined;
-    showTransitionOptions = '300ms ease-out';
-    hideTransitionOptions = '200ms cubic-bezier(0.86, 0, 0.07, 1)';
     size: 'large' | 'small' | undefined;
     variant: 'outlined' | 'text' | 'simple' | undefined;
     content = 'Test Message Content';
@@ -148,11 +130,9 @@ describe('Message', () => {
 
         it('should have default values', () => {
             const messageInstance = messageEl.componentInstance as Message;
-            expect(messageInstance.severity).toBe('info');
-            expect(messageInstance.escape).toBe(true);
-            expect(messageInstance.closable).toBe(false);
-            expect(messageInstance.showTransitionOptions).toBe('300ms ease-out');
-            expect(messageInstance.hideTransitionOptions).toBe('200ms cubic-bezier(0.86, 0, 0.07, 1)');
+            expect(messageInstance.severity()).toBe('info');
+            expect(messageInstance.escape()).toBe(true);
+            expect(messageInstance.closable()).toBe(false);
             expect(messageInstance.visible()).toBe(true);
         });
 
@@ -170,14 +150,14 @@ describe('Message', () => {
             fixture.detectChanges();
 
             const messageInstance = messageEl.componentInstance as Message;
-            expect(messageInstance.severity).toBe('error');
-            expect(messageInstance.text).toBe('Error message');
-            expect(messageInstance.escape).toBe(false);
-            expect(messageInstance.closable).toBe(true);
-            expect(messageInstance.icon).toBe('pi pi-exclamation-triangle');
-            expect(messageInstance.closeIcon).toBe('pi pi-times');
-            expect(messageInstance.size).toBe('large');
-            expect(messageInstance.variant).toBe('outlined');
+            expect(messageInstance.severity()).toBe('error');
+            expect(messageInstance.text()).toBe('Error message');
+            expect(messageInstance.escape()).toBe(false);
+            expect(messageInstance.closable()).toBe(true);
+            expect(messageInstance.icon()).toBe('pi pi-exclamation-triangle');
+            expect(messageInstance.closeIcon()).toBe('pi pi-times');
+            expect(messageInstance.size()).toBe('large');
+            expect(messageInstance.variant()).toBe('outlined');
         });
 
         it('should render with correct ARIA attributes', () => {
@@ -360,7 +340,7 @@ describe('Message', () => {
 
                 const messageEl = fixture.debugElement.query(By.css('p-message'));
                 const messageInstance = messageEl.componentInstance as Message;
-                expect(messageInstance.severity).toBe(severity);
+                expect(messageInstance.severity()).toBe(severity);
             }
         });
 
@@ -504,11 +484,8 @@ describe('Message', () => {
             const messageEl = fixture.debugElement.query(By.css('p-message'));
             const messageInstance = messageEl.componentInstance as Message;
 
-            // Spy on close method before ngAfterContentInit
             vi.spyOn(messageInstance, 'close').mockImplementation(() => {});
 
-            // Trigger ngAfterContentInit to process templates
-            messageInstance.ngAfterContentInit();
             await fixture.whenStable();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
@@ -570,28 +547,25 @@ describe('Message', () => {
             fixture.detectChanges();
         });
 
-        it('should process pTemplate container in ngAfterContentInit', () => {
+        it('should resolve pTemplate container template', () => {
             const messageEl = fixture.debugElement.query(By.css('p-message'));
             const messageInstance = messageEl.componentInstance as Message;
 
-            messageInstance.ngAfterContentInit();
-            expect(messageInstance._containerTemplate).toBeTruthy();
+            expect(messageInstance._containerTemplate()).toBeTruthy();
         });
 
-        it('should process pTemplate icon in ngAfterContentInit', () => {
+        it('should resolve pTemplate icon template', () => {
             const messageEl = fixture.debugElement.query(By.css('p-message'));
             const messageInstance = messageEl.componentInstance as Message;
 
-            messageInstance.ngAfterContentInit();
-            expect(messageInstance._iconTemplate).toBeTruthy();
+            expect(messageInstance._iconTemplate()).toBeTruthy();
         });
 
-        it('should process pTemplate closeicon in ngAfterContentInit', () => {
+        it('should resolve pTemplate closeicon template', () => {
             const messageEl = fixture.debugElement.query(By.css('p-message'));
             const messageInstance = messageEl.componentInstance as Message;
 
-            messageInstance.ngAfterContentInit();
-            expect(messageInstance._closeIconTemplate).toBeTruthy();
+            expect(messageInstance._closeIconTemplate()).toBeTruthy();
         });
 
         it('should render pTemplate content correctly', async () => {
@@ -616,11 +590,8 @@ describe('Message', () => {
             const messageEl = fixture.debugElement.query(By.css('p-message'));
             const messageInstance = messageEl.componentInstance as Message;
 
-            // Spy on close method before ngAfterContentInit
             vi.spyOn(messageInstance, 'close').mockImplementation(() => {});
 
-            // Trigger ngAfterContentInit to process templates
-            messageInstance.ngAfterContentInit();
             await fixture.whenStable();
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
@@ -652,12 +623,28 @@ describe('Message', () => {
             component = fixture.componentInstance;
         });
 
-        it('should apply styleClass correctly', () => {
-            component.styleClass = 'custom-message-class';
-            fixture.detectChanges();
+        it('should apply custom class via native class binding', async () => {
+            @Component({
+                changeDetection: ChangeDetectionStrategy.Eager,
+                standalone: false,
+                template: ` <p-message [class]="customClass"></p-message> `
+            })
+            class TestMessageClassComponent {
+                customClass = 'custom-message-class';
+            }
 
-            const messageDiv = fixture.debugElement.query(By.css('.p-message'));
-            expect(messageDiv.nativeElement.classList).toContain('custom-message-class');
+            await TestBed.resetTestingModule();
+            await TestBed.configureTestingModule({
+                imports: [CommonModule, Message, SharedModule, PrimeTemplate],
+                declarations: [TestMessageClassComponent],
+                providers: [provideZonelessChangeDetection()]
+            }).compileComponents();
+
+            const classFixture = TestBed.createComponent(TestMessageClassComponent);
+            classFixture.detectChanges();
+
+            const messageEl = classFixture.debugElement.query(By.css('p-message'));
+            expect(messageEl.nativeElement.classList.contains('custom-message-class')).toBe(true);
         });
 
         it('should apply custom styles', () => {
@@ -667,12 +654,12 @@ describe('Message', () => {
             const messageEl = fixture.debugElement.query(By.css('p-message'));
             const messageInstance = messageEl.componentInstance as Message;
 
-            expect(messageInstance.style).toEqual({ border: '2px solid red', padding: '10px' });
+            expect(messageInstance.style()).toEqual({ border: '2px solid red', padding: '10px' });
 
             // Verify component received the style input
-            expect(messageInstance.style).toBeTruthy();
-            expect(Object.keys(messageInstance.style!)).toContain('border');
-            expect(Object.keys(messageInstance.style!)).toContain('padding');
+            expect(messageInstance.style()).toBeTruthy();
+            expect(Object.keys(messageInstance.style()!)).toContain('border');
+            expect(Object.keys(messageInstance.style()!)).toContain('padding');
         });
 
         it('should apply size classes', async () => {
@@ -683,13 +670,13 @@ describe('Message', () => {
 
             const messageEl = fixture.debugElement.query(By.css('p-message'));
             const messageInstance = messageEl.componentInstance as Message;
-            expect(messageInstance.size).toBe('large');
+            expect(messageInstance.size()).toBe('large');
 
             component.size = 'small';
             fixture.changeDetectorRef.markForCheck();
             await fixture.whenStable();
             fixture.detectChanges();
-            expect(messageInstance.size).toBe('small');
+            expect(messageInstance.size()).toBe('small');
         });
 
         it('should apply variant classes', async () => {
@@ -703,7 +690,7 @@ describe('Message', () => {
 
                 const messageEl = fixture.debugElement.query(By.css('p-message'));
                 const messageInstance = messageEl.componentInstance as Message;
-                expect(messageInstance.variant).toBe(variant);
+                expect(messageInstance.variant()).toBe(variant);
             }
         });
     });
@@ -773,7 +760,6 @@ describe('Message', () => {
             component.icon = undefined as any;
             component.closeIcon = undefined as any;
             component.style = null as any;
-            component.styleClass = undefined as any;
             fixture.detectChanges();
 
             const messageDiv = fixture.debugElement.query(By.css('.p-message'));
@@ -825,8 +811,8 @@ describe('Message', () => {
             const message1 = fixture.debugElement.query(By.css('p-message')).componentInstance as Message;
             const message2 = fixture2.debugElement.query(By.css('p-message')).componentInstance as Message;
 
-            expect(message1.severity).toBe('error');
-            expect(message2.severity).toBe('success');
+            expect(message1.severity()).toBe('error');
+            expect(message2.severity()).toBe('success');
         });
 
         it('should handle life property with zero value', async () => {
@@ -1211,8 +1197,8 @@ describe('Message', () => {
                 root: ({ instance }: any) => {
                     return {
                         class: {
-                            SEVERITY_ERROR: instance?.severity === 'error',
-                            SEVERITY_SUCCESS: instance?.severity === 'success'
+                            SEVERITY_ERROR: instance?.severity() === 'error',
+                            SEVERITY_SUCCESS: instance?.severity() === 'success'
                         }
                     };
                 }
@@ -1232,7 +1218,7 @@ describe('Message', () => {
                 content: ({ instance }: any) => {
                     return {
                         style: {
-                            'background-color': instance?.closable ? 'yellow' : 'gray'
+                            'background-color': instance?.closable() ? 'yellow' : 'gray'
                         }
                     };
                 }
@@ -1249,7 +1235,7 @@ describe('Message', () => {
             fixture.componentRef.setInput('pt', {
                 text: ({ instance }: any) => {
                     return {
-                        class: instance?.escape ? 'ESCAPED_TEXT' : 'UNESCAPED_TEXT'
+                        class: instance?.escape() ? 'ESCAPED_TEXT' : 'UNESCAPED_TEXT'
                     };
                 }
             });
@@ -1265,8 +1251,8 @@ describe('Message', () => {
             fixture.componentRef.setInput('pt', {
                 closeButton: ({ instance }: any) => {
                     return {
-                        'data-closable': instance?.closable,
-                        'data-severity': instance?.severity
+                        'data-closable': instance?.closable(),
+                        'data-severity': instance?.severity()
                     };
                 }
             });
@@ -1285,7 +1271,7 @@ describe('Message', () => {
                 icon: ({ instance }: any) => {
                     return {
                         style: {
-                            'font-size': instance?.size === 'large' ? '24px' : '16px'
+                            'font-size': instance?.size() === 'large' ? '24px' : '16px'
                         }
                     };
                 }
@@ -1339,14 +1325,13 @@ describe('Message', () => {
 
         it('should bind onclick event to root element via pt', async () => {
             let clickedInstance: any = null;
+            const onclick = () => {
+                clickedInstance = fixture.componentInstance;
+            };
 
             fixture.componentRef.setInput('pt', {
-                root: ({ instance }: any) => {
-                    return {
-                        onclick: () => {
-                            clickedInstance = instance;
-                        }
-                    };
+                root: () => {
+                    return { onclick };
                 }
             });
             fixture.componentRef.setInput('text', 'Test');
@@ -1392,17 +1377,16 @@ describe('Message', () => {
         it('should bind onmouseenter and onmouseleave events via pt', async () => {
             let mouseEntered = false;
             let mouseLeft = false;
+            const onmouseenter = () => {
+                mouseEntered = true;
+            };
+            const onmouseleave = () => {
+                mouseLeft = true;
+            };
 
             fixture.componentRef.setInput('pt', {
                 root: () => {
-                    return {
-                        onmouseenter: () => {
-                            mouseEntered = true;
-                        },
-                        onmouseleave: () => {
-                            mouseLeft = true;
-                        }
-                    };
+                    return { onmouseenter, onmouseleave };
                 }
             });
             fixture.componentRef.setInput('text', 'Test');

--- a/packages/optimus-ui/src/message/message.ts
+++ b/packages/optimus-ui/src/message/message.ts
@@ -1,10 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, InjectionToken, input, Input, NgModule, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren, output } from '@angular/core';
+import { afterEveryRender, booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, InjectionToken, input, NgModule, signal, TemplateRef, ViewEncapsulation, contentChild, contentChildren, output } from '@angular/core';
 import { MotionOptions } from '@openng/optimus-ui-motion';
 import { PrimeTemplate, SharedModule } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
 import { Bind } from '@openng/optimus-ui/bind';
-import { TimesIcon } from '@openng/optimus-ui/icons';
 import { MotionModule } from '@openng/optimus-ui/motion';
 import { Ripple } from '@openng/optimus-ui/ripple';
 import { MessageContainerTemplateContext, MessagePassThrough, MessageSeverity } from '@openng/optimus-ui/types/message';
@@ -18,47 +17,46 @@ const MESSAGE_INSTANCE = new InjectionToken<Message>('MESSAGE_INSTANCE');
  */
 @Component({
     selector: 'p-message',
-    standalone: true,
-    imports: [CommonModule, TimesIcon, Ripple, SharedModule, Bind, MotionModule],
+    imports: [CommonModule, Ripple, SharedModule, Bind, MotionModule],
     template: `
-        <div [pBind]="ptm('contentWrapper')" [class]="cx('contentWrapper')" [attr.data-p]="dataP">
-            <div [pBind]="ptm('content')" [class]="cx('content')" [attr.data-p]="dataP">
-                @if (iconTemplate() || _iconTemplate) {
-                    <ng-container *ngTemplateOutlet="iconTemplate() || _iconTemplate"></ng-container>
+        <div [pBind]="ptm('contentWrapper')" [class]="cx('contentWrapper')" [attr.data-p]="dataP()">
+            <div [pBind]="ptm('content')" [class]="cx('content')" [attr.data-p]="dataP()">
+                @if (iconTemplate() || _iconTemplate()) {
+                    <ng-container *ngTemplateOutlet="iconTemplate() || _iconTemplate()"></ng-container>
                 }
-                @if (icon) {
-                    <i [pBind]="ptm('icon')" [class]="cn(cx('icon'), icon)" [attr.data-p]="dataP"></i>
+                @if (icon()) {
+                    <i [pBind]="ptm('icon')" [class]="cn(cx('icon'), icon())" [attr.data-p]="dataP()"></i>
                 }
 
-                @if (containerTemplate() || _containerTemplate) {
-                    <ng-container *ngTemplateOutlet="containerTemplate() || _containerTemplate; context: { closeCallback: closeCallback }"></ng-container>
+                @if (containerTemplate() || _containerTemplate()) {
+                    <ng-container *ngTemplateOutlet="containerTemplate() || _containerTemplate(); context: { closeCallback: closeCallback }"></ng-container>
                 } @else {
-                    @if (!escape) {
+                    @if (!escape()) {
                         <div>
-                            @if (!escape) {
-                                <span [pBind]="ptm('text')" [ngClass]="cx('text')" [innerHTML]="text" [attr.data-p]="dataP"></span>
+                            @if (!escape()) {
+                                <span [pBind]="ptm('text')" [ngClass]="cx('text')" [innerHTML]="text()" [attr.data-p]="dataP()"></span>
                             }
                         </div>
                     } @else {
-                        @if (escape && text) {
-                            <span [pBind]="ptm('text')" [ngClass]="cx('text')" [attr.data-p]="dataP">{{ text }}</span>
+                        @if (escape() && text()) {
+                            <span [pBind]="ptm('text')" [ngClass]="cx('text')" [attr.data-p]="dataP()">{{ text() }}</span>
                         }
                     }
 
-                    <span [pBind]="ptm('text')" [ngClass]="cx('text')" [attr.data-p]="dataP">
+                    <span [pBind]="ptm('text')" [ngClass]="cx('text')" [attr.data-p]="dataP()">
                         <ng-content></ng-content>
                     </span>
                 }
-                @if (closable) {
-                    <button [pBind]="ptm('closeButton')" pRipple type="button" [class]="cx('closeButton')" (click)="close($event)" [attr.aria-label]="closeAriaLabel" [attr.data-p]="dataP">
-                        @if (closeIcon) {
-                            <i [pBind]="ptm('closeIcon')" [class]="cn(cx('closeIcon'), closeIcon)" [ngClass]="closeIcon" [attr.data-p]="dataP"></i>
+                @if (closable()) {
+                    <button [pBind]="ptm('closeButton')" pRipple type="button" [class]="cx('closeButton')" (click)="close($event)" [attr.aria-label]="closeAriaLabel()" [attr.data-p]="dataP()">
+                        @if (closeIcon()) {
+                            <i [pBind]="ptm('closeIcon')" [class]="cn(cx('closeIcon'), closeIcon())" [ngClass]="closeIcon()" [attr.data-p]="dataP()"></i>
                         }
-                        @if (closeIconTemplate() || _closeIconTemplate) {
-                            <ng-container *ngTemplateOutlet="closeIconTemplate() || _closeIconTemplate"></ng-container>
+                        @if (closeIconTemplate() || _closeIconTemplate()) {
+                            <ng-container *ngTemplateOutlet="closeIconTemplate() || _closeIconTemplate()"></ng-container>
                         }
-                        @if (!closeIconTemplate() && !_closeIconTemplate && !closeIcon) {
-                            <svg [pBind]="ptm('closeIcon')" data-p-icon="times" [class]="cx('closeIcon')" [attr.data-p]="dataP" />
+                        @if (!closeIconTemplate() && !_closeIconTemplate() && !closeIcon()) {
+                            <svg [pBind]="ptm('closeIcon')" data-p-icon="times" [class]="cx('closeIcon')" [attr.data-p]="dataP()" />
                         }
                     </button>
                 }
@@ -70,10 +68,10 @@ const MESSAGE_INSTANCE = new InjectionToken<Message>('MESSAGE_INSTANCE');
     providers: [MessageStyle, { provide: MESSAGE_INSTANCE, useExisting: Message }, { provide: PARENT_INSTANCE, useExisting: Message }],
     hostDirectives: [Bind],
     host: {
-        '[attr.data-p]': 'dataP',
+        '[attr.data-p]': 'dataP()',
         role: 'alert',
         'aria-live': 'polite',
-        '[class]': 'cn(cx("root"), styleClass)',
+        '[class]': 'cx("root")',
         '[animate.enter]': '"p-message-enter-active"',
         '[animate.leave]': '"p-message-leave-active"',
         '[class.p-message-leave-active]': '!visible()'
@@ -88,8 +86,12 @@ export class Message extends BaseComponent<MessagePassThrough> {
 
     $pcMessage: Message | undefined = inject(MESSAGE_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
 
-    onAfterViewChecked(): void {
-        this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
+    constructor() {
+        super();
+
+        afterEveryRender(() => {
+            this.bindDirectiveInstance.setAttrs(this.ptms(['host', 'root']));
+        });
     }
 
     /**
@@ -97,76 +99,57 @@ export class Message extends BaseComponent<MessagePassThrough> {
      * @defaultValue 'info'
      * @group Props
      */
-    @Input() severity: MessageSeverity | undefined | null = 'info';
+    severity = input<MessageSeverity | undefined | null>('info');
     /**
      * Text content.
      * @deprecated since v20.0.0. Use content projection instead '<p-message>Content</p-message>'.
      * @group Props
      */
-    @Input() text: string | undefined;
+    text = input<string | undefined>();
     /**
      * Whether displaying messages would be escaped or not.
      * @deprecated since v20.0.0. Use content projection instead '<p-message>Content</p-message>'.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) escape: boolean = true;
+    escape = input(true, { transform: booleanAttribute });
     /**
      * Inline style of the component.
      * @group Props
      */
-    @Input() style: { [klass: string]: any } | null | undefined;
-    /**
-     * Style class of the component.
-     * @group Props
-     */
-    @Input() styleClass: string | undefined;
+    style = input<{ [klass: string]: any } | null | undefined>();
     /**
      * Whether the message can be closed manually using the close icon.
      * @group Props
      * @defaultValue false
      */
-    @Input({ transform: booleanAttribute }) closable: boolean = false;
+    closable = input(false, { transform: booleanAttribute });
     /**
      * Icon to display in the message.
      * @group Props
      * @defaultValue undefined
      */
-    @Input() icon: string | undefined;
+    icon = input<string | undefined>();
     /**
      * Icon to display in the message close button.
      * @group Props
      * @defaultValue undefined
      */
-    @Input() closeIcon: string | undefined;
+    closeIcon = input<string | undefined>();
     /**
      * Delay in milliseconds to close the message automatically.
      * @defaultValue undefined
      */
-    @Input() life: number | undefined;
-    /**
-     * Transition options of the show animation.
-     * @defaultValue '300ms ease-out'
-     * @group Props
-     * @deprecated since v21.0.0, use `motionOptions` instead.
-     */
-    @Input() showTransitionOptions: string = '300ms ease-out';
-    /**
-     * Transition options of the hide animation.
-     * @defaultValue '200ms cubic-bezier(0.86, 0, 0.07, 1)'
-     * @group Props
-     * @deprecated since v21.0.0, use `motionOptions` instead.
-     */
-    @Input() hideTransitionOptions: string = '200ms cubic-bezier(0.86, 0, 0.07, 1)';
+    life = input<number | undefined>();
     /**
      * Defines the size of the component.
      * @group Props
      */
-    @Input() size: 'large' | 'small' | undefined;
+    size = input<'large' | 'small' | undefined>();
     /**
      * Specifies the input variant of the component.
      * @group Props
      */
-    @Input() variant: 'outlined' | 'text' | 'simple' | undefined;
+    variant = input<'outlined' | 'text' | 'simple' | undefined>();
     /**
      * The motion options.
      * @group Props
@@ -188,7 +171,7 @@ export class Message extends BaseComponent<MessagePassThrough> {
         originalEvent: Event;
     }>();
 
-    get closeAriaLabel() {
+    closeAriaLabel() {
         return this.config.translation.aria ? this.config.translation.aria.close : undefined;
     }
 
@@ -216,40 +199,37 @@ export class Message extends BaseComponent<MessagePassThrough> {
 
     readonly templates = contentChildren(PrimeTemplate);
 
-    _containerTemplate: TemplateRef<MessageContainerTemplateContext> | undefined;
+    _containerTemplate = computed<TemplateRef<MessageContainerTemplateContext> | undefined>(
+        () =>
+            this.templates()
+                ?.filter((item) => item.getType() === 'container')
+                .at(-1)?.template
+    );
 
-    _iconTemplate: TemplateRef<void> | undefined;
+    _iconTemplate = computed<TemplateRef<void> | undefined>(
+        () =>
+            this.templates()
+                ?.filter((item) => item.getType() === 'icon')
+                .at(-1)?.template
+    );
 
-    _closeIconTemplate: TemplateRef<void> | undefined;
+    _closeIconTemplate = computed<TemplateRef<void> | undefined>(
+        () =>
+            this.templates()
+                ?.filter((item) => item.getType() === 'closeicon')
+                .at(-1)?.template
+    );
 
     closeCallback = (event: Event) => {
         this.close(event);
     };
 
     onInit() {
-        if (this.life) {
+        if (this.life()) {
             setTimeout(() => {
                 this.visible.set(false);
-            }, this.life);
+            }, this.life());
         }
-    }
-
-    onAfterContentInit() {
-        this.templates()?.forEach((item) => {
-            switch (item.getType()) {
-                case 'container':
-                    this._containerTemplate = item.template;
-                    break;
-
-                case 'icon':
-                    this._iconTemplate = item.template;
-                    break;
-
-                case 'closeicon':
-                    this._closeIconTemplate = item.template;
-                    break;
-            }
-        });
     }
 
     /**
@@ -262,14 +242,14 @@ export class Message extends BaseComponent<MessagePassThrough> {
         this.onClose.emit({ originalEvent: event });
     }
 
-    get dataP() {
-        return this.cn({
-            outlined: this.variant === 'outlined',
-            simple: this.variant === 'simple',
-            [this.severity as string]: this.severity,
-            [this.size as string]: this.size
-        });
-    }
+    dataP = computed(() =>
+        this.cn({
+            outlined: this.variant() === 'outlined',
+            simple: this.variant() === 'simple',
+            [this.severity() as string]: this.severity(),
+            [this.size() as string]: this.size()
+        })
+    );
 }
 
 @NgModule({

--- a/packages/optimus-ui/src/message/style/messagestyle.ts
+++ b/packages/optimus-ui/src/message/style/messagestyle.ts
@@ -3,7 +3,7 @@ import { style } from '@openng/optimus-ui-styles/message';
 import { BaseStyle } from '@openng/optimus-ui/base';
 
 const classes = {
-    root: ({ instance }) => ['p-message p-component p-message-' + instance.severity, instance.variant && 'p-message-' + instance.variant, { 'p-message-sm': instance.size === 'small', 'p-message-lg': instance.size === 'large' }],
+    root: ({ instance }) => ['p-message p-component p-message-' + instance.severity(), instance.variant() && 'p-message-' + instance.variant(), { 'p-message-sm': instance.size() === 'small', 'p-message-lg': instance.size() === 'large' }],
     contentWrapper: 'p-message-content-wrapper',
     content: 'p-message-content',
     icon: 'p-message-icon',


### PR DESCRIPTION
## Description

## Summary

Hand-migrates the `Message` component (`p-message`) to the Angular Signals API, then removes its `styleClass` input in favor of the native `class`/`[class]` attribute — matching the pattern already established for `Toast`.

## Changes

### Signals migration (`message.ts`, `message/style/messagestyle.ts`)
- All `@Input()`s converted to `input()`, including `escape`/`closable` (kept `{ transform: booleanAttribute }`).
- `onAfterContentInit()` removed; `_containerTemplate`/`_iconTemplate`/`_closeIconTemplate` are now `computed()` fields derived from `templates()`.
- `onAfterViewChecked()` replaced with `afterEveryRender()` in a new constructor.
- `get dataP()` converted to `computed()`.
- `closeAriaLabel()` kept as a **plain method**, not `computed()` — it reads `config.translation.aria`, which is a plain mutable (non-signal) property, so a `computed()` would cache stale translations forever. Matches the existing precedent in `carousel.ts`.
- `messagestyle.ts`: `instance.severity`/`variant`/`size` reads updated to call the new signals.

### Dead code removed
- `showTransitionOptions` / `hideTransitionOptions` (`@deprecated`, unused since the show/hide animation moved to native `[animate.enter]`/`[animate.leave]`) deleted outright.
- New `remove-dead-inputs` schematic entry for `p-message` so any consumer templates still binding these get them stripped automatically via `ng update`.

### `styleClass` removed
- Dropped the `styleClass` input entirely; host binding simplified from `'cn(cx("root"), styleClass())'` to `'cx("root")'`. Angular already merges a component's host `[class]` binding with a caller's own `class`/`[class]`, so the extra input was redundant.
- Fixed the two doc usages that relied on it: `apps/docs/doc/message/form-doc.ts` and `apps/docs/doc/message/icon-doc.ts` (`styleClass="..."` → `class="..."`).
- Extended the `styleclass-to-class` ng-update schematic's `MIGRATED_SELECTORS` to include `p-message` (previously only covered `p-toast`), so external consumers upgrading get an automatic `styleClass` → `class` rewrite.

## Related issues

<!-- Link issues this PR addresses, e.g. Fixes #123, Closes #456, or Relates to #789 -->

Fixes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

<!-- If this is a breaking change, describe what changed and how consumers should migrate. Otherwise, write "None". -->

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [ ] `npm run build`
- [ ] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [ ] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

<!-- Screenshots, StackBlitz links, SSR/zoneless notes, or anything else reviewers should know. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added migration tools for converting `styleClass` bindings, removing obsolete inputs and outputs, and identifying code requiring manual review.
  - Updated components across the library to use modern Angular signal-based inputs, queries, and event outputs.

- **Breaking Changes**
  - Motion lifecycle callbacks now require a motion event.
  - Removed legacy overlay animation callbacks and several obsolete component inputs, outputs, and template declarations.

- **Tests**
  - Expanded coverage for signal queries, migrations, component events, templates, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->