### PR TITLE
fix(overlay): run hide callback through zone

### DIFF
--- a/packages/optimus-ui/src/overlay/overlay.ts
+++ b/packages/optimus-ui/src/overlay/overlay.ts
@@ -671,7 +671,12 @@ export class Overlay extends BaseComponent {
                 const isOutsideClicked = !isTargetClicked && !this.isOverlayContentClicked;
                 const valid = this.listener ? this.listener(event, { type: 'outside', mode: this.overlayMode, valid: event.which !== 3 && isOutsideClicked }) : isOutsideClicked;
 
-                valid && this.hide(event);
+                if (valid) {
+                    this.zone.run(() => {
+                        this.hide(event);
+                    });
+                }
+
                 this.isOverlayClicked = this.isOverlayContentClicked = false;
             });
         }

--- a/packages/optimus-ui/src/overlay/overlay.ts
+++ b/packages/optimus-ui/src/overlay/overlay.ts
@@ -651,7 +651,11 @@ export class Overlay extends BaseComponent {
             this.scrollHandler = new ConnectedOverlayScrollHandler(this.targetEl, (event: any) => {
                 const valid = this.listener ? this.listener(event, { type: 'scroll', mode: this.overlayMode, valid: true }) : true;
 
-                valid && this.hide(event, true);
+                if (valid) {
+                    this.zone.run(() => {
+                        this.hide(event, true);
+                    });
+                }
             });
         }
 
@@ -694,7 +698,11 @@ export class Overlay extends BaseComponent {
             this.documentResizeListener = this.renderer.listen(this.document.defaultView, 'resize', (event) => {
                 const valid = this.listener ? this.listener(event, { type: 'resize', mode: this.overlayMode, valid: !isTouchDevice() }) : !isTouchDevice();
 
-                valid && this.hide(event, true);
+                if (valid) {
+                    this.zone.run(() => {
+                        this.hide(event, true);
+                    });
+                }
             });
         }
     }


### PR DESCRIPTION
## Description

Fixes overlays (eg `p-multiSelect`) not closing properly when clicking away when using zone.js. 
The bug was introduced in PrimeNG 21 with the large zoneless / removal of animations. 

Reproducer is available here - also linked in the issue - demonstrating the bug:
https://stackblitz.com/edit/stackblitz-starters-sff1tt1t

The fix is based on the Datepicker component that already implements the same `this.zone.run` wrapper in it's own `bindDocumentClickListener` function. 
`bindDocumentKeyboardListener` in the same overlay component also wraps it's `hide()` callback in the same zone wrapper too. 
This really just looks like a simple accidental inconsistency. 

I wasn't easily able to add a test as the suite runs entirely using `provideZonelessChangeDetection()`, so a test will pass the same way with or without a fix.  
Adding a test would require zone.js as a devDependency which I feel would be a larger decision, and with the move to zoneless it might be not be desirable. 
If the maintainers are happy to include zone.js as a devDependency I can add the test as well, or if you have any other suggestions I'm happy to accommodate. 

## Related issues

Fixes #1785 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes the public API)
- [ ] Documentation only
- [ ] Refactor, test, or chore (no user-facing change)

## Breaking changes

<!-- If this is a breaking change, describe what changed and how consumers should migrate. Otherwise, write "None". -->

None

## Test plan

<!-- How did you verify this change? List commands run and manual steps taken. -->

- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [ ] Verified in the demo app (if applicable)
- [x] Verified as pnpm patch in live application

## Checklist

- [x] Issue discussed or bug clearly described (link issue when applicable)
- [ ] Tests added or updated for behavioral changes
- [ ] Documentation updated (README, JSDoc, migration notes as needed)
- [ ] Public API changes documented; breaking changes called out
- [ ] CHANGELOG updated (if the repository maintains one and the change is user-facing)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I agree to follow the [OpenNG Foundation Code of Conduct](https://github.com/openng-foundation/.github/blob/main/CODE_OF_CONDUCT.md)

## Additional context

Only affects zone apps.

AI disclosure: debugging, repro and fix all AI driven. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved overlay behavior so overlays close reliably after scrolling, clicking outside them, or resizing the window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->