### PR TITLE
chore(docs): stop tracking the typedoc intermediate output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ reports
 # build:routes, build:sitemap). Committing these caused stale/conflicting
 # diffs on PRs; they are produced fresh on every build/deploy instead.
 apps/docs/doc/apidoc
+apps/docs/api-generator/typedoc.json
 apps/docs/router/routes.txt
 apps/docs/public/sitemap.xml
 apps/docs/public/llms


### PR DESCRIPTION
Follow-up to #1649, which untracked the generated docs content but left `apps/docs/api-generator/typedoc.json` behind.

It is the same class of artifact. `build-apidoc.mjs` writes it with `app.generateJson(project, './api-generator/typedoc.json')` and never reads it back — the script builds `apps/docs/doc/apidoc/index.json` (already gitignored) directly from the in-memory TypeDoc project. Nothing else in the repo imports it, so a fresh clone does not need it to exist.

Why it matters: at 37MB it is the largest file in the tree, and every run rewrites it wholesale. Any PR that adds a component and regenerates the API docs ends up carrying a ~950k-line diff that buries the review, and two PRs touching different components conflict on it for no reason.

The file stays on disk for anyone who already has it; `build:apidoc` produces it as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude generated API documentation configuration from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->