### PR TITLE
fix(schematics): correct PrimeNG migration command guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Full setup, including the manual path and icons, is in the [getting started guid
 
 ```bash
 npm install @openng/optimus-ui@1
-ng generate @openng/optimus-ui@1:migrate-from-primeng
+ng generate @openng/optimus-ui:migrate-from-primeng
 ```
 
 See the [migration guide](https://v1.optimus.openng.org/migration/primeng) for prerequisites and the manual cases. If you are on PrimeNG v20 or older, upgrade to v21 first.

--- a/packages/optimus-ui/README.md
+++ b/packages/optimus-ui/README.md
@@ -43,7 +43,7 @@ Optimus UI is API-compatible with PrimeNG v21. On a PrimeNG v21 workspace, run t
 migration schematic:
 
 ```bash
-ng generate @openng/optimus-ui@1:migrate-from-primeng          # options: --skip-install, --force
+ng generate @openng/optimus-ui:migrate-from-primeng          # options: --skip-install, --force
 ```
 
 This replaces `primeng` and `@primeuix/*` dependencies with their `@openng` counterparts, rewrites

--- a/packages/optimus-ui/schematics/migrate-from-primeng/index.ts
+++ b/packages/optimus-ui/schematics/migrate-from-primeng/index.ts
@@ -31,7 +31,7 @@ const LOCKFILE_NAMES = new Set(['package-lock.json', 'npm-shrinkwrap.json', 'yar
  *
  * @deprecated This schematic is only maintained on the `release/1.x` line (the `@openng/optimus-ui@1`
  * package, published to v1.optimus.openng.org). It is not actively maintained on `main` going forward.
- * Run it via `ng generate @openng/optimus-ui@1:migrate-from-primeng` rather than an unpinned install.
+ * Install `@openng/optimus-ui@1`, then run `ng generate @openng/optimus-ui:migrate-from-primeng`.
  */
 export function migrateFromPrimeng(options: Schema): Rule {
     return (tree: Tree, context: SchematicContext) => {
@@ -100,7 +100,7 @@ function warnDeprecated(context: SchematicContext): void {
         'migrate-from-primeng is deprecated on this line of @openng/optimus-ui and is only maintained on release/1.x. ' +
             'Run it via the pinned v1 package instead:\n' +
             '  npm install @openng/optimus-ui@1\n' +
-            '  ng generate @openng/optimus-ui@1:migrate-from-primeng'
+            '  ng generate @openng/optimus-ui:migrate-from-primeng'
     );
 }
 

--- a/packages/optimus-ui/schematics/ng-add/index.ts
+++ b/packages/optimus-ui/schematics/ng-add/index.ts
@@ -9,7 +9,7 @@ import { Schema, Theme } from './schema';
 
 const THEMES_PACKAGE = '@openng/optimus-ui-themes';
 const DEFAULT_THEME: Theme = 'Aura';
-const MIGRATE_COMMAND = 'ng generate @openng/optimus-ui@1:migrate-from-primeng';
+const MIGRATE_COMMAND = 'ng generate @openng/optimus-ui:migrate-from-primeng';
 
 function projectNotFound(name: string): string {
     return `Project "${name}" was not found in the workspace.`;
@@ -47,7 +47,7 @@ function manualInstructions(theme: Theme): string {
 /**
  * Sets up Optimus UI in a fresh (non-PrimeNG) project. Migrating an existing PrimeNG workspace is
  * a separate concern handled by the `migrate-from-primeng` schematic
- * (`ng generate @openng/optimus-ui@1:migrate-from-primeng`) — when primeng is detected, ng-add
+ * (`ng generate @openng/optimus-ui:migrate-from-primeng`) — when primeng is detected, ng-add
  * makes no changes and throws, so the CLI reports the refusal as a failure (#1447). A warning was
  * not enough: the command exited 0 after asking for a theme preset it then discarded, which reads
  * as a successful setup, and the freshly-installed dependency in package.json reinforces that.

--- a/packages/optimus-ui/schematics/test/ng-add.spec.ts
+++ b/packages/optimus-ui/schematics/test/ng-add.spec.ts
@@ -120,7 +120,7 @@ describe('ng-add', () => {
         expect(error).toBeInstanceOf(SchematicsException);
         expect(error!.message).toContain('primeng detected');
         expect(error!.message).toContain('no changes were made');
-        expect(error!.message).toContain('ng generate @openng/optimus-ui@1:migrate-from-primeng');
+        expect(error!.message).toContain('ng generate @openng/optimus-ui:migrate-from-primeng');
         expect(error!.message).toContain('already added @openng/optimus-ui to your dependencies');
     });
 
@@ -235,7 +235,7 @@ describe('ng-add', () => {
         expect(result.readContent('/src/app/app.config.ts')).toBe(primengConfig);
         const log = logs.join('\n');
         expect(log).toContain('Found a providePrimeNG call in /src/app/app.config.ts');
-        expect(log).toContain('ng generate @openng/optimus-ui@1:migrate-from-primeng');
+        expect(log).toContain('ng generate @openng/optimus-ui:migrate-from-primeng');
         expect(log).toContain('provideOptimus({ theme: { preset: Aura } })');
         expect(log).not.toContain('Added provideOptimus');
     });


### PR DESCRIPTION
## Description

The documented command `ng generate @openng/optimus-ui@1:migrate-from-primeng` fails with `Collection "@openng/optimus-ui@1" cannot be resolved`, even after installing Optimus UI v1. Angular CLI resolves an installed collection name here, not an npm package version specification.

Remove `@1` from the generate command in both READMEs, the corresponding TypeDoc metadata, and schematic guidance. Keep the `npm install @openng/optimus-ui@1` pin. Update the existing ng-add test expectations to match the corrected guidance.

Correct sequence:
```bash
npm install @openng/optimus-ui@1
ng generate @openng/optimus-ui:migrate-from-primeng
```

## Related issues

No existing issue found for this exact error. The v1 migration guide requires a companion change targeting `release/1.x`.

## Type of change

- [x] Bug fix: documentation and CLI guidance
- [x] Documentation updated

## Breaking changes

None. Migration behavior is unchanged.

## Test plan

- Confirmed the corrected command successfully migrates an Angular 21 / PrimeNG 21 application with Optimus UI 1.0.2.
- Built the schematics and ran all 134 schematic tests successfully using Node 24 and available Angular 21 tooling (not a full Angular 22 workspace validation).
- Reviewed the six-file diff in GitHub; changes are limited to command guidance and matching assertions.
- Lint could not start: the repository command uses `--ignore-path`, which ESLint flat-config mode rejects.
- The broader unit-test command triggered dependency installation, which failed on registry access; it was stopped. Full build/unit validation remains for CI.

## Additional context

Prepared with AI assistance and reviewed against the reported failure and GitHub diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PrimeNG migration instructions to use the package-installed `@openng/optimus-ui:migrate-from-primeng` command without a version suffix.
  * Aligned migration guidance across project documentation, generated API documentation, and setup instructions.

* **Bug Fixes**
  * Updated migration prompts and deprecation warnings to display the correct unversioned command.
  * Updated related validation to reflect the current migration command format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->