### PR TITLE
docs: correct v1 PrimeNG migration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Full setup, including the manual path and icons, is in the [getting started guid
 
 ```bash
 npm install @openng/optimus-ui@1
-ng generate @openng/optimus-ui@1:migrate-from-primeng
+ng generate @openng/optimus-ui:migrate-from-primeng
 ```
 
 The `@1` pin matters: this repo's `latest` npm tag points at the current major, not this one. Once migrated, `ng update` moves you to a newer major when you're ready — see the [update guide](https://optimus.openng.org/migration/update).

--- a/apps/docs/doc/migration/primeng/automated-doc.ts
+++ b/apps/docs/doc/migration/primeng/automated-doc.ts
@@ -31,11 +31,11 @@ import { AppCode } from '@/components/doc/app.code';
 export class AutomatedDoc {
     migrateCode: Code = {
         command: `npm install @openng/optimus-ui@1
-ng generate @openng/optimus-ui@1:migrate-from-primeng`
+ng generate @openng/optimus-ui:migrate-from-primeng`
     };
 
     flagsCode: Code = {
-        command: `ng generate @openng/optimus-ui@1:migrate-from-primeng --skip-install
-ng generate @openng/optimus-ui@1:migrate-from-primeng --force`
+        command: `ng generate @openng/optimus-ui:migrate-from-primeng --skip-install
+ng generate @openng/optimus-ui:migrate-from-primeng --force`
     };
 }

--- a/packages/optimus-ui/README.md
+++ b/packages/optimus-ui/README.md
@@ -42,7 +42,7 @@ migration schematic:
 
 ```bash
 npm install @openng/optimus-ui@1
-ng generate @openng/optimus-ui@1:migrate-from-primeng          # options: --skip-install, --force
+ng generate @openng/optimus-ui:migrate-from-primeng          # options: --skip-install, --force
 ```
 
 The `@1` pin matters: this repo's `latest` npm tag points at the current major, not this one.


### PR DESCRIPTION
## Description

The v1 PrimeNG migration guide instructs users to run `ng generate @openng/optimus-ui@1:migrate-from-primeng`. This fails with `Collection "@openng/optimus-ui@1" cannot be resolved` after the package is installed. Angular CLI needs the installed collection name without the npm version suffix.

Remove `@1` from all three generate examples in `apps/docs/doc/migration/primeng/automated-doc.ts` and from the root and package READMEs. Preserve the `@1` pin on installation commands so users install the Angular 21-compatible v1 package.

```bash
npm install @openng/optimus-ui@1
ng generate @openng/optimus-ui:migrate-from-primeng
```

## Related issues

Companion to #1765, which corrects the READMEs and schematic guidance on `main`. This PR targets `release/1.x`, where the published guide at https://v1.optimus.openng.org/migration/primeng is maintained.

## Type of change

- [x] Documentation only

## Breaking changes

None.

## Test plan

- Confirmed the corrected command successfully migrates an Angular 21 / PrimeNG 21 application with Optimus UI 1.0.2.
- Reviewed all five command corrections in the three-file GitHub diff, including `--skip-install` and `--force`.
- Verified installation commands retain their `@1` pin.
- Formatting and whitespace checks passed during preparation. No v1 documentation build or test suite was run for these command-string-only changes.

## Additional context

Prepared with AI assistance and reviewed against the reported failure and GitHub diff.