### PR TITLE
fix(tooltip): wait for dialog motion before showing

### DIFF
--- a/packages/optimus-ui/src/tooltip/tooltip.ts
+++ b/packages/optimus-ui/src/tooltip/tooltip.ts
@@ -579,7 +579,7 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
 
         const reveal = () => {
             // A hide, destroy or subsequent show invalidates this pending reveal.
-            if (this.container !== container || !nativeElement.isConnected) {
+            if (!this.active || this.container !== container || !nativeElement.isConnected) {
                 return;
             }
 

--- a/packages/optimus-ui/src/tooltip/tooltip.ts
+++ b/packages/optimus-ui/src/tooltip/tooltip.ts
@@ -566,20 +566,34 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
 
         this.create();
 
-        const nativeElement = this.el.nativeElement;
-        const pDialogWrapper = nativeElement.closest('p-dialog');
+        const nativeElement = this.el.nativeElement as HTMLElement;
+        const container = this.container;
+        const dialogSelector = '.p-dialog, [data-pc-name="dialog"]';
+        const dialogAnimations: Animation[] = [];
 
-        if (pDialogWrapper) {
-            setTimeout(() => {
-                this.container && (this.container.style.display = 'inline-block');
-                this.container && this.align();
-            }, 100);
-        } else {
-            this.container.style.display = 'inline-block';
-            this.align();
+        // Inspect dialog surfaces, not descendants: button hover/focus transitions
+        // must not delay a settled dialog's tooltip. This also works with appendTo="body".
+        for (let dialog = nativeElement.closest(dialogSelector); dialog; dialog = dialog.parentElement?.closest(dialogSelector) ?? null) {
+            dialogAnimations.push(...(dialog.getAnimations?.() || []).filter((animation) => (animation.playState === 'running' || animation.playState === 'paused') && Number.isFinite(animation.effect?.getComputedTiming().endTime)));
         }
 
-        fadeIn(this.container, 250);
+        const reveal = () => {
+            // A hide, destroy or subsequent show invalidates this pending reveal.
+            if (this.container !== container || !nativeElement.isConnected) {
+                return;
+            }
+
+            container.style.display = 'inline-block';
+            this.align();
+            fadeIn(container, 250);
+        };
+
+        if (dialogAnimations.length) {
+            // Include paused initial frames and settle cancellation without a rejection.
+            Promise.allSettled(dialogAnimations.map((animation) => animation.finished)).then(reveal);
+        } else {
+            reveal();
+        }
 
         if (this.getOption('tooltipZIndex') === 'auto') ZIndexUtils.set('tooltip', this.container, this.config.zIndex.tooltip);
         else this.container.style.zIndex = this.getOption('tooltipZIndex');


### PR DESCRIPTION
## Description

Tooltips inside a dialog currently wait a fixed 100 ms before becoming visible, even when the dialog is already open and stationary. The 250 ms fade starts while the tooltip is still hidden, so it appears late and partway through its animation compared with the same tooltip outside a dialog.

This change replaces the fixed timeout with a wait for active, finite animations on the actual ancestor dialog panels. Once the motion finishes, the tooltip is displayed, aligned and faded in. Tooltips in settled dialogs appear immediately, respecting the configured show delay.

This also preserves the original autofocus positioning fix: when an input receives focus during dialog entrance, its tooltip waits until the panel reaches its final position. Nested dialogs and dialogs appended to the body are supported. Animations on child elements do not delay the tooltip, and pending callbacks cannot reveal a dismissed or replaced tooltip.

## Related issues

Related historical issue: [primefaces/primeng#15485](https://github.com/primefaces/primeng/issues/15485).

Preserves the positioning fix introduced in [primefaces/primeng#15486](https://github.com/primefaces/primeng/pull/15486), replacing its fixed timeout with the actual dialog animation lifecycle.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

None

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [ ] `npm run lint`
- [ ] Verified in the demo app (if applicable)

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Before

https://github.com/user-attachments/assets/0e073a93-9e1e-4e52-ae8f-1486197c7701


After

https://github.com/user-attachments/assets/143e61c4-263a-4f76-a100-35958600bb69


The before recording uses the existing implementation, which already includes the historical autofocus fix.

The `ms` values show the elapsed time from the hover or focus event to the first observed animation frame where the tooltip is displayed with an opacity greater than zero. They measure the delay until the tooltip starts appearing, not the duration of the full fade-in. 

The videos were recorded in Chrome. In Firefox, the effect is worse, with the tooltip almost popping into view instead of fading in smoothly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip timing while dialog surfaces are animating, including paused and nested animations.
  * Prevented tooltips from appearing in stale containers or after their associated interface elements are no longer connected.
  * Ensured tooltips reveal immediately when no dialog animation is active.
  * Improved tooltip positioning and fade-in behavior after the appropriate display timing is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->