### PR TITLE
feat(dynamicdialog): forward Angular bindings to the dialog content

### DIFF
--- a/packages/optimus-ui/src/dynamicdialog/dialogservice.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dialogservice.ts
@@ -37,6 +37,7 @@ export class DialogService {
         if (componentRefInstance) {
             componentRefInstance.instance.childComponentType = componentType;
             componentRefInstance.instance.inputValues = config.inputValues || {};
+            componentRefInstance.instance.bindings = config.bindings || [];
         }
 
         return dialogRef;

--- a/packages/optimus-ui/src/dynamicdialog/dialogservice.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dialogservice.ts
@@ -38,6 +38,7 @@ export class DialogService {
             componentRefInstance.instance.childComponentType = componentType;
             componentRefInstance.instance.inputValues = config.inputValues || {};
             componentRefInstance.instance.bindings = config.bindings || [];
+            componentRefInstance.instance.directives = config.directives || [];
         }
 
         return dialogRef;

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog-config.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog-config.ts
@@ -1,4 +1,4 @@
-import { Type } from '@angular/core';
+import { Binding, Type } from '@angular/core';
 import type { DialogPassThrough } from '@openng/optimus-ui/types/dialog';
 
 /**
@@ -196,6 +196,11 @@ export class DynamicDialogConfig<DataType = any, InputValuesType extends Record<
      * @group Props
      */
     unstyled?: boolean;
+    /**
+     * An array of Angular Bindings (providers) to pass to the dynamically created component.
+     * @group Props
+     */
+    bindings?: Binding[];
 }
 
 /**

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog-config.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog-config.ts
@@ -1,4 +1,4 @@
-import { Binding, Type } from '@angular/core';
+import { Binding, DirectiveWithBindings, Type } from '@angular/core';
 import type { DialogPassThrough } from '@openng/optimus-ui/types/dialog';
 
 /**
@@ -197,10 +197,18 @@ export class DynamicDialogConfig<DataType = any, InputValuesType extends Record<
      */
     unstyled?: boolean;
     /**
-     * An array of Angular Bindings (providers) to pass to the dynamically created component.
+     * Bindings applied to the component loaded inside the Dialog when it is created, built with
+     * `inputBinding`, `outputBinding` or `twoWayBinding`. Composes with `inputValues`, which is
+     * merged in as input bindings after these.
      * @group Props
      */
     bindings?: Binding[];
+    /**
+     * Directives applied to the component loaded inside the Dialog. Each entry is either a directive
+     * type or a `directive()` result carrying its own bindings.
+     * @group Props
+     */
+    directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[];
 }
 
 /**

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inputBinding, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DomHandler } from '@openng/optimus-ui/dom';
@@ -793,7 +793,25 @@ describe('DynamicDialog', () => {
             component.loadChildComponent(TestDialogContentComponent);
 
             expect(mockViewContainer.clear).toHaveBeenCalled();
-            expect(mockViewContainer.createComponent).toHaveBeenCalledWith(TestDialogContentComponent);
+            expect(mockViewContainer.createComponent).toHaveBeenCalledWith(TestDialogContentComponent, { bindings: [] });
+        });
+
+        it('should forward the configured bindings to the child component', () => {
+            const bindings = [inputBinding('title', () => 'From binding')];
+            const mockViewContainer = {
+                clear: vi.fn(),
+                createComponent: vi.fn(() => ({
+                    setInput: vi.fn(),
+                    instance: new TestDialogContentComponent(mockDialogRef as unknown as DynamicDialogRef<any>, mockConfig)
+                }))
+            };
+
+            component.insertionPoint = { viewContainerRef: mockViewContainer as any } as any;
+            component.bindings = bindings;
+
+            component.loadChildComponent(TestDialogContentComponent);
+
+            expect(mockViewContainer.createComponent).toHaveBeenCalledWith(TestDialogContentComponent, { bindings });
         });
 
         it('should display header content', async () => {

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inputBinding, provideZonelessChangeDetection } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Directive, input, inputBinding, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DomHandler } from '@openng/optimus-ui/dom';
@@ -77,6 +77,20 @@ class DialogWithinDialogComponent {
     closeDialog() {
         this.dialogRef.close('inner dialog closed');
     }
+}
+
+@Directive({})
+class BoundContentDirective {}
+
+@Component({
+    changeDetection: ChangeDetectionStrategy.Eager,
+    selector: 'test-bound-content',
+    template: `<span class="bound-content">{{ title() }}|{{ subtitle() }}</span>`
+})
+class BoundContentComponent {
+    title = input('');
+
+    subtitle = input('');
 }
 
 @Component({
@@ -793,25 +807,61 @@ describe('DynamicDialog', () => {
             component.loadChildComponent(TestDialogContentComponent);
 
             expect(mockViewContainer.clear).toHaveBeenCalled();
-            expect(mockViewContainer.createComponent).toHaveBeenCalledWith(TestDialogContentComponent, { bindings: [] });
+            expect(mockViewContainer.createComponent).toHaveBeenCalledWith(TestDialogContentComponent, { bindings: [], directives: [] });
         });
 
-        it('should forward the configured bindings to the child component', () => {
+        it('should forward the configured bindings and directives to the child component', () => {
+            const bindings = [inputBinding('title', () => 'From binding')];
+            const directives = [BoundContentDirective];
+            const mockViewContainer = {
+                clear: vi.fn(),
+                createComponent: vi.fn(() => ({ setInput: vi.fn(), instance: {} }))
+            };
+
+            component.childComponentType = BoundContentComponent;
+            component.insertionPoint = { viewContainerRef: mockViewContainer as any } as any;
+            component.bindings = bindings;
+            component.directives = directives;
+
+            component.loadChildComponent(BoundContentComponent);
+
+            expect(mockViewContainer.createComponent).toHaveBeenCalledWith(BoundContentComponent, { bindings, directives });
+        });
+
+        it('should pass inputValues as creation bindings instead of calling setInput', () => {
             const bindings = [inputBinding('title', () => 'From binding')];
             const mockViewContainer = {
                 clear: vi.fn(),
-                createComponent: vi.fn(() => ({
-                    setInput: vi.fn(),
-                    instance: new TestDialogContentComponent(mockDialogRef as unknown as DynamicDialogRef<any>, mockConfig)
-                }))
+                createComponent: vi.fn(() => ({ setInput: vi.fn(), instance: {} }))
             };
 
+            component.childComponentType = BoundContentComponent;
             component.insertionPoint = { viewContainerRef: mockViewContainer as any } as any;
             component.bindings = bindings;
+            component.inputValues = { subtitle: 'From inputValues' };
 
-            component.loadChildComponent(TestDialogContentComponent);
+            component.loadChildComponent(BoundContentComponent);
 
-            expect(mockViewContainer.createComponent).toHaveBeenCalledWith(TestDialogContentComponent, { bindings });
+            const options = (mockViewContainer.createComponent.mock.calls[0] as any[])[1];
+            expect(options.bindings).toHaveLength(2);
+            expect(options.bindings[0]).toBe(bindings[0]);
+            expect(component.componentRef!.setInput).not.toHaveBeenCalled();
+        });
+
+        it('should render bindings and inputValues together on the real child component', async () => {
+            const dialogFixture = TestBed.createComponent(DynamicDialog);
+            const dialog = dialogFixture.componentInstance;
+
+            dialog.childComponentType = BoundContentComponent;
+            dialog.visible = true;
+            dialog.bindings = [inputBinding('title', () => 'From binding')];
+            dialog.inputValues = { subtitle: 'From inputValues' };
+
+            dialogFixture.changeDetectorRef.markForCheck();
+            await dialogFixture.whenStable();
+
+            const content = dialogFixture.debugElement.query(By.css('.bound-content'));
+            expect(content.nativeElement.textContent).toBe('From binding|From inputValues');
         });
 
         it('should display header content', async () => {

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ComponentRef, inject, InjectionToken, NgModule, Type, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Binding, ChangeDetectionStrategy, Component, ComponentRef, inject, InjectionToken, NgModule, Type, ViewChild, ViewEncapsulation } from '@angular/core';
 import { uuid } from '@openng/optimus-ui-utils';
 import { SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -131,6 +131,8 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
     childComponentType: Nullable<Type<any>>;
 
     inputValues: Record<string, any>;
+
+    bindings: Binding[] = [];
 
     get minX(): number {
         return this.ddconfig.minX ? this.ddconfig.minX : 0;
@@ -292,7 +294,7 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
         let viewContainerRef = this.insertionPoint?.viewContainerRef;
         viewContainerRef?.clear();
 
-        this.componentRef = viewContainerRef?.createComponent(componentType);
+        this.componentRef = viewContainerRef?.createComponent(componentType, { bindings: this.bindings });
 
         if (this.inputValues && this.componentRef) {
             Object.entries(this.inputValues).forEach(([key, value]) => {

--- a/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/optimus-ui/src/dynamicdialog/dynamicdialog.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Binding, ChangeDetectionStrategy, Component, ComponentRef, inject, InjectionToken, NgModule, Type, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Binding, ChangeDetectionStrategy, Component, ComponentRef, DirectiveWithBindings, inject, InjectionToken, inputBinding, NgModule, Type, ViewChild, ViewEncapsulation } from '@angular/core';
 import { uuid } from '@openng/optimus-ui-utils';
 import { SharedModule, TranslationKeys } from '@openng/optimus-ui/api';
 import { BaseComponent, PARENT_INSTANCE } from '@openng/optimus-ui/basecomponent';
@@ -133,6 +133,8 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
     inputValues: Record<string, any>;
 
     bindings: Binding[] = [];
+
+    directives: (Type<unknown> | DirectiveWithBindings<unknown>)[] = [];
 
     get minX(): number {
         return this.ddconfig.minX ? this.ddconfig.minX : 0;
@@ -294,13 +296,15 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
         let viewContainerRef = this.insertionPoint?.viewContainerRef;
         viewContainerRef?.clear();
 
-        this.componentRef = viewContainerRef?.createComponent(componentType, { bindings: this.bindings });
+        // `setInput` throws once the component owns input bindings, so `inputValues` is merged in as
+        // input bindings instead. They come last so an explicit `bindings` entry is overridden the
+        // same way `setInput` used to override it.
+        const inputValueBindings = Object.entries(this.inputValues ?? {}).map(([key, value]) => inputBinding(key, () => value));
 
-        if (this.inputValues && this.componentRef) {
-            Object.entries(this.inputValues).forEach(([key, value]) => {
-                this.componentRef!.setInput(key, value);
-            });
-        }
+        this.componentRef = viewContainerRef?.createComponent(componentType, {
+            bindings: [...this.bindings, ...inputValueBindings],
+            directives: this.directives
+        });
 
         this.dialogRef.onChildComponentLoaded.next(this.componentRef!.instance);
     }


### PR DESCRIPTION
`DialogService.open` can pass `inputValues`, which DynamicDialog applies by walking the created `ComponentRef` and calling `setInput` for each key. That covers inputs and nothing else: an output cannot be subscribed to, a two-way binding cannot be wired, and a directive cannot be attached to the projected content.

Angular accepts `bindings` and `directives` on `ViewContainerRef.createComponent`, which is the supported way to bind anything at creation time — `inputBinding`, `outputBinding`, `twoWayBinding`, `directive`. This exposes both:

- `bindings?: Binding[]` and `directives?: (Type<unknown> | DirectiveWithBindings<unknown>)[]` on `DynamicDialogConfig`
- `DialogService.open` carries them to the DynamicDialog instance next to `inputValues`
- `loadChildComponent` passes them to `createComponent(type, { bindings, directives })`

```ts
this.dialogService.open(EditUserComponent, {
    header: 'Edit user',
    bindings: [inputBinding('user', () => this.user()), outputBinding<User>('saved', (user) => this.save(user))],
    directives: [TooltipDirective]
});
```

`inputValues` is unchanged from the caller's side and still works, but it can no longer be applied with `setInput`: `ComponentRef.setInput` throws `NG0317` once the component owns an input binding, so a config using both options at once would have broken. Each `inputValues` entry becomes an `inputBinding` appended after the configured `bindings`, so it still wins over an explicit binding to the same input, the way `setInput` used to.

One behaviour change worth flagging: a key in `inputValues` that is not a declared input used to log an `NG0303` error and carry on, and now throws `NG0315` in dev mode. That was already a caller bug, it just fails louder.

Specs cover the forwarded options on the mocked `createComponent` call and, on top of that, render a real child component to prove `bindings` and `inputValues` reach it together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dynamic dialogs now support Angular bindings for dynamically created child components.
  - Dialog configurations can apply host directives to child components.
  - Existing input values are integrated with component bindings during creation.

- **Tests**
  - Added coverage for forwarding bindings and directives.
  - Added tests confirming input values and bindings render together.
  - Updated expectations for dynamically created dialog components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->